### PR TITLE
Fix: Address UI test failures in admin and user apps

### DIFF
--- a/tests/ui/tests/user-app-&-proxy.spec.ts
+++ b/tests/ui/tests/user-app-&-proxy.spec.ts
@@ -68,10 +68,7 @@ test('Apps on AI Portal page', async ({ page, loginPage, aiPortalPage, adminApps
     await aiPortalPage.DescriptionInput.fill(app_description);
 
     // Verify and select LLM
-    await aiPortalPage.LlmDropDown.click();
-    await expect(page.getByRole('option', { name: 'Env Anthropic LLM' })).toBeVisible();
-    await page.getByRole('option', { name: 'Env Anthropic LLM' }).click();
-    await page.keyboard.press('Escape');
+    await aiPortalPage.LlmDropDown.setValue('Env Anthropic LLM');
     await aiPortalPage.AddLlmButton.click();
     await expect(page.getByRole('chip', { name: 'Env Anthropic LLM' })).toBeVisible({ timeout: 7000 });
 

--- a/tests/ui/utils/wrappers/DropDownWrapper.ts
+++ b/tests/ui/utils/wrappers/DropDownWrapper.ts
@@ -41,13 +41,13 @@ export class DropDownWrapper {
             const dropdown = await this.getDropdownElement();
             
             // Click to open dropdown
-            await dropdown.click({ timeout: 5000 });
+            await dropdown.click({ timeout: 10000 });
             
             // Wait for animation
             await this.page.waitForTimeout(300);
             
             // Select the option
-            await this.page.locator('[role="option"]').filter({ hasText: text }).click({ timeout: 5000 });
+            await this.page.locator('[role="option"]').filter({ hasText: text }).click({ timeout: 10000 });
             
             // For multiple select, close the dropdown with Escape
             if (await this.isMultipleChoice()) {


### PR DESCRIPTION
This commit includes two main fixes for the UI tests:

1.  Resolved a `TypeError` in `tests/user-app-&-proxy.spec.ts` by correctly using the `setValue()` method for the `LlmDropDown` instead of attempting to call a non-existent `click()` method. Redundant lines for option selection and closing the dropdown were also removed as `setValue()` handles this.

2.  Mitigated potential timeout errors in `tests/admin-apps.spec.ts` (and other tests using `DropDownWrapper`) by increasing the timeout for dropdown interactions within the `DropDownWrapper.setValue` method from 5000ms to 10000ms. This provides more time for options to appear and be selected, making the tests more robust.