### PR TITLE
fix: use PublishDown for system events to propagate across replicas

### DIFF
--- a/services/system_events.go
+++ b/services/system_events.go
@@ -103,7 +103,7 @@ func (e *SystemEventEmitter) EmitObjectEvent(topic string, objectType string, ac
 		Object:     object,
 	}
 
-	if err := eventbridge.PublishLocal(e.bus, e.nodeID, topic, payload); err != nil {
+	if err := eventbridge.PublishDown(e.bus, e.nodeID, topic, payload); err != nil {
 		logger.Warnf("Failed to emit system event %s: %v", topic, err)
 	} else {
 		logger.Debugf("Emitted system event: topic=%s object_type=%s action=%s object_id=%d", topic, objectType, action, objectID)


### PR DESCRIPTION
## Summary
- Changes `eventbridge.PublishLocal` to `eventbridge.PublishDown` in `SystemEventEmitter.EmitObjectEvent`
- Ensures application creation events (and all system CRUD events) are propagated to all nodes
- Fixes issue where new application API keys were failing validation in distributed deployments

## Problem
New application API keys were failing validation because the `AppCreated` event was only published locally within the control plane replica that handled the creation request. This meant other replicas and microgateways did not receive the event, causing cache synchronization issues.

## Solution
Use `PublishDown` instead of `PublishLocal` to broadcast system events to all nodes, including other replicas and microgateways.

## Test plan
- [ ] Deploy to a multi-replica environment
- [ ] Create a new application
- [ ] Verify the API key works when hitting different replicas

Fixes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)