### PR TITLE
Configure Package Signing and Distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,8 +360,19 @@ jobs:
           BASE_REF: ${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}
         run: |
           set -eo pipefail
-          curl -s --retry 5 --retry-delay 10 --fail-with-body "http://tui.internal.dev.tyk.technology/v2/$VARIATION/ai-studio/$BASE_REF/${{ github.event_name}}/api/Distros.gho" | tee -a "$GITHUB_OUTPUT"
-          if ! [[ $VARIATION =~ prod ]];then
+          RESPONSE=$(curl -s --retry 5 --retry-delay 10 --fail-with-body "http://tui.internal.dev.tyk.technology/v2/$VARIATION/ai-studio/$BASE_REF/${{ github.event_name}}/api/Distros.gho" || echo "")
+
+          if [[ "$RESPONSE" == *"deb"* && "$RESPONSE" == *"rpm"* ]]; then
+            # TUI returned valid data, use it
+            echo "$RESPONSE" >> $GITHUB_OUTPUT
+          else
+            # TUI returned empty or invalid data, use defaults
+            echo "::warning::TUI returned empty or invalid response, using default values"
+            echo "deb=[\"ubuntu:jammy\", \"ubuntu:focal\", \"debian:bullseye\"]" >> $GITHUB_OUTPUT
+            echo "rpm=[\"amazonlinux:2\", \"el/8\", \"el/9\"]" >> $GITHUB_OUTPUT
+          fi
+
+          if ! [[ $VARIATION =~ prod ]]; then
             echo "::warning file=.github/workflows/release.yml,line=24,col=1,endColumn=8::Using test variation"
           fi
   upgrade-deb:
@@ -377,7 +388,7 @@ jobs:
         arch:
           - amd64
           - arm64
-        distro: ${{ fromJson(needs.test-controller-distros.outputs.deb || '["ubuntu:jammy", "ubuntu:focal", "debian:bullseye"]') }}
+        distro: ${{ fromJson(needs.test-controller-distros.outputs.deb) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -422,7 +433,7 @@ jobs:
         arch:
           - amd64
           - arm64
-        distro: ${{ fromJson(needs.test-controller-distros.outputs.rpm || '["amazonlinux:2", "el/8", "el/9"]') }}
+        distro: ${{ fromJson(needs.test-controller-distros.outputs.rpm) }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# Summary

This PR makes the definition of deb and rpm upgrade versions more robust, it also means that if tui goes down any gromit sync will update the deb and rpm upgrade versions with the defined defaults instead of what would have been configured in tui.
Jira ticket: [TT-15923](https://tyktech.atlassian.net/browse/TT-15923)
Related epic: [TT-15920](https://tyktech.atlassian.net/browse/TT-15920)

[TT-15923]: https://tyktech.atlassian.net/browse/TT-15923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TT-15920]: https://tyktech.atlassian.net/browse/TT-15920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ