### PR TITLE
feat: Display Tool API Endpoints in App Detail View

### DIFF
--- a/ui/admin-frontend/src/portal/components/AppDetailView.js
+++ b/ui/admin-frontend/src/portal/components/AppDetailView.js
@@ -549,6 +549,72 @@ const AppDetailView = () => {
         )}
       </Paper>
 
+      <Paper sx={{ p: 3, mt: 3 }}>
+        <SectionTitle>Tool Access Details</SectionTitle>
+        {appTools.length > 0 ? (
+          appTools.map((tool) => (
+            <Card key={tool.id} sx={{ mb: 3 }}>
+              <CardContent>
+                <Typography variant="h6">{tool.attributes.name}</Typography>
+                <Typography variant="body2" color="text.secondary" mb={2}>
+                  {tool.attributes.short_description || "No description available"}
+                </Typography>
+
+                <Typography
+                  variant="subtitle1"
+                  sx={{
+                    fontWeight: "bold",
+                    mt: 2,
+                    mb: 1,
+                  }}
+                >
+                  Endpoint
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 2 }}>
+                  Use the following URL to interact with this tool.
+                </Typography>
+
+                <Box sx={{ display: "flex", alignItems: "center" }}>
+                  <FieldLabel sx={{ minWidth: "100px" }}>Tool API:</FieldLabel>
+                  <Box>
+                    <Tooltip title="Use this endpoint to interact with the tool. Refer to the tool's specific documentation for API details.">
+                      <HelpOutlineIcon sx={{ color: "text.secondary", mr: 1 }} />
+                    </Tooltip>
+                  </Box>
+                  <Box sx={{ flexGrow: 1, display: "flex", alignItems: "center" }}>
+                    <Typography
+                      variant="body2"
+                      component="code"
+                      sx={{
+                        fontFamily: "monospace",
+                        bgcolor: "background.paper",
+                        p: 1,
+                        borderRadius: 1,
+                        flexGrow: 1,
+                      }}
+                    >
+                      {generateEndpointUrl("/tools/", tool.attributes.name)}
+                    </Typography>
+                    <IconButton
+                      onClick={() =>
+                        copyToClipboard(
+                          generateEndpointUrl("/tools/", tool.attributes.name)
+                        )
+                      }
+                      size="small"
+                    >
+                      <ContentCopyIcon />
+                    </IconButton>
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+          ))
+        ) : (
+          <Typography variant="body1">No tools associated with this app.</Typography>
+        )}
+      </Paper>
+
       <Dialog
         open={deleteDialogOpen}
         onClose={handleDeleteCancel}

--- a/ui/admin-frontend/src/portal/components/PortalDrawer.js
+++ b/ui/admin-frontend/src/portal/components/PortalDrawer.js
@@ -20,6 +20,7 @@ import PsychologyIcon from "@mui/icons-material/Psychology";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutline";
 import AppsIcon from "@mui/icons-material/Apps";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
+import ExtensionIcon from "@mui/icons-material/Extension"; // Import for Tools icon
 
 import pubClient from "../../admin/utils/pubClient";
 import useSystemFeatures from "../../admin/hooks/useSystemFeatures";
@@ -37,6 +38,7 @@ const PortalDrawer = () => {
   const [openDev, setOpenDev] = useState(true);
   const [openLLMs, setOpenLLMs] = useState(false);
   const [openDatabases, setOpenDatabases] = useState(false);
+  const [openTools, setOpenTools] = useState(false); // State for Tools section
   const [openChatRooms, setOpenChatRooms] = useState(true);
   const theme = useTheme();
 
@@ -83,6 +85,10 @@ const PortalDrawer = () => {
 
   const handleDatabasesClick = () => {
     setOpenDatabases(!openDatabases);
+  };
+
+  const handleToolsClick = () => { // Handler for Tools section
+    setOpenTools(!openTools);
   };
 
   const handleChatRoomsClick = () => {
@@ -278,6 +284,43 @@ const PortalDrawer = () => {
                     ))}
                   </List>
                 </Collapse>
+
+                {userEntitlements?.tool_catalogues && userEntitlements.tool_catalogues.length > 0 && (
+                  <>
+                    <ListItem
+                      button
+                      onClick={handleToolsClick}
+                      sx={{ pl: 4, mb: 1 }}
+                    >
+                      <ListItemIcon>
+                        <ExtensionIcon />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary="Tools"
+                        primaryTypographyProps={{ noWrap: true }}
+                      />
+                      {openTools ? <ExpandLess /> : <ExpandMore />}
+                    </ListItem>
+                    <Collapse in={openTools} timeout="auto" unmountOnExit>
+                      <List component="div" disablePadding>
+                        {userEntitlements.tool_catalogues.map((toolCatalogue) => (
+                          <ListItem
+                            key={toolCatalogue.id}
+                            button
+                            component={Link}
+                            to={`/portal/tools/${toolCatalogue.id}`}
+                            sx={{ pl: 6, mb: 1 }}
+                          >
+                            <ListItemText
+                              primary={toolCatalogue.attributes.name}
+                              primaryTypographyProps={{ noWrap: true }}
+                            />
+                          </ListItem>
+                        ))}
+                      </List>
+                    </Collapse>
+                  </>
+                )}
               </List>
             </Collapse>
 

--- a/ui/admin-frontend/src/portal/components/ToolListView.js
+++ b/ui/admin-frontend/src/portal/components/ToolListView.js
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import {
+  Box,
+  Grid,
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Button,
+  CircularProgress,
+  Container,
+} from "@mui/material";
+import pubClient from "../../admin/utils/pubClient";
+import DetailModal from "./DetailModal";
+import { getVendorName, getVendorLogo } from "../../admin/utils/vendorLogos";
+import { PrimaryButton } from "../../admin/styles/sharedStyles";
+
+const defaultLogo = "/generic-tool-logo.png";
+
+const ToolListView = () => {
+  const [tools, setTools] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const { catalogueId } = useParams();
+  const navigate = useNavigate();
+  const [openModal, setOpenModal] = useState(false);
+  const [selectedTool, setSelectedTool] = useState(null);
+
+  useEffect(() => {
+    const fetchTools = async () => {
+      try {
+        const response = await pubClient.get(
+          `/common/catalogues/${catalogueId}/tools`,
+        );
+        setTools(response.data);
+        setLoading(false);
+      } catch (err) {
+        console.error("Error fetching Tools:", err);
+        setError("Failed to fetch Tools. Please try again later.");
+        setLoading(false);
+      }
+    };
+
+    fetchTools();
+  }, [catalogueId]);
+
+  const handleBuildApp = (toolId) => {
+    navigate(`/portal/app/new?tool=${toolId}`);
+  };
+
+  const handleOpenModal = (tool) => {
+    setSelectedTool(tool);
+    setOpenModal(true);
+  };
+
+  const handleCloseModal = () => {
+    setOpenModal(false);
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Typography color="error" sx={{ textAlign: "center", mt: 4 }}>
+        {error}
+      </Typography>
+    );
+  }
+
+  return (
+    <Container
+      maxWidth={false}
+      sx={{
+        px: 3,
+        py: 3,
+        boxSizing: "border-box",
+        width: "100%",
+      }}
+    >
+      <Typography variant="h4" component="h1" gutterBottom sx={{ mb: 4 }}>
+        Available Tools
+      </Typography>
+      <Grid container spacing={3}>
+        {tools.map((tool) => (
+          <Grid item xs={12} sm={6} md={4} key={tool.id}>
+            <Card
+              sx={{ height: "100%", display: "flex", flexDirection: "column" }}
+            >
+              <CardMedia
+                component="img"
+                sx={{ height: 140, objectFit: "contain" }}
+                image={tool.attributes.logoURL || defaultLogo}
+                alt={`${tool.attributes.name} logo`}
+              />
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Typography gutterBottom variant="h6" component="div">
+                  {tool.attributes.name}
+                </Typography>
+                <Typography variant="body2" color="text.defaultSubdued">
+                  {tool.attributes.short_description}
+                </Typography>
+                <Box sx={{ display: "flex", alignItems: "center", mt: 1 }}>
+                  <img
+                    src={getVendorLogo(tool.attributes.vendor)}
+                    alt={getVendorName(tool.attributes.vendor)}
+                    style={{
+                      width: 24,
+                      height: 24,
+                      marginRight: 8,
+                      objectFit: "contain",
+                    }}
+                    onError={(e) => {
+                      e.target.onerror = null;
+                      e.target.src =
+                        process.env.PUBLIC_URL + "/images/placeholder-logo.png";
+                    }}
+                  />
+                  <Typography variant="body2" color="text.defaultSubdued">
+                    {getVendorName(tool.attributes.vendor)}
+                  </Typography>
+                </Box>
+              </CardContent>
+              <Box
+                sx={{ p: 2, display: "flex", justifyContent: "space-between" }}
+              >
+                <Button variant="outlined" onClick={() => handleOpenModal(tool)}>
+                  More
+                </Button>
+                <PrimaryButton
+                  variant="contained"
+                  onClick={() => handleBuildApp(tool.id)}
+                >
+                  Build App
+                </PrimaryButton>
+              </Box>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+      {selectedTool && (
+        <DetailModal
+          open={openModal}
+          handleClose={handleCloseModal}
+          title={selectedTool.attributes.name}
+        >
+          <Typography variant="body1" sx={{ mt: 2 }}>
+            {selectedTool.attributes.long_description}
+          </Typography>
+          <Box sx={{ display: "flex", alignItems: "center", mt: 2 }}>
+            <Typography variant="subtitle1">Vendor:</Typography>
+            <img
+              src={getVendorLogo(selectedTool.attributes.vendor)}
+              alt={getVendorName(selectedTool.attributes.vendor)}
+              style={{
+                width: 24,
+                height: 24,
+                marginLeft: 8,
+                marginRight: 8,
+                objectFit: "contain",
+              }}
+            />
+            <Typography>
+              {getVendorName(selectedTool.attributes.vendor)}
+            </Typography>
+          </Box>
+        </DetailModal>
+      )}
+    </Container>
+  );
+};
+
+export default ToolListView;

--- a/ui/admin-frontend/src/routes/index.js
+++ b/ui/admin-frontend/src/routes/index.js
@@ -55,6 +55,7 @@ import ChatView from "../portal/components/ChatView";
 import PortalDashboard from "../portal/pages/PortalDashboard";
 import LLMListView from "../portal/components/LLMListView";
 import DataSourceListView from "../portal/components/DataSourceListView";
+import ToolListView from "../portal/components/ToolListView";
 import AppBuilder from "../portal/components/AppBuilder";
 import AppListView from "../portal/components/AppListView";
 import AppDetailView from "../portal/components/AppDetailView";
@@ -92,6 +93,10 @@ export const protectedRoutes = [
   {
     path: "/portal/databases/:catalogueId",
     element: <DataSourceListView />,
+  },
+  {
+    path: "/portal/tools/:catalogueId",
+    element: <ToolListView />,
   },
   {
     path: "/portal/app/new",


### PR DESCRIPTION
This commit enhances the App Detail View in the portal to display API endpoint information for any tools associated with an application. This addresses your feedback requesting visibility of how to use these tools.

Changes include:
- Added a new "Tool Access Details" section to `AppDetailView.js`.
- For each tool linked to an app, this section now shows:
    - Tool name and description.
    - A generated API endpoint URL (e.g., PROXY_URL/tools/tool-slug).
    - A button to copy the endpoint URL.
- The implementation mirrors the existing display for LLM and Datasource access details.