### PR TITLE
fixes tool list dropdowns so they are not paginated in the admin

### DIFF
--- a/ui/admin-frontend/src/admin/components/tool-catalogues/ToolCatalogueForm.js
+++ b/ui/admin-frontend/src/admin/components/tool-catalogues/ToolCatalogueForm.js
@@ -79,7 +79,7 @@ const ToolCatalogueForm = () => {
   const fetchAvailableToolsAndTags = async () => {
     try {
       const [toolsResponse, tagsResponse] = await Promise.all([
-        apiClient.get("/tools"),
+        apiClient.get("/tools", { params: { all: true } }),
         apiClient.get("/tags"),
       ]);
       setAvailableTools(toolsResponse.data.data || []);


### PR DESCRIPTION
When adding a tool to a catalogue, and the tools list is larger than 10, it doesnt show all the tools. This is because the backend defaults to 10 poer page, but adding a all=true param fixes that.