### PR TITLE
added health and readiness endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -363,6 +363,12 @@ func (a *API) setupRoutes() {
 	public.GET("/auth/config", a.handleGetConfig)
 	public.GET("/auth/features", a.handleFeatureSet)
 
+	// Health and readiness endpoints (unauthenticated)
+	public.GET("/healthz", a.handleHealth)
+	public.GET("/health", a.handleHealth)
+	public.GET("/readyz", a.handleReadiness)
+	public.GET("/ready", a.handleReadiness)
+
 	// routes for portal users
 	authed := public.Group("/common")
 	authed.Use(a.auth.AuthMiddleware())

--- a/api/health_handlers.go
+++ b/api/health_handlers.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (a *API) handleHealth(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func (a *API) handleReadiness(c *gin.Context) {
+	if !a.checkReadiness() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not ready"})
+		return
+	}
+	
+	c.JSON(http.StatusOK, gin.H{"status": "ready"})
+}
+
+func (a *API) checkReadiness() bool {
+	if a.config == nil || a.config.DB == nil {
+		return false
+	}
+	
+	sqlDB, err := a.config.DB.DB()
+	if err != nil {
+		return false
+	}
+	
+	if err := sqlDB.Ping(); err != nil {
+		return false
+	}
+	
+	return true
+}


### PR DESCRIPTION
Most apps expect these now, so this will add /health[z] and /ready[z] endpoints, the first to make sure the service is up and the latter to make sure dependency connectivity is OK.