### PR TITLE
fix: add placeholder file for go:embed ui/admin-frontend/build directive

### DIFF
--- a/ui/admin-frontend/.gitignore
+++ b/ui/admin-frontend/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build
+/build/*
 !/build/.keep
 
 # misc

--- a/ui/admin-frontend/build/.keep
+++ b/ui/admin-frontend/build/.keep
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary

- Fixes Go unit test failures caused by `pattern ui/admin-frontend/build: no matching files found` error
- Changes `.gitignore` from `/build` to `/build/*` to allow tracking the `.keep` file
- Adds `build/.keep` placeholder so `go:embed` directive always has at least one file to match

## Problem

The `main.go` file uses a `go:embed` directive that includes `ui/admin-frontend/build`:

```go
//go:embed ui/admin-frontend/build templates docs/site/public
var staticFiles embed.FS
```

When running `go test` without first building the frontend, the embed fails because the directory is empty.

## Solution

Add a tracked `.keep` placeholder file that ensures the directory always has at least one file, allowing tests to run independently of the frontend build.

## Test plan

- [ ] Go tests pass in CI without building frontend first
- [ ] Frontend build still works and outputs are still ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)