### PR TITLE
fix: use PublishDown for system events to broadcast to all replicas

### DIFF
--- a/services/system_events.go
+++ b/services/system_events.go
@@ -103,7 +103,7 @@ func (e *SystemEventEmitter) EmitObjectEvent(topic string, objectType string, ac
 		Object:     object,
 	}
 
-	if err := eventbridge.PublishLocal(e.bus, e.nodeID, topic, payload); err != nil {
+	if err := eventbridge.PublishDown(e.bus, e.nodeID, topic, payload); err != nil {
 		logger.Warnf("Failed to emit system event %s: %v", topic, err)
 	} else {
 		logger.Debugf("Emitted system event: topic=%s object_type=%s action=%s object_id=%d", topic, objectType, action, objectID)


### PR DESCRIPTION
## Summary
- Changes `eventbridge.PublishLocal` to `eventbridge.PublishDown` in `SystemEventEmitter.EmitObjectEvent()`
- Ensures system events (app created, LLM created, etc.) are broadcast to all control plane replicas
- Fixes cache synchronization issue where new API keys fail validation on other replicas

Fixes #268

## Root Cause
The `SystemEventEmitter` was using `PublishLocal` which only notifies local handlers. In a distributed environment with multiple control plane replicas, other replicas were never receiving the `AppCreated` event, causing their caches to miss the new application and resulting in API key validation failures.

## Solution
Change to `PublishDown` which broadcasts events to all nodes in the event bus, ensuring all replicas update their caches when applications are created, updated, or deleted.

## Test plan
- [ ] Deploy to multi-replica environment
- [ ] Create a new application with API key
- [ ] Verify API key works immediately on all replicas without cache misses

🤖 Generated with [Claude Code](https://claude.ai/code)