### PR TITLE
feat: disable browser autocomplete for text fields

### DIFF
--- a/ui/admin-frontend/src/admin/components/chats/ChatForm.js
+++ b/ui/admin-frontend/src/admin/components/chats/ChatForm.js
@@ -398,6 +398,7 @@ const ChatForm = () => {
                 error={!!errors.name}
                 helperText={errors.name}
                 required
+                autoComplete="off"
               />
             </Grid>
             <Grid item xs={12}>
@@ -510,6 +511,7 @@ const ChatForm = () => {
                 multiline
                 rows={4}
                 placeholder="Enter the system prompt for this chat"
+                autoComplete="off"
               />
             </Grid>
 

--- a/ui/admin-frontend/src/admin/components/llm-settings/LLMSettingsForm.js
+++ b/ui/admin-frontend/src/admin/components/llm-settings/LLMSettingsForm.js
@@ -460,6 +460,7 @@ const LLMSettingsForm = () => {
                 error={!!errors.model_name}
                 helperText={errors.model_name}
                 required
+                autoComplete="off"
                 tooltip="The name of the language model (e.g., 'gpt-3.5-turbo', 'text-davinci-003')"
               />
             </Grid>
@@ -560,6 +561,7 @@ const LLMSettingsForm = () => {
                 onChange={handleChange}
                 multiline
                 rows={4}
+                autoComplete="off"
                 tooltip="A long-form text prompt that sets the context or behavior for the language model"
               />
             </Grid>
@@ -628,6 +630,7 @@ const LLMSettingsForm = () => {
             onChange={handleModelPriceChange}
             required
             margin="normal"
+            autoComplete="off"
           />
         </StyledDialogContent>
         <DialogActions>

--- a/ui/admin-frontend/src/admin/components/model-prices/ModelPriceForm.js
+++ b/ui/admin-frontend/src/admin/components/model-prices/ModelPriceForm.js
@@ -223,6 +223,7 @@ const ModelPriceForm = () => {
                 error={!!errors.model_name}
                 helperText={errors.model_name}
                 required
+                autoComplete="off"
                 tooltip="The name of the language model (e.g., 'gpt-3.5-turbo', 'text-davinci-003')"
               />
             </Grid>
@@ -280,6 +281,7 @@ const ModelPriceForm = () => {
                 error={!!errors.currency}
                 helperText={errors.currency}
                 required
+                autoComplete="off"
                 tooltip="The currency for the cost per token (e.g., USD)"
               />
             </Grid>

--- a/ui/admin-frontend/src/admin/components/tools/ToolForm.js
+++ b/ui/admin-frontend/src/admin/components/tools/ToolForm.js
@@ -115,6 +115,7 @@ const OperationsInput = ({ value, onChange }) => {
         onKeyDown={handleInputKeyDown}
         placeholder="Type and press comma or enter to add"
         sx={{ flexGrow: 1, "& fieldset": { border: "none" } }}
+        autoComplete="off"
       />
     </Paper>
   );
@@ -582,6 +583,7 @@ const ToolForm = () => {
                 error={!!errors.name}
                 helperText={errors.name}
                 required
+                autoComplete="off"
               />
             </Grid>
             <Grid item xs={12}>
@@ -596,6 +598,7 @@ const ToolForm = () => {
                 multiline
                 rows={4}
                 required
+                autoComplete="off"
               />
             </Grid>
             <Grid item xs={12}>
@@ -642,6 +645,7 @@ const ToolForm = () => {
                 multiline
                 rows={12}
                 variant="outlined"
+                autoComplete="off"
               />
             </Grid>
           </Grid>
@@ -798,6 +802,7 @@ const ToolForm = () => {
                     name="auth_schema_name"
                     value={tool.auth_schema_name}
                     onChange={handleChange}
+                    autoComplete="off"
                   />
                 </Grid>
                 <Grid item xs={12}>

--- a/ui/admin-frontend/src/admin/components/users/UserForm.js
+++ b/ui/admin-frontend/src/admin/components/users/UserForm.js
@@ -312,6 +312,7 @@ const UserForm = () => {
                 error={!!errors.name}
                 helperText={errors.name}
                 required
+                autoComplete="off"
               />
             </Grid>
             <Grid item xs={12}>
@@ -324,6 +325,7 @@ const UserForm = () => {
                 error={!!errors.email}
                 helperText={errors.email}
                 required
+                autoComplete="off"
               />
             </Grid>
             {!id && (

--- a/ui/admin-frontend/src/portal/pages/ForgotPassword.js
+++ b/ui/admin-frontend/src/portal/pages/ForgotPassword.js
@@ -55,6 +55,7 @@ const ForgotPassword = () => {
             onChange={(e) => setEmail(e.target.value)}
             margin="normal"
             required
+            autoComplete="off"
           />
           <Button
             type="submit"

--- a/ui/admin-frontend/src/portal/pages/Login.js
+++ b/ui/admin-frontend/src/portal/pages/Login.js
@@ -80,6 +80,7 @@ const Login = () => {
             onChange={(e) => setEmail(e.target.value)}
             margin="normal"
             required
+            autoComplete="off"
           />
           <TextField
             fullWidth

--- a/ui/admin-frontend/src/portal/pages/Register.js
+++ b/ui/admin-frontend/src/portal/pages/Register.js
@@ -175,6 +175,7 @@ const Register = () => {
             onChange={(e) => setName(e.target.value)}
             margin="normal"
             required
+            autoComplete="off"
           />
           <TextField
             fullWidth
@@ -184,6 +185,7 @@ const Register = () => {
             onChange={(e) => setEmail(e.target.value)}
             margin="normal"
             required
+            autoComplete="off"
           />
           <TextField
             fullWidth


### PR DESCRIPTION
- Added autoComplete='off' to all text input fields across frontend components
- Improves security by preventing browsers from storing sensitive data
- Excludes password fields to maintain default browser security behavior
- Modified components:
  - Login, Register, ForgotPassword pages
  - UserForm, ChatForm, LLMSettingsForm
  - ModelPriceForm, ToolForm