### PR TITLE
Fix failing tests: embed assets + example cleanup

### DIFF
--- a/pkg/aigateway/example_test.go
+++ b/pkg/aigateway/example_test.go
@@ -1,4 +1,4 @@
-package aigateway_test
+package aigateway
 
 import (
 	"fmt"

--- a/pkg/ociplugins/examples_test.go
+++ b/pkg/ociplugins/examples_test.go
@@ -2,8 +2,7 @@
 package ociplugins
 
 import (
-	"fmt"
-	"runtime"
+    "fmt"
 )
 
 // ExampleParseOCICommand demonstrates how to parse OCI plugin commands
@@ -63,14 +62,12 @@ func ExampleOCIPluginClient_FetchPlugin() {
 	}
 
 	// This would fetch from the registry in a real scenario
-	fmt.Printf("Would fetch plugin: %s\n", ref.FullReference())
-	fmt.Printf("Target architecture: %s\n", params.Architecture)
-	fmt.Printf("Runtime: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+    fmt.Printf("Would fetch plugin: %s\n", ref.FullReference())
+    fmt.Printf("Target architecture: %s\n", params.Architecture)
 
-	// Output:
-	// Would fetch plugin: nexus.example.com/plugins/ner@sha256:0123deadbeef456
-	// Target architecture: linux/amd64
-	// Runtime: darwin/arm64
+    // Output:
+    // Would fetch plugin: nexus.example.com/plugins/ner@sha256:0123deadbeef456
+    // Target architecture: linux/amd64
 }
 
 // ExampleOCIReference_FullReference demonstrates reference formatting

--- a/ui/admin-frontend/.gitignore
+++ b/ui/admin-frontend/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+!/build/.keep
 
 # misc
 .DS_Store


### PR DESCRIPTION
Fixes failing tests on `main`.

Summary of changes
- Ensure `//go:embed ui/admin-frontend/build` always matches at least one file in CI by committing `ui/admin-frontend/build/.keep` and adding an ignore exception. This prevents `cannot embed directory ... contains no embeddable files` during `go test`.
- pkg/aigateway: Change examples to same package to resolve exported identifiers (ExampleX refers to unknown identifier errors).
- pkg/ociplugins: Make example output deterministic by removing environment-dependent GOOS/GOARCH print.

Rationale
- CI runs `go test ./...` and builds the root package; without an asset in `ui/admin-frontend/build`, the embed fails the whole build. Committing a tiny placeholder is a common pattern to keep embeds/packaging happy without affecting runtime.

Local verification
- Ran `go test ./...` locally; all packages pass.

Follow-ups (optional)
- If we prefer not to keep placeholders, we can guard the embed behind a build tag (e.g. `//go:build uiassets`) and provide a test stub; happy to send a follow-up PR.
