### PR TITLE
[TT-15942]: Integrate Sentinel One CNS scanner workflow

### DIFF
--- a/.github/workflows/s1-cns-scans.yml
+++ b/.github/workflows/s1-cns-scans.yml
@@ -4,7 +4,7 @@ name: SentinelOne CNS Scan
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    branches: [master]
+    branches: [main]
 
 jobs:
   s1_scanner:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

This adds a github action workflow that will scan the code base for vulnerabilities, secrets, misconfigurations etc. on every pull request. 
These can be manged based on centrally set up rules on the S1 console.

## Related Issue
TT-15942

## Motivation and Context
This is to integrate S1 with our repositories so that everything can be managed centrally in the S1 console.

## How This Has Been Tested

This is not very testable, as it requires the workflow to be added and then run to actually see how it behaves.
But some scans have been done independently locally for testing.