### PR TITLE
Chat Room Wizard Bugfix - String to Int casting

### DIFF
--- a/ui/admin-frontend/src/admin/components/wizards/ChatRoomWizard.js
+++ b/ui/admin-frontend/src/admin/components/wizards/ChatRoomWizard.js
@@ -116,7 +116,7 @@ const ChatRoomWizard = ({ open, onClose, fetchData }) => {
           attributes: {
             name: formData.vendorName,
             vendor: formData.vendor,
-            privacy_score: formData.privacyLevel,
+            privacy_score: Number(formData.privacyLevel),
             api_endpoint: formData.apiEndpoint,
             api_key: formData.apiKey,
             active: true,


### PR DESCRIPTION
Fixes a bug where the server expects the chat room privacy score as an integer, and the frontend was sending a string:
https://tyktech.slack.com/archives/C08527XAJGL/p1745507366122589