### PR TITLE
Fix new session on error in new chat 

### DIFF
--- a/ui/admin-frontend/src/portal/components/chat/services/sseConnectionService.js
+++ b/ui/admin-frontend/src/portal/components/chat/services/sseConnectionService.js
@@ -17,9 +17,12 @@ export const setupSSEConnection = ({
   maxReconnectAttempts = 5,
   initialReconnectDelay = 500
 }) => {
+  let currentSessionId = continueId;
+
   const baseUrl = pubClient.defaults.baseURL;
   const token = localStorage.getItem('token');
   const params = new URLSearchParams();
+
   if (continueId) {
     params.append('session_id', continueId);
   }
@@ -27,17 +30,14 @@ export const setupSSEConnection = ({
     params.append('token', token);
   }
   const url = `${baseUrl}/common/chat/${chatId}${params.toString() ? `?${params.toString()}` : ''}`;
-  console.log('Setting up SSE connection to:', url);
 
   if (!eventSourceRef.current || eventSourceRef.current.readyState === EventSource.CLOSED) {
-    console.log('Creating new EventSource');
     eventSourceRef.current = new EventSource(url, {
       withCredentials: true
     });
   }
 
   eventSourceRef.current.onopen = () => {
-    console.log('SSE connection established');
     setIsConnected(true);
     isConnectedRef.current = true;
     reconnectAttempts.current = 0;
@@ -52,18 +52,16 @@ export const setupSSEConnection = ({
   // Listen specifically for session_id events
   eventSourceRef.current.addEventListener('session_id', (event) => {
     try {
-      console.log('SSE session_id event received:', event.data);
       const data = JSON.parse(event.data);
-      console.log('Processing session_id message:', data);
       const newSessionId = data.payload;
-      console.log('Setting new sessionId:', newSessionId);
+      
+      currentSessionId = newSessionId;
+      
       setSessionId(newSessionId);
       // Update URL with new session ID
       const newUrl = `/chat/${chatId}?continue_id=${newSessionId}`;
-      console.log('Updating URL to:', newUrl);
       try {
         window.history.replaceState({}, "", newUrl);
-        console.log('URL updated successfully');
       } catch (err) {
         console.error('Failed to update URL:', err);
       }
@@ -124,7 +122,6 @@ export const setupSSEConnection = ({
   // Handle stream_chunk events
   eventSourceRef.current.addEventListener('stream_chunk', (event) => {
     try {
-      console.log('SSE stream_chunk received:', event.data);
       onMessageReceived({
         type: 'stream_chunk',
         payload: event.data
@@ -137,7 +134,6 @@ export const setupSSEConnection = ({
   // Handle message events
   eventSourceRef.current.addEventListener('message', (event) => {
     try {
-      console.log('SSE message received:', event.data);
       const data = JSON.parse(event.data);
       onMessageReceived(data);
     } catch (error) {
@@ -148,7 +144,6 @@ export const setupSSEConnection = ({
   // Handle system events
   eventSourceRef.current.addEventListener('system', (event) => {
     try {
-      console.log('SSE system message received:', event.data);
       const messageContent = event.data.includes(':::system')
         ? event.data
         : `:::system ${event.data}:::`;
@@ -166,7 +161,6 @@ export const setupSSEConnection = ({
   // Handle error events
   eventSourceRef.current.addEventListener('error', (event) => {
     try {
-      console.log('SSE error message received:', event.data);
       const errorType = detectErrorType(event.data);
 
       // For LLM config errors, don't attempt reconnection
@@ -189,7 +183,6 @@ export const setupSSEConnection = ({
   // Handle any other events
   eventSourceRef.current.onmessage = (event) => {
     try {
-      console.log('SSE generic message received:', event.data);
       const data = JSON.parse(event.data);
       onMessageReceived(data);
     } catch (error) {
@@ -209,6 +202,7 @@ export const setupSSEConnection = ({
     isConnectedRef.current = false;
     setIsLoading(false);
 
+    
     // Check if we have a recent LLM config error
     const hasLLMError = error?.data && detectErrorType(error.data) === 'llm_config';
 
@@ -221,11 +215,9 @@ export const setupSSEConnection = ({
       });
 
       const delay = initialReconnectDelay * Math.pow(2, reconnectAttempts.current);
-      console.log(`Attempting to reconnect in ${delay / 1000} seconds... (Attempt ${reconnectAttempts.current + 1}/${maxReconnectAttempts})`);
 
       setTimeout(() => {
         reconnectAttempts.current++;
-        console.log("Reconnecting SSE...");
 
         if (eventSourceRef.current) {
           eventSourceRef.current.close();
@@ -236,7 +228,7 @@ export const setupSSEConnection = ({
           setupSSEConnection({
             eventSourceRef,
             chatId,
-            continueId,
+            continueId: currentSessionId || continueId,
             onMessageReceived,
             setIsConnected,
             setSessionId,

--- a/ui/admin-frontend/src/portal/components/chat/services/sseConnectionService.test.js
+++ b/ui/admin-frontend/src/portal/components/chat/services/sseConnectionService.test.js
@@ -603,4 +603,147 @@ describe('setupSSEConnection', () => {
     // Verify a new EventSource was created
     expect(mockRefs.eventSourceRef.current).not.toBe(existingEventSource);
   });
+
+  // New tests for the session reconnection fix
+
+  test('should update currentSessionId when session_id event is received', () => {
+    // Call the function
+    setupSSEConnection(defaultParams);
+    
+    // Create mock session_id event data
+    const sessionData = {
+      payload: 'session-789',
+      tools: []
+    };
+    
+    // Simulate session_id event
+    mockRefs.eventSourceRef.current.dispatchEvent({
+      type: 'session_id',
+      data: JSON.stringify(sessionData)
+    });
+    
+    // Verify setSessionId was called with the correct session ID
+    expect(mockCallbacks.setSessionId).toHaveBeenCalledWith('session-789');
+    
+    // Store the original EventSource
+    const originalEventSource = mockRefs.eventSourceRef.current;
+    
+    // Now simulate a connection error to trigger reconnection
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error' });
+    
+    // Fast-forward timers to trigger reconnection
+    jest.advanceTimersByTime(100);
+    
+    // Verify that a new EventSource was created
+    expect(mockRefs.eventSourceRef.current).not.toBe(originalEventSource);
+    
+    // Verify that the new connection uses the session ID from the session_id event
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=session-789');
+  });
+  
+  test('should use current sessionId instead of original continueId for reconnection', () => {
+    // Call the function with an initial continueId
+    setupSSEConnection({
+      ...defaultParams,
+      continueId: 'original-session-123'
+    });
+    
+    // Verify initial connection uses the original continueId
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=original-session-123');
+    
+    // Create mock session_id event data with a different session ID
+    const sessionData = {
+      payload: 'new-session-456',
+      tools: []
+    };
+    
+    // Simulate session_id event
+    mockRefs.eventSourceRef.current.dispatchEvent({
+      type: 'session_id',
+      data: JSON.stringify(sessionData)
+    });
+    
+    // Store the original EventSource
+    const originalEventSource = mockRefs.eventSourceRef.current;
+    
+    // Now simulate a connection error to trigger reconnection
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error' });
+    
+    // Fast-forward timers to trigger reconnection
+    jest.advanceTimersByTime(100);
+    
+    // Verify that a new EventSource was created
+    expect(mockRefs.eventSourceRef.current).not.toBe(originalEventSource);
+    
+    // Verify that the new connection uses the new session ID, not the original continueId
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=new-session-456');
+    expect(mockRefs.eventSourceRef.current.url).not.toContain('session_id=original-session-123');
+  });
+  
+  test('should maintain session continuity across multiple reconnections', () => {
+    // Call the function
+    setupSSEConnection(defaultParams);
+    
+    // Create mock session_id event data
+    const sessionData = {
+      payload: 'persistent-session-id',
+      tools: []
+    };
+    
+    // Simulate session_id event
+    mockRefs.eventSourceRef.current.dispatchEvent({
+      type: 'session_id',
+      data: JSON.stringify(sessionData)
+    });
+    
+    // Verify setSessionId was called with the correct session ID
+    expect(mockCallbacks.setSessionId).toHaveBeenCalledWith('persistent-session-id');
+    
+    // Simulate first connection error and reconnection
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error 1' });
+    jest.advanceTimersByTime(100);
+    
+    // Verify first reconnection uses the correct session ID
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=persistent-session-id');
+    
+    // Simulate second connection error and reconnection
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error 2' });
+    jest.advanceTimersByTime(200); // 100 * 2^1
+    
+    // Verify second reconnection still uses the correct session ID
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=persistent-session-id');
+    
+    // Simulate third connection error and reconnection
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error 3' });
+    jest.advanceTimersByTime(400); // 100 * 2^2
+    
+    // Verify third reconnection still uses the correct session ID
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=persistent-session-id');
+  });
+
+  test('should fallback to continueId if currentSessionId is not available', () => {
+    // Call the function with an initial continueId
+    setupSSEConnection({
+      ...defaultParams,
+      continueId: 'fallback-session-id'
+    });
+    
+    // Verify initial connection uses the continueId
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=fallback-session-id');
+    
+    // Store the original EventSource
+    const originalEventSource = mockRefs.eventSourceRef.current;
+    
+    // Simulate a connection error without receiving a session_id event first
+    mockRefs.eventSourceRef.current.onerror({ data: 'Connection error' });
+    
+    // Fast-forward timers to trigger reconnection
+    jest.advanceTimersByTime(100);
+    
+    // Verify that a new EventSource was created
+    expect(mockRefs.eventSourceRef.current).not.toBe(originalEventSource);
+    
+    // Verify that the new connection still uses the original continueId as fallback
+    expect(mockRefs.eventSourceRef.current.url).toContain('session_id=fallback-session-id');
+  });
 });


### PR DESCRIPTION
This PR fixes an issue where chat sessions were being lost during reconnection when an error occurred in the middle of a conversation. The root cause was that the reconnection logic was using the original `continueId` parameter instead of the current session ID, causing a new session to be created and losing the chat history.

Changes:
- Added a `currentSessionId` variable to store the session ID received from the server
- Modified the reconnection logic to use the current session ID instead of the original continueId
- Added comprehensive unit tests to verify the fix maintains session continuity across reconnections