### PR TITLE
Add helpers and improvements to SDK

### DIFF
--- a/docs/site/docs/plugins-best-practices.md
+++ b/docs/site/docs/plugins-best-practices.md
@@ -187,24 +187,32 @@ func (p *MyPlugin) HandlePostAuth(ctx plugin_sdk.Context, req *pb.EnrichedReques
 
 ### Use Connection Pooling
 
-Reuse HTTP clients and database connections:
+Reuse HTTP clients and database connections. The SDK provides a `DefaultHTTPClient()` with sensible defaults (30s timeout, connection pooling, TLS handshake timeout):
 
 ```go
 func NewMyPlugin() *MyPlugin {
     return &MyPlugin{
         BasePlugin: plugin_sdk.NewBasePlugin("my-plugin", "1.0.0", "desc"),
-        // Reuse client across requests
-        httpClient: &http.Client{
-            Timeout: 10 * time.Second,
-            Transport: &http.Transport{
-                MaxIdleConns:        100,
-                MaxIdleConnsPerHost: 10,
-                IdleConnTimeout:     90 * time.Second,
-            },
-        },
+        // Use the SDK default client with connection pooling
+        httpClient: plugin_sdk.DefaultHTTPClient(),
     }
 }
 ```
+
+You can also configure your own client if you need different settings:
+
+```go
+httpClient: &http.Client{
+    Timeout: 10 * time.Second,
+    Transport: &http.Transport{
+        MaxIdleConns:        100,
+        MaxIdleConnsPerHost: 10,
+        IdleConnTimeout:     90 * time.Second,
+    },
+}
+```
+
+**Important**: Always use `http.NewRequestWithContext(ctx, ...)` to respect context cancellation and timeouts. Never use the default `http.Client{}` with zero timeout in production plugins.
 
 ### Cache Frequently Accessed Data
 

--- a/docs/site/docs/plugins-custom-endpoints.md
+++ b/docs/site/docs/plugins-custom-endpoints.md
@@ -579,9 +579,28 @@ Custom endpoint routes are managed automatically across all plugin lifecycle eve
 | No route match | 404 Not Found |
 | Plugin not loaded / unhealthy | 503 Service Unavailable |
 | Plugin returns error via gRPC | 502 Bad Gateway |
-| gRPC timeout (60s unary / 5min stream) | 504 Gateway Timeout |
+| gRPC timeout (60s unary / configurable stream) | 504 Gateway Timeout |
 | Auth required but missing/invalid | 401 Unauthorized |
 | Streaming error after headers sent | Connection closed, error logged |
+
+## Configuration
+
+### Streaming Timeout
+
+The streaming endpoint timeout is configurable via environment variable:
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `PLUGIN_ENDPOINT_STREAM_TIMEOUT` | `5m` | Maximum duration for streaming endpoint responses (SSE) |
+| `PLUGIN_ENDPOINT_MAX_BODY_SIZE` | `1048576` (1MB) | Maximum request body size for custom plugin endpoints |
+
+For long-running streaming connections (e.g., MCP proxy, real-time data feeds), increase the timeout:
+
+```bash
+PLUGIN_ENDPOINT_STREAM_TIMEOUT=30m
+```
+
+The upstream server should send periodic data to keep the connection alive within the timeout window.
 
 ## Related Documentation
 

--- a/docs/site/docs/plugins-sdk.md
+++ b/docs/site/docs/plugins-sdk.md
@@ -596,8 +596,20 @@ if ctx.Runtime == plugin_sdk.RuntimeStudio {
     // Get app
     app, err := ctx.Services.Studio().GetApp(ctx, appID)
 
-    // Update app with metadata
+    // List apps (basic)
+    apps, err := ctx.Services.Studio().ListApps(ctx, page, limit)
+
+    // List apps with filtering (by owner, namespace, active status)
+    apps, err := ctx.Services.Studio().ListAppsWithFilters(ctx, page, limit, &plugin_sdk.ListAppsOptions{
+        UserID: &ownerID,
+        Namespace: "production",
+    })
+
+    // Update app with metadata (full replacement)
     err := ctx.Services.Studio().UpdateAppWithMetadata(ctx, appID, metadata)
+
+    // Patch a single metadata key (atomic, safe for concurrent use)
+    metadataJSON, err := ctx.Services.Studio().PatchAppMetadata(ctx, appID, "tier", `"premium"`, false)
 
     // List LLMs
     llms, err := ctx.Services.Studio().ListLLMs(ctx, page, limit)

--- a/docs/site/docs/plugins-service-api.md
+++ b/docs/site/docs/plugins-service-api.md
@@ -1025,6 +1025,43 @@ for _, app := range appsResp.Apps {
 }
 ```
 
+### List Apps with Filters
+
+```go
+func ListAppsWithFilters(ctx context.Context, page, limit int32, opts *ListAppsOptions) (*mgmtpb.ListAppsResponse, error)
+```
+
+`ListAppsOptions` supports filtering by:
+- `IsActive *bool` — Filter by active/inactive status
+- `Namespace string` — Filter by namespace (empty = all namespaces)
+- `UserID *uint32` — Filter by owner user ID
+
+Example — list only the current user's apps:
+```go
+userID := uint32(ctx.UserID)
+appsResp, err := ai_studio_sdk.ListAppsWithFilters(ctx, 1, 10, &ai_studio_sdk.ListAppsOptions{
+    UserID: &userID,
+})
+if err != nil {
+    return err
+}
+
+for _, app := range appsResp.Apps {
+    log.Printf("My app: %s (namespace: %s)", app.Name, app.Namespace)
+}
+```
+
+Example — list active apps in a namespace:
+```go
+active := true
+appsResp, err := ai_studio_sdk.ListAppsWithFilters(ctx, 1, 20, &ai_studio_sdk.ListAppsOptions{
+    IsActive:  &active,
+    Namespace: "production",
+})
+```
+
+The original `ListApps(ctx, page, limit)` function is still available for backward compatibility and returns all apps without filtering.
+
 ### Get App by ID
 
 ```go
@@ -1041,6 +1078,48 @@ if err != nil {
 log.Printf("App: %s - Description: %s", app.Name, app.Description)
 ```
 
+### Patch App Metadata
+
+```go
+func PatchAppMetadata(ctx context.Context, appID uint32, key, value string, deleteKey bool) (*mgmtpb.PatchAppMetadataResponse, error)
+```
+
+Atomically updates a single metadata key on an app without requiring a full app update. This is safer than `UpdateAppWithMetadata` for concurrent modifications since it uses database-level transactions with row locking.
+
+**Set a metadata key** (value must be JSON-encoded):
+```go
+resp, err := ai_studio_sdk.PatchAppMetadata(ctx, appID, "cache_enabled", `true`, false)
+if err != nil {
+    return err
+}
+log.Printf("Updated metadata: %s", resp.Metadata) // Full metadata JSON
+```
+
+**Set complex values:**
+```go
+// String value
+ai_studio_sdk.PatchAppMetadata(ctx, appID, "tier", `"premium"`, false)
+
+// Numeric value
+ai_studio_sdk.PatchAppMetadata(ctx, appID, "max_requests", `1000`, false)
+
+// Object value
+ai_studio_sdk.PatchAppMetadata(ctx, appID, "settings", `{"timeout": 30, "retries": 3}`, false)
+```
+
+**Delete a metadata key:**
+```go
+resp, err := ai_studio_sdk.PatchAppMetadata(ctx, appID, "deprecated_field", "", true)
+```
+
+**Via the plugin_sdk interface:**
+```go
+// Returns the full metadata JSON string after the operation
+metadataJSON, err := ctx.Services.Studio().PatchAppMetadata(ctx, appID, "tier", `"premium"`, false)
+```
+
+Requires: `apps.write` scope.
+
 ## KV Storage Operations
 
 Requires: `kv.read` or `kv.readwrite` scope
@@ -1048,10 +1127,10 @@ Requires: `kv.read` or `kv.readwrite` scope
 ### Write Data
 
 ```go
-func WritePluginKV(ctx context.Context, key string, value []byte) (bool, error)
+func WritePluginKV(ctx context.Context, key string, value []byte, expireAt *time.Time) (bool, error)
 ```
 
-Returns `true` if created, `false` if updated.
+Returns `true` if created, `false` if updated. Pass `nil` for `expireAt` for no expiration.
 
 Example:
 ```go
@@ -1061,7 +1140,7 @@ settings := map[string]interface{}{
 }
 
 data, _ := json.Marshal(settings)
-created, err := ai_studio_sdk.WritePluginKV(ctx, "settings", data)
+created, err := ai_studio_sdk.WritePluginKV(ctx, "settings", data, nil)
 if err != nil {
     return err
 }
@@ -1072,6 +1151,26 @@ if created {
     log.Println("Settings updated")
 }
 ```
+
+### Write Data with TTL
+
+```go
+func WritePluginKVWithTTL(ctx context.Context, key string, value []byte, ttl time.Duration) (bool, error)
+```
+
+Convenience function that writes data with a relative time-to-live. The entry is automatically expired and cleaned up after the TTL elapses.
+
+Example:
+```go
+// Cache a response for 1 hour
+data, _ := json.Marshal(cachedResponse)
+created, err := ai_studio_sdk.WritePluginKVWithTTL(ctx, "cache:response:123", data, 1*time.Hour)
+if err != nil {
+    return err
+}
+```
+
+Expired keys are automatically cleaned up by the platform. Reads on expired keys return a not-found error.
 
 ### Read Data
 
@@ -1314,8 +1413,8 @@ llmsResp, err := ai_studio_sdk.ListLLMs(ctx, 1, 10)
 | ListTools, GetTool | `tools.read` |
 | ExecuteTool | `tools.execute` |
 | CreateTool, UpdateTool | `tools.write` |
-| ListApps, GetApp | `apps.read` |
-| CreateApp, UpdateApp | `apps.write` |
+| ListApps, ListAppsWithFilters, GetApp | `apps.read` |
+| CreateApp, UpdateApp, PatchAppMetadata | `apps.write` |
 | ListPlugins, GetPlugin | `plugins.read` |
 | ReadPluginKV, ListPluginKVKeys | `kv.read` |
 | WritePluginKV, DeletePluginKV | `kv.readwrite` |

--- a/microgateway/internal/api/router.go
+++ b/microgateway/internal/api/router.go
@@ -96,8 +96,9 @@ type RouterConfig struct {
 	ModelRouterService        *services.ModelRouterService // Enterprise: Model router service
 	EnableSwagger             bool
 	EnableMetrics             bool
-	PluginEndpointMaxBodySize int64 // Max request body for custom plugin endpoints (default 1MB)
-	Version                   string
+	PluginEndpointMaxBodySize    int64         // Max request body for custom plugin endpoints (default 1MB)
+	PluginEndpointStreamTimeout time.Duration // Timeout for streaming plugin endpoints (default 5m)
+	Version                     string
 	BuildHash                 string
 	BuildTime                 string
 }
@@ -527,7 +528,11 @@ func handlePluginEndpointUnary(c *gin.Context, config *RouterConfig, pluginID ui
 
 // handlePluginEndpointStream handles a streaming plugin endpoint request (SSE)
 func handlePluginEndpointStream(c *gin.Context, config *RouterConfig, pluginID uint, req *pb.EndpointRequest) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Minute)
+	streamTimeout := config.PluginEndpointStreamTimeout
+	if streamTimeout == 0 {
+		streamTimeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), streamTimeout)
 	defer cancel()
 
 	stream, err := config.PluginManager.HandleEndpointRequestStream(ctx, pluginID, req)

--- a/microgateway/internal/config/config.go
+++ b/microgateway/internal/config/config.go
@@ -88,7 +88,8 @@ type GatewayConfig struct {
 	RateLimitRPM              int           `env:"GATEWAY_DEFAULT_RATE_LIMIT" envDefault:"100"`
 	EnableFilters             bool          `env:"GATEWAY_ENABLE_FILTERS" envDefault:"true"`
 	EnableAnalytics           bool          `env:"GATEWAY_ENABLE_ANALYTICS" envDefault:"true"`
-	PluginEndpointMaxBodySize int64         `env:"PLUGIN_ENDPOINT_MAX_BODY_SIZE" envDefault:"1048576"` // 1MB max request body for custom plugin endpoints
+	PluginEndpointMaxBodySize    int64         `env:"PLUGIN_ENDPOINT_MAX_BODY_SIZE" envDefault:"1048576"`    // 1MB max request body for custom plugin endpoints
+	PluginEndpointStreamTimeout time.Duration `env:"PLUGIN_ENDPOINT_STREAM_TIMEOUT" envDefault:"5m"`       // Timeout for streaming plugin endpoints
 }
 
 // HubSpokeConfig holds hub-and-spoke architecture configuration

--- a/microgateway/internal/server/server.go
+++ b/microgateway/internal/server/server.go
@@ -108,18 +108,19 @@ func New(cfg *config.Config, serviceContainer *services.ServiceContainer, versio
 
 	// Setup API router with mounted gateway
 	routerConfig := &api.RouterConfig{
-		AuthProvider:              serviceContainer.AuthProvider,
-		Services:                  serviceContainer,
-		Gateway:                   gateway, // Mount gateway back in router
-		PluginManager:             api.NewPluginManagerAdapter(pluginManager),
-		ReloadCoordinator:         nil, // Will be set for control instances
-		ModelRouterService:        serviceContainer.ModelRouterService, // Enterprise: Model router
-		EnableSwagger:             cfg.IsDevelopment(),
-		EnableMetrics:             cfg.Observability.EnableMetrics,
-		PluginEndpointMaxBodySize: cfg.Gateway.PluginEndpointMaxBodySize,
-		Version:                   version,
-		BuildHash:                 buildHash,
-		BuildTime:                 buildTime,
+		AuthProvider:                serviceContainer.AuthProvider,
+		Services:                    serviceContainer,
+		Gateway:                     gateway, // Mount gateway back in router
+		PluginManager:               api.NewPluginManagerAdapter(pluginManager),
+		ReloadCoordinator:           nil, // Will be set for control instances
+		ModelRouterService:          serviceContainer.ModelRouterService, // Enterprise: Model router
+		EnableSwagger:               cfg.IsDevelopment(),
+		EnableMetrics:               cfg.Observability.EnableMetrics,
+		PluginEndpointMaxBodySize:   cfg.Gateway.PluginEndpointMaxBodySize,
+		PluginEndpointStreamTimeout: cfg.Gateway.PluginEndpointStreamTimeout,
+		Version:                     version,
+		BuildHash:                   buildHash,
+		BuildTime:                   buildTime,
 	}
 
 	router := api.SetupRouter(routerConfig)
@@ -155,17 +156,18 @@ func (s *Server) SetReloadCoordinator(reloadCoordinator *services.ReloadCoordina
 	
 	// Update router config with reload coordinator
 	routerConfig := &api.RouterConfig{
-		AuthProvider:              s.services.AuthProvider,
-		Services:                  s.services,
-		Gateway:                   s.gateway,
-		PluginManager:             api.NewPluginManagerAdapter(s.pluginManager),
-		ReloadCoordinator:         reloadCoordinator, // Add reload coordinator
-		EnableSwagger:             s.config.IsDevelopment(),
-		EnableMetrics:             s.config.Observability.EnableMetrics,
-		PluginEndpointMaxBodySize: s.config.Gateway.PluginEndpointMaxBodySize,
-		Version:                   s.version,
-		BuildHash:                 s.buildHash,
-		BuildTime:                 s.buildTime,
+		AuthProvider:                s.services.AuthProvider,
+		Services:                    s.services,
+		Gateway:                     s.gateway,
+		PluginManager:               api.NewPluginManagerAdapter(s.pluginManager),
+		ReloadCoordinator:           reloadCoordinator, // Add reload coordinator
+		EnableSwagger:               s.config.IsDevelopment(),
+		EnableMetrics:               s.config.Observability.EnableMetrics,
+		PluginEndpointMaxBodySize:   s.config.Gateway.PluginEndpointMaxBodySize,
+		PluginEndpointStreamTimeout: s.config.Gateway.PluginEndpointStreamTimeout,
+		Version:                     s.version,
+		BuildHash:                   s.buildHash,
+		BuildTime:                   s.buildTime,
 	}
 
 	// Recreate router with reload coordinator

--- a/models/app.go
+++ b/models/app.go
@@ -258,8 +258,8 @@ func (a *Apps) ListWithPagination(db *gorm.DB, pageSize int, pageNumber int, all
 	return totalCount, totalPages, err
 }
 
-// ListWithFilters returns a paginated list of apps with namespace and active status filtering
-func (a *Apps) ListWithFilters(db *gorm.DB, pageSize int, pageNumber int, all bool, sort, namespace string, isActive *bool) (int64, int, error) {
+// ListWithFilters returns a paginated list of apps with namespace, active status, and owner filtering
+func (a *Apps) ListWithFilters(db *gorm.DB, pageSize int, pageNumber int, all bool, sort, namespace string, isActive *bool, userID *uint) (int64, int, error) {
 	var totalCount int64
 	query := db.Model(&App{})
 
@@ -275,6 +275,11 @@ func (a *Apps) ListWithFilters(db *gorm.DB, pageSize int, pageNumber int, all bo
 	// Apply is_active filtering
 	if isActive != nil {
 		query = query.Where("is_active = ?", *isActive)
+	}
+
+	// Apply user_id (owner) filtering
+	if userID != nil {
+		query = query.Where("user_id = ?", *userID)
 	}
 
 	// Handle sorting

--- a/pkg/ai_studio_sdk/service_api.go
+++ b/pkg/ai_studio_sdk/service_api.go
@@ -295,6 +295,35 @@ func ListApps(ctx context.Context, page, limit int32) (*mgmtpb.ListAppsResponse,
 	})
 }
 
+// ListAppsOptions provides optional filters for ListAppsWithFilters
+type ListAppsOptions struct {
+	IsActive  *bool
+	Namespace string
+	UserID    *uint32
+}
+
+// ListAppsWithFilters returns apps with optional filtering by user_id, namespace, and is_active
+func ListAppsWithFilters(ctx context.Context, page, limit int32, opts *ListAppsOptions) (*mgmtpb.ListAppsResponse, error) {
+	client, err := getServiceClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("service client unavailable: %w", err)
+	}
+
+	req := &mgmtpb.ListAppsRequest{
+		Context: createPluginContext(AvailableScopes.AppsRead),
+		Page:    page,
+		Limit:   limit,
+	}
+
+	if opts != nil {
+		req.IsActive = opts.IsActive
+		req.Namespace = opts.Namespace
+		req.UserId = opts.UserID
+	}
+
+	return client.ListApps(ctx, req)
+}
+
 // GetPluginsCount returns the total number of plugins (helper function)
 func GetPluginsCount(ctx context.Context) (int, error) {
 	resp, err := ListPlugins(ctx, 1, 1)
@@ -567,6 +596,24 @@ func UpdateAppWithMetadata(ctx context.Context, appID uint32, name, description 
 		DatasourceIds: datasourceIDs,
 		MonthlyBudget: monthlyBudget,
 		Metadata:      metadata,
+	})
+}
+
+// PatchAppMetadata atomically updates a single metadata key on an app.
+// Pass deleteKey=true to remove the key, or provide a JSON-encoded value to set it.
+// Returns the full metadata JSON after the operation.
+func PatchAppMetadata(ctx context.Context, appID uint32, key, value string, deleteKey bool) (*mgmtpb.PatchAppMetadataResponse, error) {
+	client, err := getServiceClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("service client unavailable: %w", err)
+	}
+
+	return client.PatchAppMetadata(ctx, &mgmtpb.PatchAppMetadataRequest{
+		Context: createPluginContext(AvailableScopes.AppsWrite),
+		AppId:   appID,
+		Key:     key,
+		Value:   value,
+		Delete:  deleteKey,
 	})
 }
 

--- a/pkg/plugin_sdk/context.go
+++ b/pkg/plugin_sdk/context.go
@@ -156,6 +156,13 @@ type GatewayServices interface {
 	SendToControlJSON(ctx context.Context, value interface{}, correlationID string, metadata map[string]string) (int64, error)
 }
 
+// ListAppsOptions provides optional filters for listing apps
+type ListAppsOptions struct {
+	IsActive  *bool
+	Namespace string
+	UserID    *uint32
+}
+
 // StudioServices provides access to AI Studio-specific services
 // Only available when Runtime == RuntimeStudio
 type StudioServices interface {
@@ -168,6 +175,15 @@ type StudioServices interface {
 
 	// UpdateAppWithMetadata updates app configuration including metadata
 	UpdateAppWithMetadata(ctx context.Context, appID uint32, name, description string, isActive bool, llmIDs, toolIDs, datasourceIDs []uint32, monthlyBudget *float64, metadata string) (interface{}, error)
+
+	// PatchAppMetadata atomically updates a single metadata key on an app.
+	// To set a key: PatchAppMetadata(ctx, appID, "mykey", `"myvalue"`, false)
+	// To delete a key: PatchAppMetadata(ctx, appID, "mykey", "", true)
+	// Returns the full metadata JSON string after the operation.
+	PatchAppMetadata(ctx context.Context, appID uint32, key, value string, deleteKey bool) (string, error)
+
+	// ListAppsWithFilters lists apps with optional filtering by user_id, namespace, and is_active
+	ListAppsWithFilters(ctx context.Context, page, limit int32, opts *ListAppsOptions) (interface{}, error)
 
 	// GetLLM retrieves LLM details from AI Studio database
 	GetLLM(ctx context.Context, llmID uint32) (interface{}, error)

--- a/pkg/plugin_sdk/http.go
+++ b/pkg/plugin_sdk/http.go
@@ -1,0 +1,34 @@
+package plugin_sdk
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// DefaultHTTPClient returns an HTTP client with sensible defaults for plugin use.
+// Plugins should reuse this client across requests for connection pooling.
+//
+// Defaults:
+//   - 30 second overall timeout
+//   - 10 second dial timeout
+//   - 10 second TLS handshake timeout
+//   - 100 max idle connections, 10 per host
+//   - 90 second idle connection timeout
+//
+// Plugins can also create their own http.Client if different settings are needed.
+func DefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+		},
+	}
+}

--- a/pkg/plugin_sdk/http_test.go
+++ b/pkg/plugin_sdk/http_test.go
@@ -1,0 +1,48 @@
+package plugin_sdk
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestDefaultHTTPClient(t *testing.T) {
+	client := DefaultHTTPClient()
+
+	if client == nil {
+		t.Fatal("DefaultHTTPClient returned nil")
+	}
+
+	if client.Timeout == 0 {
+		t.Error("Expected non-zero timeout")
+	}
+
+	if client.Timeout.Seconds() != 30 {
+		t.Errorf("Expected 30s timeout, got %v", client.Timeout)
+	}
+
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("Expected *http.Transport")
+	}
+
+	if transport.MaxIdleConns != 100 {
+		t.Errorf("Expected 100 max idle conns, got %d", transport.MaxIdleConns)
+	}
+
+	if transport.MaxIdleConnsPerHost != 10 {
+		t.Errorf("Expected 10 max idle conns per host, got %d", transport.MaxIdleConnsPerHost)
+	}
+
+	if transport.TLSHandshakeTimeout.Seconds() != 10 {
+		t.Errorf("Expected 10s TLS handshake timeout, got %v", transport.TLSHandshakeTimeout)
+	}
+}
+
+func TestDefaultHTTPClient_ReturnsNewInstance(t *testing.T) {
+	client1 := DefaultHTTPClient()
+	client2 := DefaultHTTPClient()
+
+	if client1 == client2 {
+		t.Error("Expected different instances from each call")
+	}
+}

--- a/pkg/plugin_sdk/services.go
+++ b/pkg/plugin_sdk/services.go
@@ -229,6 +229,24 @@ func (s *studioServicesImpl) UpdateAppWithMetadata(ctx context.Context, appID ui
 	return ai_studio_sdk.UpdateAppWithMetadata(ctx, appID, name, description, isActive, llmIDs, toolIDs, datasourceIDs, monthlyBudget, metadata)
 }
 
+func (s *studioServicesImpl) PatchAppMetadata(ctx context.Context, appID uint32, key, value string, deleteKey bool) (string, error) {
+	resp, err := ai_studio_sdk.PatchAppMetadata(ctx, appID, key, value, deleteKey)
+	if err != nil {
+		return "", err
+	}
+	return resp.Metadata, nil
+}
+
+func (s *studioServicesImpl) ListAppsWithFilters(ctx context.Context, page, limit int32, opts *ListAppsOptions) (interface{}, error) {
+	sdkOpts := &ai_studio_sdk.ListAppsOptions{}
+	if opts != nil {
+		sdkOpts.IsActive = opts.IsActive
+		sdkOpts.Namespace = opts.Namespace
+		sdkOpts.UserID = opts.UserID
+	}
+	return ai_studio_sdk.ListAppsWithFilters(ctx, page, limit, sdkOpts)
+}
+
 func (s *studioServicesImpl) GetLLM(ctx context.Context, llmID uint32) (interface{}, error) {
 	return ai_studio_sdk.GetLLM(ctx, llmID)
 }

--- a/proto/ai_studio_management/ai_studio_management.pb.go
+++ b/proto/ai_studio_management/ai_studio_management.pb.go
@@ -2375,8 +2375,10 @@ type ListAppsRequest struct {
 	IsActive  *bool  `protobuf:"varint,2,opt,name=is_active,json=isActive,proto3,oneof" json:"is_active,omitempty"`
 	Namespace string `protobuf:"bytes,3,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// Pagination
-	Page          int32 `protobuf:"varint,4,opt,name=page,proto3" json:"page,omitempty"`
-	Limit         int32 `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
+	Page  int32 `protobuf:"varint,4,opt,name=page,proto3" json:"page,omitempty"`
+	Limit int32 `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
+	// Owner filtering
+	UserId        *uint32 `protobuf:"varint,6,opt,name=user_id,json=userId,proto3,oneof" json:"user_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2442,6 +2444,13 @@ func (x *ListAppsRequest) GetPage() int32 {
 func (x *ListAppsRequest) GetLimit() int32 {
 	if x != nil {
 		return x.Limit
+	}
+	return 0
+}
+
+func (x *ListAppsRequest) GetUserId() uint32 {
+	if x != nil && x.UserId != nil {
+		return *x.UserId
 	}
 	return 0
 }
@@ -3166,6 +3175,143 @@ func (x *DeleteAppResponse) GetMessage() string {
 	return ""
 }
 
+// PatchAppMetadata atomically updates a single metadata key on an app
+type PatchAppMetadataRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Context       *PluginContext         `protobuf:"bytes,1,opt,name=context,proto3" json:"context,omitempty"`
+	AppId         uint32                 `protobuf:"varint,2,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	Key           string                 `protobuf:"bytes,3,opt,name=key,proto3" json:"key,omitempty"`        // Metadata key to set or delete
+	Value         string                 `protobuf:"bytes,4,opt,name=value,proto3" json:"value,omitempty"`    // JSON-encoded value (ignored if delete=true)
+	Delete        bool                   `protobuf:"varint,5,opt,name=delete,proto3" json:"delete,omitempty"` // If true, removes the key instead of setting it
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PatchAppMetadataRequest) Reset() {
+	*x = PatchAppMetadataRequest{}
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PatchAppMetadataRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PatchAppMetadataRequest) ProtoMessage() {}
+
+func (x *PatchAppMetadataRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PatchAppMetadataRequest.ProtoReflect.Descriptor instead.
+func (*PatchAppMetadataRequest) Descriptor() ([]byte, []int) {
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *PatchAppMetadataRequest) GetContext() *PluginContext {
+	if x != nil {
+		return x.Context
+	}
+	return nil
+}
+
+func (x *PatchAppMetadataRequest) GetAppId() uint32 {
+	if x != nil {
+		return x.AppId
+	}
+	return 0
+}
+
+func (x *PatchAppMetadataRequest) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *PatchAppMetadataRequest) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+func (x *PatchAppMetadataRequest) GetDelete() bool {
+	if x != nil {
+		return x.Delete
+	}
+	return false
+}
+
+type PatchAppMetadataResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	Metadata      string                 `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"` // Full metadata JSON after the operation
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PatchAppMetadataResponse) Reset() {
+	*x = PatchAppMetadataResponse{}
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PatchAppMetadataResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PatchAppMetadataResponse) ProtoMessage() {}
+
+func (x *PatchAppMetadataResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PatchAppMetadataResponse.ProtoReflect.Descriptor instead.
+func (*PatchAppMetadataResponse) Descriptor() ([]byte, []int) {
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *PatchAppMetadataResponse) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *PatchAppMetadataResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *PatchAppMetadataResponse) GetMetadata() string {
+	if x != nil {
+		return x.Metadata
+	}
+	return ""
+}
+
 type ListToolsRequest struct {
 	state   protoimpl.MessageState `protogen:"open.v1"`
 	Context *PluginContext         `protobuf:"bytes,1,opt,name=context,proto3" json:"context,omitempty"`
@@ -3182,7 +3328,7 @@ type ListToolsRequest struct {
 
 func (x *ListToolsRequest) Reset() {
 	*x = ListToolsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[44]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3194,7 +3340,7 @@ func (x *ListToolsRequest) String() string {
 func (*ListToolsRequest) ProtoMessage() {}
 
 func (x *ListToolsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[44]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3207,7 +3353,7 @@ func (x *ListToolsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListToolsRequest.ProtoReflect.Descriptor instead.
 func (*ListToolsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{44}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ListToolsRequest) GetContext() *PluginContext {
@@ -3262,7 +3408,7 @@ type ListToolsResponse struct {
 
 func (x *ListToolsResponse) Reset() {
 	*x = ListToolsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[45]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3274,7 +3420,7 @@ func (x *ListToolsResponse) String() string {
 func (*ListToolsResponse) ProtoMessage() {}
 
 func (x *ListToolsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[45]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3287,7 +3433,7 @@ func (x *ListToolsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListToolsResponse.ProtoReflect.Descriptor instead.
 func (*ListToolsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{45}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *ListToolsResponse) GetTools() []*ToolInfo {
@@ -3314,7 +3460,7 @@ type GetToolRequest struct {
 
 func (x *GetToolRequest) Reset() {
 	*x = GetToolRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[46]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3326,7 +3472,7 @@ func (x *GetToolRequest) String() string {
 func (*GetToolRequest) ProtoMessage() {}
 
 func (x *GetToolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[46]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3339,7 +3485,7 @@ func (x *GetToolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolRequest.ProtoReflect.Descriptor instead.
 func (*GetToolRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{46}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetToolRequest) GetContext() *PluginContext {
@@ -3365,7 +3511,7 @@ type GetToolResponse struct {
 
 func (x *GetToolResponse) Reset() {
 	*x = GetToolResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[47]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3377,7 +3523,7 @@ func (x *GetToolResponse) String() string {
 func (*GetToolResponse) ProtoMessage() {}
 
 func (x *GetToolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[47]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3390,7 +3536,7 @@ func (x *GetToolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolResponse.ProtoReflect.Descriptor instead.
 func (*GetToolResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{47}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *GetToolResponse) GetTool() *ToolInfo {
@@ -3410,7 +3556,7 @@ type GetToolOperationsRequest struct {
 
 func (x *GetToolOperationsRequest) Reset() {
 	*x = GetToolOperationsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[48]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3422,7 +3568,7 @@ func (x *GetToolOperationsRequest) String() string {
 func (*GetToolOperationsRequest) ProtoMessage() {}
 
 func (x *GetToolOperationsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[48]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3435,7 +3581,7 @@ func (x *GetToolOperationsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolOperationsRequest.ProtoReflect.Descriptor instead.
 func (*GetToolOperationsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{48}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetToolOperationsRequest) GetContext() *PluginContext {
@@ -3461,7 +3607,7 @@ type GetToolOperationsResponse struct {
 
 func (x *GetToolOperationsResponse) Reset() {
 	*x = GetToolOperationsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[49]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3473,7 +3619,7 @@ func (x *GetToolOperationsResponse) String() string {
 func (*GetToolOperationsResponse) ProtoMessage() {}
 
 func (x *GetToolOperationsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[49]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3486,7 +3632,7 @@ func (x *GetToolOperationsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolOperationsResponse.ProtoReflect.Descriptor instead.
 func (*GetToolOperationsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{49}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *GetToolOperationsResponse) GetOperations() []*ToolOperation {
@@ -3510,7 +3656,7 @@ type CallToolOperationRequest struct {
 
 func (x *CallToolOperationRequest) Reset() {
 	*x = CallToolOperationRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[50]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3522,7 +3668,7 @@ func (x *CallToolOperationRequest) String() string {
 func (*CallToolOperationRequest) ProtoMessage() {}
 
 func (x *CallToolOperationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[50]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3535,7 +3681,7 @@ func (x *CallToolOperationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallToolOperationRequest.ProtoReflect.Descriptor instead.
 func (*CallToolOperationRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{50}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *CallToolOperationRequest) GetContext() *PluginContext {
@@ -3591,7 +3737,7 @@ type CallToolOperationResponse struct {
 
 func (x *CallToolOperationResponse) Reset() {
 	*x = CallToolOperationResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[51]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3603,7 +3749,7 @@ func (x *CallToolOperationResponse) String() string {
 func (*CallToolOperationResponse) ProtoMessage() {}
 
 func (x *CallToolOperationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[51]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3616,7 +3762,7 @@ func (x *CallToolOperationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallToolOperationResponse.ProtoReflect.Descriptor instead.
 func (*CallToolOperationResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{51}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *CallToolOperationResponse) GetSuccess() bool {
@@ -3661,7 +3807,7 @@ type ToolInfo struct {
 
 func (x *ToolInfo) Reset() {
 	*x = ToolInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[52]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3673,7 +3819,7 @@ func (x *ToolInfo) String() string {
 func (*ToolInfo) ProtoMessage() {}
 
 func (x *ToolInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[52]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3686,7 +3832,7 @@ func (x *ToolInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolInfo.ProtoReflect.Descriptor instead.
 func (*ToolInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{52}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ToolInfo) GetId() uint32 {
@@ -3795,7 +3941,7 @@ type ToolOperation struct {
 
 func (x *ToolOperation) Reset() {
 	*x = ToolOperation{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[53]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3807,7 +3953,7 @@ func (x *ToolOperation) String() string {
 func (*ToolOperation) ProtoMessage() {}
 
 func (x *ToolOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[53]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3820,7 +3966,7 @@ func (x *ToolOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolOperation.ProtoReflect.Descriptor instead.
 func (*ToolOperation) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{53}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *ToolOperation) GetOperationId() string {
@@ -3886,7 +4032,7 @@ type ToolParameter struct {
 
 func (x *ToolParameter) Reset() {
 	*x = ToolParameter{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[54]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3898,7 +4044,7 @@ func (x *ToolParameter) String() string {
 func (*ToolParameter) ProtoMessage() {}
 
 func (x *ToolParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[54]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3911,7 +4057,7 @@ func (x *ToolParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolParameter.ProtoReflect.Descriptor instead.
 func (*ToolParameter) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{54}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *ToolParameter) GetName() string {
@@ -3968,7 +4114,7 @@ type ToolRequestBody struct {
 
 func (x *ToolRequestBody) Reset() {
 	*x = ToolRequestBody{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[55]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3980,7 +4126,7 @@ func (x *ToolRequestBody) String() string {
 func (*ToolRequestBody) ProtoMessage() {}
 
 func (x *ToolRequestBody) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[55]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3993,7 +4139,7 @@ func (x *ToolRequestBody) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolRequestBody.ProtoReflect.Descriptor instead.
 func (*ToolRequestBody) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{55}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ToolRequestBody) GetDescription() string {
@@ -4040,7 +4186,7 @@ type CreateToolRequest struct {
 
 func (x *CreateToolRequest) Reset() {
 	*x = CreateToolRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[56]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4052,7 +4198,7 @@ func (x *CreateToolRequest) String() string {
 func (*CreateToolRequest) ProtoMessage() {}
 
 func (x *CreateToolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[56]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4065,7 +4211,7 @@ func (x *CreateToolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateToolRequest.ProtoReflect.Descriptor instead.
 func (*CreateToolRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{56}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *CreateToolRequest) GetContext() *PluginContext {
@@ -4133,7 +4279,7 @@ type CreateToolResponse struct {
 
 func (x *CreateToolResponse) Reset() {
 	*x = CreateToolResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[57]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4145,7 +4291,7 @@ func (x *CreateToolResponse) String() string {
 func (*CreateToolResponse) ProtoMessage() {}
 
 func (x *CreateToolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[57]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4158,7 +4304,7 @@ func (x *CreateToolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateToolResponse.ProtoReflect.Descriptor instead.
 func (*CreateToolResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{57}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *CreateToolResponse) GetTool() *ToolInfo {
@@ -4185,7 +4331,7 @@ type UpdateToolRequest struct {
 
 func (x *UpdateToolRequest) Reset() {
 	*x = UpdateToolRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[58]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4197,7 +4343,7 @@ func (x *UpdateToolRequest) String() string {
 func (*UpdateToolRequest) ProtoMessage() {}
 
 func (x *UpdateToolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[58]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4210,7 +4356,7 @@ func (x *UpdateToolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateToolRequest.ProtoReflect.Descriptor instead.
 func (*UpdateToolRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{58}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *UpdateToolRequest) GetContext() *PluginContext {
@@ -4285,7 +4431,7 @@ type UpdateToolResponse struct {
 
 func (x *UpdateToolResponse) Reset() {
 	*x = UpdateToolResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[59]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4297,7 +4443,7 @@ func (x *UpdateToolResponse) String() string {
 func (*UpdateToolResponse) ProtoMessage() {}
 
 func (x *UpdateToolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[59]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4310,7 +4456,7 @@ func (x *UpdateToolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateToolResponse.ProtoReflect.Descriptor instead.
 func (*UpdateToolResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{59}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *UpdateToolResponse) GetTool() *ToolInfo {
@@ -4330,7 +4476,7 @@ type DeleteToolRequest struct {
 
 func (x *DeleteToolRequest) Reset() {
 	*x = DeleteToolRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[60]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4342,7 +4488,7 @@ func (x *DeleteToolRequest) String() string {
 func (*DeleteToolRequest) ProtoMessage() {}
 
 func (x *DeleteToolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[60]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4355,7 +4501,7 @@ func (x *DeleteToolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteToolRequest.ProtoReflect.Descriptor instead.
 func (*DeleteToolRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{60}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *DeleteToolRequest) GetContext() *PluginContext {
@@ -4382,7 +4528,7 @@ type DeleteToolResponse struct {
 
 func (x *DeleteToolResponse) Reset() {
 	*x = DeleteToolResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[61]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4394,7 +4540,7 @@ func (x *DeleteToolResponse) String() string {
 func (*DeleteToolResponse) ProtoMessage() {}
 
 func (x *DeleteToolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[61]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4407,7 +4553,7 @@ func (x *DeleteToolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteToolResponse.ProtoReflect.Descriptor instead.
 func (*DeleteToolResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{61}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *DeleteToolResponse) GetSuccess() bool {
@@ -4437,7 +4583,7 @@ type ListDatasourcesRequest struct {
 
 func (x *ListDatasourcesRequest) Reset() {
 	*x = ListDatasourcesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[62]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4449,7 +4595,7 @@ func (x *ListDatasourcesRequest) String() string {
 func (*ListDatasourcesRequest) ProtoMessage() {}
 
 func (x *ListDatasourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[62]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4462,7 +4608,7 @@ func (x *ListDatasourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatasourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListDatasourcesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{62}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *ListDatasourcesRequest) GetContext() *PluginContext {
@@ -4510,7 +4656,7 @@ type ListDatasourcesResponse struct {
 
 func (x *ListDatasourcesResponse) Reset() {
 	*x = ListDatasourcesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[63]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4522,7 +4668,7 @@ func (x *ListDatasourcesResponse) String() string {
 func (*ListDatasourcesResponse) ProtoMessage() {}
 
 func (x *ListDatasourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[63]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4535,7 +4681,7 @@ func (x *ListDatasourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatasourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListDatasourcesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{63}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListDatasourcesResponse) GetDatasources() []*DatasourceInfo {
@@ -4562,7 +4708,7 @@ type GetDatasourceRequest struct {
 
 func (x *GetDatasourceRequest) Reset() {
 	*x = GetDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[64]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4574,7 +4720,7 @@ func (x *GetDatasourceRequest) String() string {
 func (*GetDatasourceRequest) ProtoMessage() {}
 
 func (x *GetDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[64]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4587,7 +4733,7 @@ func (x *GetDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*GetDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{64}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *GetDatasourceRequest) GetContext() *PluginContext {
@@ -4613,7 +4759,7 @@ type GetDatasourceResponse struct {
 
 func (x *GetDatasourceResponse) Reset() {
 	*x = GetDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[65]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4625,7 +4771,7 @@ func (x *GetDatasourceResponse) String() string {
 func (*GetDatasourceResponse) ProtoMessage() {}
 
 func (x *GetDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[65]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4638,7 +4784,7 @@ func (x *GetDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*GetDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{65}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *GetDatasourceResponse) GetDatasource() *DatasourceInfo {
@@ -4674,7 +4820,7 @@ type CreateDatasourceRequest struct {
 
 func (x *CreateDatasourceRequest) Reset() {
 	*x = CreateDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[66]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4686,7 +4832,7 @@ func (x *CreateDatasourceRequest) String() string {
 func (*CreateDatasourceRequest) ProtoMessage() {}
 
 func (x *CreateDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[66]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4699,7 +4845,7 @@ func (x *CreateDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*CreateDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{66}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *CreateDatasourceRequest) GetContext() *PluginContext {
@@ -4837,7 +4983,7 @@ type CreateDatasourceResponse struct {
 
 func (x *CreateDatasourceResponse) Reset() {
 	*x = CreateDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[67]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4849,7 +4995,7 @@ func (x *CreateDatasourceResponse) String() string {
 func (*CreateDatasourceResponse) ProtoMessage() {}
 
 func (x *CreateDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[67]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4862,7 +5008,7 @@ func (x *CreateDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*CreateDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{67}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *CreateDatasourceResponse) GetDatasource() *DatasourceInfo {
@@ -4900,7 +5046,7 @@ type UpdateDatasourceRequest struct {
 
 func (x *UpdateDatasourceRequest) Reset() {
 	*x = UpdateDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[68]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4912,7 +5058,7 @@ func (x *UpdateDatasourceRequest) String() string {
 func (*UpdateDatasourceRequest) ProtoMessage() {}
 
 func (x *UpdateDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[68]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4925,7 +5071,7 @@ func (x *UpdateDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{68}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *UpdateDatasourceRequest) GetContext() *PluginContext {
@@ -5070,7 +5216,7 @@ type UpdateDatasourceResponse struct {
 
 func (x *UpdateDatasourceResponse) Reset() {
 	*x = UpdateDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[69]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5082,7 +5228,7 @@ func (x *UpdateDatasourceResponse) String() string {
 func (*UpdateDatasourceResponse) ProtoMessage() {}
 
 func (x *UpdateDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[69]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5095,7 +5241,7 @@ func (x *UpdateDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{69}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *UpdateDatasourceResponse) GetDatasource() *DatasourceInfo {
@@ -5115,7 +5261,7 @@ type DeleteDatasourceRequest struct {
 
 func (x *DeleteDatasourceRequest) Reset() {
 	*x = DeleteDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[70]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5127,7 +5273,7 @@ func (x *DeleteDatasourceRequest) String() string {
 func (*DeleteDatasourceRequest) ProtoMessage() {}
 
 func (x *DeleteDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[70]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5140,7 +5286,7 @@ func (x *DeleteDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{70}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *DeleteDatasourceRequest) GetContext() *PluginContext {
@@ -5167,7 +5313,7 @@ type DeleteDatasourceResponse struct {
 
 func (x *DeleteDatasourceResponse) Reset() {
 	*x = DeleteDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[71]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5179,7 +5325,7 @@ func (x *DeleteDatasourceResponse) String() string {
 func (*DeleteDatasourceResponse) ProtoMessage() {}
 
 func (x *DeleteDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[71]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5192,7 +5338,7 @@ func (x *DeleteDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{71}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *DeleteDatasourceResponse) GetSuccess() bool {
@@ -5219,7 +5365,7 @@ type CloneDatasourceRequest struct {
 
 func (x *CloneDatasourceRequest) Reset() {
 	*x = CloneDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[72]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5231,7 +5377,7 @@ func (x *CloneDatasourceRequest) String() string {
 func (*CloneDatasourceRequest) ProtoMessage() {}
 
 func (x *CloneDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[72]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5244,7 +5390,7 @@ func (x *CloneDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloneDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*CloneDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{72}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *CloneDatasourceRequest) GetContext() *PluginContext {
@@ -5270,7 +5416,7 @@ type CloneDatasourceResponse struct {
 
 func (x *CloneDatasourceResponse) Reset() {
 	*x = CloneDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[73]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5282,7 +5428,7 @@ func (x *CloneDatasourceResponse) String() string {
 func (*CloneDatasourceResponse) ProtoMessage() {}
 
 func (x *CloneDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[73]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5295,7 +5441,7 @@ func (x *CloneDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloneDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*CloneDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{73}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *CloneDatasourceResponse) GetDatasource() *DatasourceInfo {
@@ -5315,7 +5461,7 @@ type SearchDatasourcesRequest struct {
 
 func (x *SearchDatasourcesRequest) Reset() {
 	*x = SearchDatasourcesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[74]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5327,7 +5473,7 @@ func (x *SearchDatasourcesRequest) String() string {
 func (*SearchDatasourcesRequest) ProtoMessage() {}
 
 func (x *SearchDatasourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[74]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5340,7 +5486,7 @@ func (x *SearchDatasourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchDatasourcesRequest.ProtoReflect.Descriptor instead.
 func (*SearchDatasourcesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{74}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *SearchDatasourcesRequest) GetContext() *PluginContext {
@@ -5366,7 +5512,7 @@ type SearchDatasourcesResponse struct {
 
 func (x *SearchDatasourcesResponse) Reset() {
 	*x = SearchDatasourcesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[75]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5378,7 +5524,7 @@ func (x *SearchDatasourcesResponse) String() string {
 func (*SearchDatasourcesResponse) ProtoMessage() {}
 
 func (x *SearchDatasourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[75]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5391,7 +5537,7 @@ func (x *SearchDatasourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchDatasourcesResponse.ProtoReflect.Descriptor instead.
 func (*SearchDatasourcesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{75}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *SearchDatasourcesResponse) GetDatasources() []*DatasourceInfo {
@@ -5411,7 +5557,7 @@ type ProcessEmbeddingsRequest struct {
 
 func (x *ProcessEmbeddingsRequest) Reset() {
 	*x = ProcessEmbeddingsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[76]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5423,7 +5569,7 @@ func (x *ProcessEmbeddingsRequest) String() string {
 func (*ProcessEmbeddingsRequest) ProtoMessage() {}
 
 func (x *ProcessEmbeddingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[76]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5436,7 +5582,7 @@ func (x *ProcessEmbeddingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessEmbeddingsRequest.ProtoReflect.Descriptor instead.
 func (*ProcessEmbeddingsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{76}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ProcessEmbeddingsRequest) GetContext() *PluginContext {
@@ -5464,7 +5610,7 @@ type ProcessEmbeddingsResponse struct {
 
 func (x *ProcessEmbeddingsResponse) Reset() {
 	*x = ProcessEmbeddingsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[77]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5476,7 +5622,7 @@ func (x *ProcessEmbeddingsResponse) String() string {
 func (*ProcessEmbeddingsResponse) ProtoMessage() {}
 
 func (x *ProcessEmbeddingsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[77]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5489,7 +5635,7 @@ func (x *ProcessEmbeddingsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessEmbeddingsResponse.ProtoReflect.Descriptor instead.
 func (*ProcessEmbeddingsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{77}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *ProcessEmbeddingsResponse) GetSuccess() bool {
@@ -5525,7 +5671,7 @@ type GenerateEmbeddingRequest struct {
 
 func (x *GenerateEmbeddingRequest) Reset() {
 	*x = GenerateEmbeddingRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[78]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5537,7 +5683,7 @@ func (x *GenerateEmbeddingRequest) String() string {
 func (*GenerateEmbeddingRequest) ProtoMessage() {}
 
 func (x *GenerateEmbeddingRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[78]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5550,7 +5696,7 @@ func (x *GenerateEmbeddingRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateEmbeddingRequest.ProtoReflect.Descriptor instead.
 func (*GenerateEmbeddingRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{78}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{80}
 }
 
 func (x *GenerateEmbeddingRequest) GetContext() *PluginContext {
@@ -5585,7 +5731,7 @@ type GenerateEmbeddingResponse struct {
 
 func (x *GenerateEmbeddingResponse) Reset() {
 	*x = GenerateEmbeddingResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[79]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5597,7 +5743,7 @@ func (x *GenerateEmbeddingResponse) String() string {
 func (*GenerateEmbeddingResponse) ProtoMessage() {}
 
 func (x *GenerateEmbeddingResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[79]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5610,7 +5756,7 @@ func (x *GenerateEmbeddingResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GenerateEmbeddingResponse.ProtoReflect.Descriptor instead.
 func (*GenerateEmbeddingResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{79}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{81}
 }
 
 func (x *GenerateEmbeddingResponse) GetSuccess() bool {
@@ -5643,7 +5789,7 @@ type EmbeddingVector struct {
 
 func (x *EmbeddingVector) Reset() {
 	*x = EmbeddingVector{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[80]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5655,7 +5801,7 @@ func (x *EmbeddingVector) String() string {
 func (*EmbeddingVector) ProtoMessage() {}
 
 func (x *EmbeddingVector) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[80]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5668,7 +5814,7 @@ func (x *EmbeddingVector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EmbeddingVector.ProtoReflect.Descriptor instead.
 func (*EmbeddingVector) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{80}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *EmbeddingVector) GetValues() []float32 {
@@ -5690,7 +5836,7 @@ type StoreDocumentsRequest struct {
 
 func (x *StoreDocumentsRequest) Reset() {
 	*x = StoreDocumentsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[81]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5702,7 +5848,7 @@ func (x *StoreDocumentsRequest) String() string {
 func (*StoreDocumentsRequest) ProtoMessage() {}
 
 func (x *StoreDocumentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[81]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5715,7 +5861,7 @@ func (x *StoreDocumentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoreDocumentsRequest.ProtoReflect.Descriptor instead.
 func (*StoreDocumentsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{81}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *StoreDocumentsRequest) GetContext() *PluginContext {
@@ -5750,7 +5896,7 @@ type DocumentWithEmbedding struct {
 
 func (x *DocumentWithEmbedding) Reset() {
 	*x = DocumentWithEmbedding{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[82]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5762,7 +5908,7 @@ func (x *DocumentWithEmbedding) String() string {
 func (*DocumentWithEmbedding) ProtoMessage() {}
 
 func (x *DocumentWithEmbedding) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[82]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5775,7 +5921,7 @@ func (x *DocumentWithEmbedding) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DocumentWithEmbedding.ProtoReflect.Descriptor instead.
 func (*DocumentWithEmbedding) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{82}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *DocumentWithEmbedding) GetContent() string {
@@ -5810,7 +5956,7 @@ type StoreDocumentsResponse struct {
 
 func (x *StoreDocumentsResponse) Reset() {
 	*x = StoreDocumentsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[83]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5822,7 +5968,7 @@ func (x *StoreDocumentsResponse) String() string {
 func (*StoreDocumentsResponse) ProtoMessage() {}
 
 func (x *StoreDocumentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[83]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5835,7 +5981,7 @@ func (x *StoreDocumentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoreDocumentsResponse.ProtoReflect.Descriptor instead.
 func (*StoreDocumentsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{83}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *StoreDocumentsResponse) GetSuccess() bool {
@@ -5871,7 +6017,7 @@ type ProcessAndStoreRequest struct {
 
 func (x *ProcessAndStoreRequest) Reset() {
 	*x = ProcessAndStoreRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[84]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5883,7 +6029,7 @@ func (x *ProcessAndStoreRequest) String() string {
 func (*ProcessAndStoreRequest) ProtoMessage() {}
 
 func (x *ProcessAndStoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[84]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5896,7 +6042,7 @@ func (x *ProcessAndStoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessAndStoreRequest.ProtoReflect.Descriptor instead.
 func (*ProcessAndStoreRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{84}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *ProcessAndStoreRequest) GetContext() *PluginContext {
@@ -5930,7 +6076,7 @@ type DocumentChunk struct {
 
 func (x *DocumentChunk) Reset() {
 	*x = DocumentChunk{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[85]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5942,7 +6088,7 @@ func (x *DocumentChunk) String() string {
 func (*DocumentChunk) ProtoMessage() {}
 
 func (x *DocumentChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[85]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5955,7 +6101,7 @@ func (x *DocumentChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DocumentChunk.ProtoReflect.Descriptor instead.
 func (*DocumentChunk) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{85}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *DocumentChunk) GetContent() string {
@@ -5983,7 +6129,7 @@ type ProcessAndStoreResponse struct {
 
 func (x *ProcessAndStoreResponse) Reset() {
 	*x = ProcessAndStoreResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[86]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5995,7 +6141,7 @@ func (x *ProcessAndStoreResponse) String() string {
 func (*ProcessAndStoreResponse) ProtoMessage() {}
 
 func (x *ProcessAndStoreResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[86]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6008,7 +6154,7 @@ func (x *ProcessAndStoreResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ProcessAndStoreResponse.ProtoReflect.Descriptor instead.
 func (*ProcessAndStoreResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{86}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *ProcessAndStoreResponse) GetSuccess() bool {
@@ -6046,7 +6192,7 @@ type DeleteDocumentsByMetadataRequest struct {
 
 func (x *DeleteDocumentsByMetadataRequest) Reset() {
 	*x = DeleteDocumentsByMetadataRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[87]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6058,7 +6204,7 @@ func (x *DeleteDocumentsByMetadataRequest) String() string {
 func (*DeleteDocumentsByMetadataRequest) ProtoMessage() {}
 
 func (x *DeleteDocumentsByMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[87]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6071,7 +6217,7 @@ func (x *DeleteDocumentsByMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDocumentsByMetadataRequest.ProtoReflect.Descriptor instead.
 func (*DeleteDocumentsByMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{87}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *DeleteDocumentsByMetadataRequest) GetContext() *PluginContext {
@@ -6120,7 +6266,7 @@ type DeleteDocumentsByMetadataResponse struct {
 
 func (x *DeleteDocumentsByMetadataResponse) Reset() {
 	*x = DeleteDocumentsByMetadataResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[88]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6132,7 +6278,7 @@ func (x *DeleteDocumentsByMetadataResponse) String() string {
 func (*DeleteDocumentsByMetadataResponse) ProtoMessage() {}
 
 func (x *DeleteDocumentsByMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[88]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6145,7 +6291,7 @@ func (x *DeleteDocumentsByMetadataResponse) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use DeleteDocumentsByMetadataResponse.ProtoReflect.Descriptor instead.
 func (*DeleteDocumentsByMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{88}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *DeleteDocumentsByMetadataResponse) GetSuccess() bool {
@@ -6184,7 +6330,7 @@ type QueryByMetadataOnlyRequest struct {
 
 func (x *QueryByMetadataOnlyRequest) Reset() {
 	*x = QueryByMetadataOnlyRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[89]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6196,7 +6342,7 @@ func (x *QueryByMetadataOnlyRequest) String() string {
 func (*QueryByMetadataOnlyRequest) ProtoMessage() {}
 
 func (x *QueryByMetadataOnlyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[89]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6209,7 +6355,7 @@ func (x *QueryByMetadataOnlyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryByMetadataOnlyRequest.ProtoReflect.Descriptor instead.
 func (*QueryByMetadataOnlyRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{89}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *QueryByMetadataOnlyRequest) GetContext() *PluginContext {
@@ -6264,7 +6410,7 @@ type QueryByMetadataOnlyResponse struct {
 
 func (x *QueryByMetadataOnlyResponse) Reset() {
 	*x = QueryByMetadataOnlyResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[90]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6276,7 +6422,7 @@ func (x *QueryByMetadataOnlyResponse) String() string {
 func (*QueryByMetadataOnlyResponse) ProtoMessage() {}
 
 func (x *QueryByMetadataOnlyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[90]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6289,7 +6435,7 @@ func (x *QueryByMetadataOnlyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryByMetadataOnlyResponse.ProtoReflect.Descriptor instead.
 func (*QueryByMetadataOnlyResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{90}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *QueryByMetadataOnlyResponse) GetResults() []*DatasourceResult {
@@ -6317,7 +6463,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[91]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6329,7 +6475,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[91]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6342,7 +6488,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{91}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{93}
 }
 
 func (x *ListNamespacesRequest) GetContext() *PluginContext {
@@ -6368,7 +6514,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[92]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6380,7 +6526,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[92]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6393,7 +6539,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{92}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []*NamespaceInfo {
@@ -6413,7 +6559,7 @@ type NamespaceInfo struct {
 
 func (x *NamespaceInfo) Reset() {
 	*x = NamespaceInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[93]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6425,7 +6571,7 @@ func (x *NamespaceInfo) String() string {
 func (*NamespaceInfo) ProtoMessage() {}
 
 func (x *NamespaceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[93]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6438,7 +6584,7 @@ func (x *NamespaceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NamespaceInfo.ProtoReflect.Descriptor instead.
 func (*NamespaceInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{93}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *NamespaceInfo) GetName() string {
@@ -6468,7 +6614,7 @@ type DeleteNamespaceRequest struct {
 
 func (x *DeleteNamespaceRequest) Reset() {
 	*x = DeleteNamespaceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[94]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6480,7 +6626,7 @@ func (x *DeleteNamespaceRequest) String() string {
 func (*DeleteNamespaceRequest) ProtoMessage() {}
 
 func (x *DeleteNamespaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[94]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6493,7 +6639,7 @@ func (x *DeleteNamespaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNamespaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteNamespaceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{94}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *DeleteNamespaceRequest) GetContext() *PluginContext {
@@ -6534,7 +6680,7 @@ type DeleteNamespaceResponse struct {
 
 func (x *DeleteNamespaceResponse) Reset() {
 	*x = DeleteNamespaceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[95]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6546,7 +6692,7 @@ func (x *DeleteNamespaceResponse) String() string {
 func (*DeleteNamespaceResponse) ProtoMessage() {}
 
 func (x *DeleteNamespaceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[95]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6559,7 +6705,7 @@ func (x *DeleteNamespaceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteNamespaceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteNamespaceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{95}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *DeleteNamespaceResponse) GetSuccess() bool {
@@ -6590,7 +6736,7 @@ type QueryByVectorRequest struct {
 
 func (x *QueryByVectorRequest) Reset() {
 	*x = QueryByVectorRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[96]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6602,7 +6748,7 @@ func (x *QueryByVectorRequest) String() string {
 func (*QueryByVectorRequest) ProtoMessage() {}
 
 func (x *QueryByVectorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[96]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6615,7 +6761,7 @@ func (x *QueryByVectorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryByVectorRequest.ProtoReflect.Descriptor instead.
 func (*QueryByVectorRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{96}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *QueryByVectorRequest) GetContext() *PluginContext {
@@ -6680,7 +6826,7 @@ type DatasourceInfo struct {
 
 func (x *DatasourceInfo) Reset() {
 	*x = DatasourceInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[97]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6692,7 +6838,7 @@ func (x *DatasourceInfo) String() string {
 func (*DatasourceInfo) ProtoMessage() {}
 
 func (x *DatasourceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[97]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6705,7 +6851,7 @@ func (x *DatasourceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatasourceInfo.ProtoReflect.Descriptor instead.
 func (*DatasourceInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{97}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *DatasourceInfo) GetId() uint32 {
@@ -6852,7 +6998,7 @@ type ListDataCataloguesRequest struct {
 
 func (x *ListDataCataloguesRequest) Reset() {
 	*x = ListDataCataloguesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[98]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6864,7 +7010,7 @@ func (x *ListDataCataloguesRequest) String() string {
 func (*ListDataCataloguesRequest) ProtoMessage() {}
 
 func (x *ListDataCataloguesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[98]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6877,7 +7023,7 @@ func (x *ListDataCataloguesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDataCataloguesRequest.ProtoReflect.Descriptor instead.
 func (*ListDataCataloguesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{98}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ListDataCataloguesRequest) GetContext() *PluginContext {
@@ -6911,7 +7057,7 @@ type ListDataCataloguesResponse struct {
 
 func (x *ListDataCataloguesResponse) Reset() {
 	*x = ListDataCataloguesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[99]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6923,7 +7069,7 @@ func (x *ListDataCataloguesResponse) String() string {
 func (*ListDataCataloguesResponse) ProtoMessage() {}
 
 func (x *ListDataCataloguesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[99]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6936,7 +7082,7 @@ func (x *ListDataCataloguesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDataCataloguesResponse.ProtoReflect.Descriptor instead.
 func (*ListDataCataloguesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{99}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ListDataCataloguesResponse) GetDataCatalogues() []*DataCatalogueInfo {
@@ -6963,7 +7109,7 @@ type GetDataCatalogueRequest struct {
 
 func (x *GetDataCatalogueRequest) Reset() {
 	*x = GetDataCatalogueRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[100]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6975,7 +7121,7 @@ func (x *GetDataCatalogueRequest) String() string {
 func (*GetDataCatalogueRequest) ProtoMessage() {}
 
 func (x *GetDataCatalogueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[100]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6988,7 +7134,7 @@ func (x *GetDataCatalogueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDataCatalogueRequest.ProtoReflect.Descriptor instead.
 func (*GetDataCatalogueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{100}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *GetDataCatalogueRequest) GetContext() *PluginContext {
@@ -7014,7 +7160,7 @@ type GetDataCatalogueResponse struct {
 
 func (x *GetDataCatalogueResponse) Reset() {
 	*x = GetDataCatalogueResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[101]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7026,7 +7172,7 @@ func (x *GetDataCatalogueResponse) String() string {
 func (*GetDataCatalogueResponse) ProtoMessage() {}
 
 func (x *GetDataCatalogueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[101]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7039,7 +7185,7 @@ func (x *GetDataCatalogueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDataCatalogueResponse.ProtoReflect.Descriptor instead.
 func (*GetDataCatalogueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{101}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *GetDataCatalogueResponse) GetDataCatalogue() *DataCatalogueInfo {
@@ -7062,7 +7208,7 @@ type CreateDataCatalogueRequest struct {
 
 func (x *CreateDataCatalogueRequest) Reset() {
 	*x = CreateDataCatalogueRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[102]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7074,7 +7220,7 @@ func (x *CreateDataCatalogueRequest) String() string {
 func (*CreateDataCatalogueRequest) ProtoMessage() {}
 
 func (x *CreateDataCatalogueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[102]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7087,7 +7233,7 @@ func (x *CreateDataCatalogueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDataCatalogueRequest.ProtoReflect.Descriptor instead.
 func (*CreateDataCatalogueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{102}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *CreateDataCatalogueRequest) GetContext() *PluginContext {
@@ -7134,7 +7280,7 @@ type CreateDataCatalogueResponse struct {
 
 func (x *CreateDataCatalogueResponse) Reset() {
 	*x = CreateDataCatalogueResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[103]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7146,7 +7292,7 @@ func (x *CreateDataCatalogueResponse) String() string {
 func (*CreateDataCatalogueResponse) ProtoMessage() {}
 
 func (x *CreateDataCatalogueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[103]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7159,7 +7305,7 @@ func (x *CreateDataCatalogueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateDataCatalogueResponse.ProtoReflect.Descriptor instead.
 func (*CreateDataCatalogueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{103}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *CreateDataCatalogueResponse) GetDataCatalogue() *DataCatalogueInfo {
@@ -7183,7 +7329,7 @@ type UpdateDataCatalogueRequest struct {
 
 func (x *UpdateDataCatalogueRequest) Reset() {
 	*x = UpdateDataCatalogueRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[104]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7195,7 +7341,7 @@ func (x *UpdateDataCatalogueRequest) String() string {
 func (*UpdateDataCatalogueRequest) ProtoMessage() {}
 
 func (x *UpdateDataCatalogueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[104]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7208,7 +7354,7 @@ func (x *UpdateDataCatalogueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDataCatalogueRequest.ProtoReflect.Descriptor instead.
 func (*UpdateDataCatalogueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{104}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *UpdateDataCatalogueRequest) GetContext() *PluginContext {
@@ -7262,7 +7408,7 @@ type UpdateDataCatalogueResponse struct {
 
 func (x *UpdateDataCatalogueResponse) Reset() {
 	*x = UpdateDataCatalogueResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[105]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7274,7 +7420,7 @@ func (x *UpdateDataCatalogueResponse) String() string {
 func (*UpdateDataCatalogueResponse) ProtoMessage() {}
 
 func (x *UpdateDataCatalogueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[105]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7287,7 +7433,7 @@ func (x *UpdateDataCatalogueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateDataCatalogueResponse.ProtoReflect.Descriptor instead.
 func (*UpdateDataCatalogueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{105}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *UpdateDataCatalogueResponse) GetDataCatalogue() *DataCatalogueInfo {
@@ -7307,7 +7453,7 @@ type DeleteDataCatalogueRequest struct {
 
 func (x *DeleteDataCatalogueRequest) Reset() {
 	*x = DeleteDataCatalogueRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[106]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7319,7 +7465,7 @@ func (x *DeleteDataCatalogueRequest) String() string {
 func (*DeleteDataCatalogueRequest) ProtoMessage() {}
 
 func (x *DeleteDataCatalogueRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[106]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7332,7 +7478,7 @@ func (x *DeleteDataCatalogueRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDataCatalogueRequest.ProtoReflect.Descriptor instead.
 func (*DeleteDataCatalogueRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{106}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *DeleteDataCatalogueRequest) GetContext() *PluginContext {
@@ -7359,7 +7505,7 @@ type DeleteDataCatalogueResponse struct {
 
 func (x *DeleteDataCatalogueResponse) Reset() {
 	*x = DeleteDataCatalogueResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[107]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7371,7 +7517,7 @@ func (x *DeleteDataCatalogueResponse) String() string {
 func (*DeleteDataCatalogueResponse) ProtoMessage() {}
 
 func (x *DeleteDataCatalogueResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[107]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7384,7 +7530,7 @@ func (x *DeleteDataCatalogueResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteDataCatalogueResponse.ProtoReflect.Descriptor instead.
 func (*DeleteDataCatalogueResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{107}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *DeleteDataCatalogueResponse) GetSuccess() bool {
@@ -7418,7 +7564,7 @@ type DataCatalogueInfo struct {
 
 func (x *DataCatalogueInfo) Reset() {
 	*x = DataCatalogueInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[108]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7430,7 +7576,7 @@ func (x *DataCatalogueInfo) String() string {
 func (*DataCatalogueInfo) ProtoMessage() {}
 
 func (x *DataCatalogueInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[108]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7443,7 +7589,7 @@ func (x *DataCatalogueInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataCatalogueInfo.ProtoReflect.Descriptor instead.
 func (*DataCatalogueInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{108}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *DataCatalogueInfo) GetId() uint32 {
@@ -7520,7 +7666,7 @@ type ListTagsRequest struct {
 
 func (x *ListTagsRequest) Reset() {
 	*x = ListTagsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[109]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7532,7 +7678,7 @@ func (x *ListTagsRequest) String() string {
 func (*ListTagsRequest) ProtoMessage() {}
 
 func (x *ListTagsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[109]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7545,7 +7691,7 @@ func (x *ListTagsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTagsRequest.ProtoReflect.Descriptor instead.
 func (*ListTagsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{109}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *ListTagsRequest) GetContext() *PluginContext {
@@ -7579,7 +7725,7 @@ type ListTagsResponse struct {
 
 func (x *ListTagsResponse) Reset() {
 	*x = ListTagsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[110]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7591,7 +7737,7 @@ func (x *ListTagsResponse) String() string {
 func (*ListTagsResponse) ProtoMessage() {}
 
 func (x *ListTagsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[110]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7604,7 +7750,7 @@ func (x *ListTagsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTagsResponse.ProtoReflect.Descriptor instead.
 func (*ListTagsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{110}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *ListTagsResponse) GetTags() []*TagInfo {
@@ -7631,7 +7777,7 @@ type GetTagRequest struct {
 
 func (x *GetTagRequest) Reset() {
 	*x = GetTagRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[111]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7643,7 +7789,7 @@ func (x *GetTagRequest) String() string {
 func (*GetTagRequest) ProtoMessage() {}
 
 func (x *GetTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[111]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7656,7 +7802,7 @@ func (x *GetTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTagRequest.ProtoReflect.Descriptor instead.
 func (*GetTagRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{111}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *GetTagRequest) GetContext() *PluginContext {
@@ -7682,7 +7828,7 @@ type GetTagResponse struct {
 
 func (x *GetTagResponse) Reset() {
 	*x = GetTagResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[112]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7694,7 +7840,7 @@ func (x *GetTagResponse) String() string {
 func (*GetTagResponse) ProtoMessage() {}
 
 func (x *GetTagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[112]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7707,7 +7853,7 @@ func (x *GetTagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTagResponse.ProtoReflect.Descriptor instead.
 func (*GetTagResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{112}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *GetTagResponse) GetTag() *TagInfo {
@@ -7727,7 +7873,7 @@ type CreateTagRequest struct {
 
 func (x *CreateTagRequest) Reset() {
 	*x = CreateTagRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[113]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7739,7 +7885,7 @@ func (x *CreateTagRequest) String() string {
 func (*CreateTagRequest) ProtoMessage() {}
 
 func (x *CreateTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[113]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7752,7 +7898,7 @@ func (x *CreateTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTagRequest.ProtoReflect.Descriptor instead.
 func (*CreateTagRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{113}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *CreateTagRequest) GetContext() *PluginContext {
@@ -7778,7 +7924,7 @@ type CreateTagResponse struct {
 
 func (x *CreateTagResponse) Reset() {
 	*x = CreateTagResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[114]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7790,7 +7936,7 @@ func (x *CreateTagResponse) String() string {
 func (*CreateTagResponse) ProtoMessage() {}
 
 func (x *CreateTagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[114]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7803,7 +7949,7 @@ func (x *CreateTagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateTagResponse.ProtoReflect.Descriptor instead.
 func (*CreateTagResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{114}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *CreateTagResponse) GetTag() *TagInfo {
@@ -7824,7 +7970,7 @@ type UpdateTagRequest struct {
 
 func (x *UpdateTagRequest) Reset() {
 	*x = UpdateTagRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[115]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7836,7 +7982,7 @@ func (x *UpdateTagRequest) String() string {
 func (*UpdateTagRequest) ProtoMessage() {}
 
 func (x *UpdateTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[115]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7849,7 +7995,7 @@ func (x *UpdateTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTagRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTagRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{115}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *UpdateTagRequest) GetContext() *PluginContext {
@@ -7882,7 +8028,7 @@ type UpdateTagResponse struct {
 
 func (x *UpdateTagResponse) Reset() {
 	*x = UpdateTagResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[116]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7894,7 +8040,7 @@ func (x *UpdateTagResponse) String() string {
 func (*UpdateTagResponse) ProtoMessage() {}
 
 func (x *UpdateTagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[116]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7907,7 +8053,7 @@ func (x *UpdateTagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateTagResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTagResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{116}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *UpdateTagResponse) GetTag() *TagInfo {
@@ -7927,7 +8073,7 @@ type DeleteTagRequest struct {
 
 func (x *DeleteTagRequest) Reset() {
 	*x = DeleteTagRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[117]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7939,7 +8085,7 @@ func (x *DeleteTagRequest) String() string {
 func (*DeleteTagRequest) ProtoMessage() {}
 
 func (x *DeleteTagRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[117]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7952,7 +8098,7 @@ func (x *DeleteTagRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTagRequest.ProtoReflect.Descriptor instead.
 func (*DeleteTagRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{117}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *DeleteTagRequest) GetContext() *PluginContext {
@@ -7979,7 +8125,7 @@ type DeleteTagResponse struct {
 
 func (x *DeleteTagResponse) Reset() {
 	*x = DeleteTagResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[118]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7991,7 +8137,7 @@ func (x *DeleteTagResponse) String() string {
 func (*DeleteTagResponse) ProtoMessage() {}
 
 func (x *DeleteTagResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[118]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8004,7 +8150,7 @@ func (x *DeleteTagResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteTagResponse.ProtoReflect.Descriptor instead.
 func (*DeleteTagResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{118}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *DeleteTagResponse) GetSuccess() bool {
@@ -8031,7 +8177,7 @@ type SearchTagsRequest struct {
 
 func (x *SearchTagsRequest) Reset() {
 	*x = SearchTagsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[119]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[121]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8043,7 +8189,7 @@ func (x *SearchTagsRequest) String() string {
 func (*SearchTagsRequest) ProtoMessage() {}
 
 func (x *SearchTagsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[119]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[121]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8056,7 +8202,7 @@ func (x *SearchTagsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchTagsRequest.ProtoReflect.Descriptor instead.
 func (*SearchTagsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{119}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{121}
 }
 
 func (x *SearchTagsRequest) GetContext() *PluginContext {
@@ -8082,7 +8228,7 @@ type SearchTagsResponse struct {
 
 func (x *SearchTagsResponse) Reset() {
 	*x = SearchTagsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[120]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[122]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8094,7 +8240,7 @@ func (x *SearchTagsResponse) String() string {
 func (*SearchTagsResponse) ProtoMessage() {}
 
 func (x *SearchTagsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[120]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[122]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8107,7 +8253,7 @@ func (x *SearchTagsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SearchTagsResponse.ProtoReflect.Descriptor instead.
 func (*SearchTagsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{120}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{122}
 }
 
 func (x *SearchTagsResponse) GetTags() []*TagInfo {
@@ -8130,7 +8276,7 @@ type TagInfo struct {
 
 func (x *TagInfo) Reset() {
 	*x = TagInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[121]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[123]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8142,7 +8288,7 @@ func (x *TagInfo) String() string {
 func (*TagInfo) ProtoMessage() {}
 
 func (x *TagInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[121]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[123]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8155,7 +8301,7 @@ func (x *TagInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagInfo.ProtoReflect.Descriptor instead.
 func (*TagInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{121}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{123}
 }
 
 func (x *TagInfo) GetId() uint32 {
@@ -8198,7 +8344,7 @@ type GetChatRecordsPerDayRequest struct {
 
 func (x *GetChatRecordsPerDayRequest) Reset() {
 	*x = GetChatRecordsPerDayRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[122]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[124]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8210,7 +8356,7 @@ func (x *GetChatRecordsPerDayRequest) String() string {
 func (*GetChatRecordsPerDayRequest) ProtoMessage() {}
 
 func (x *GetChatRecordsPerDayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[122]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[124]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8223,7 +8369,7 @@ func (x *GetChatRecordsPerDayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChatRecordsPerDayRequest.ProtoReflect.Descriptor instead.
 func (*GetChatRecordsPerDayRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{122}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{124}
 }
 
 func (x *GetChatRecordsPerDayRequest) GetContext() *PluginContext {
@@ -8263,7 +8409,7 @@ type GetChatRecordsPerDayResponse struct {
 
 func (x *GetChatRecordsPerDayResponse) Reset() {
 	*x = GetChatRecordsPerDayResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[123]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[125]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8275,7 +8421,7 @@ func (x *GetChatRecordsPerDayResponse) String() string {
 func (*GetChatRecordsPerDayResponse) ProtoMessage() {}
 
 func (x *GetChatRecordsPerDayResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[123]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[125]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8288,7 +8434,7 @@ func (x *GetChatRecordsPerDayResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetChatRecordsPerDayResponse.ProtoReflect.Descriptor instead.
 func (*GetChatRecordsPerDayResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{123}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{125}
 }
 
 func (x *GetChatRecordsPerDayResponse) GetRecords() []*DayRecord {
@@ -8310,7 +8456,7 @@ type GetModelUsageRequest struct {
 
 func (x *GetModelUsageRequest) Reset() {
 	*x = GetModelUsageRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[124]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[126]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8322,7 +8468,7 @@ func (x *GetModelUsageRequest) String() string {
 func (*GetModelUsageRequest) ProtoMessage() {}
 
 func (x *GetModelUsageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[124]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[126]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8335,7 +8481,7 @@ func (x *GetModelUsageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelUsageRequest.ProtoReflect.Descriptor instead.
 func (*GetModelUsageRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{124}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{126}
 }
 
 func (x *GetModelUsageRequest) GetContext() *PluginContext {
@@ -8375,7 +8521,7 @@ type GetModelUsageResponse struct {
 
 func (x *GetModelUsageResponse) Reset() {
 	*x = GetModelUsageResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[125]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[127]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8387,7 +8533,7 @@ func (x *GetModelUsageResponse) String() string {
 func (*GetModelUsageResponse) ProtoMessage() {}
 
 func (x *GetModelUsageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[125]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[127]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8400,7 +8546,7 @@ func (x *GetModelUsageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelUsageResponse.ProtoReflect.Descriptor instead.
 func (*GetModelUsageResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{125}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{127}
 }
 
 func (x *GetModelUsageResponse) GetUsage() []*ModelUsageRecord {
@@ -8423,7 +8569,7 @@ type GetVendorUsageRequest struct {
 
 func (x *GetVendorUsageRequest) Reset() {
 	*x = GetVendorUsageRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[126]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[128]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8435,7 +8581,7 @@ func (x *GetVendorUsageRequest) String() string {
 func (*GetVendorUsageRequest) ProtoMessage() {}
 
 func (x *GetVendorUsageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[126]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[128]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8448,7 +8594,7 @@ func (x *GetVendorUsageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVendorUsageRequest.ProtoReflect.Descriptor instead.
 func (*GetVendorUsageRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{126}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{128}
 }
 
 func (x *GetVendorUsageRequest) GetContext() *PluginContext {
@@ -8495,7 +8641,7 @@ type GetVendorUsageResponse struct {
 
 func (x *GetVendorUsageResponse) Reset() {
 	*x = GetVendorUsageResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[127]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[129]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8507,7 +8653,7 @@ func (x *GetVendorUsageResponse) String() string {
 func (*GetVendorUsageResponse) ProtoMessage() {}
 
 func (x *GetVendorUsageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[127]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[129]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8520,7 +8666,7 @@ func (x *GetVendorUsageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVendorUsageResponse.ProtoReflect.Descriptor instead.
 func (*GetVendorUsageResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{127}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{129}
 }
 
 func (x *GetVendorUsageResponse) GetUsage() []*VendorUsageRecord {
@@ -8541,7 +8687,7 @@ type GetTokenUsagePerAppRequest struct {
 
 func (x *GetTokenUsagePerAppRequest) Reset() {
 	*x = GetTokenUsagePerAppRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[128]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[130]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8553,7 +8699,7 @@ func (x *GetTokenUsagePerAppRequest) String() string {
 func (*GetTokenUsagePerAppRequest) ProtoMessage() {}
 
 func (x *GetTokenUsagePerAppRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[128]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[130]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8566,7 +8712,7 @@ func (x *GetTokenUsagePerAppRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTokenUsagePerAppRequest.ProtoReflect.Descriptor instead.
 func (*GetTokenUsagePerAppRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{128}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{130}
 }
 
 func (x *GetTokenUsagePerAppRequest) GetContext() *PluginContext {
@@ -8599,7 +8745,7 @@ type GetTokenUsagePerAppResponse struct {
 
 func (x *GetTokenUsagePerAppResponse) Reset() {
 	*x = GetTokenUsagePerAppResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[129]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[131]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8611,7 +8757,7 @@ func (x *GetTokenUsagePerAppResponse) String() string {
 func (*GetTokenUsagePerAppResponse) ProtoMessage() {}
 
 func (x *GetTokenUsagePerAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[129]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[131]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8624,7 +8770,7 @@ func (x *GetTokenUsagePerAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTokenUsagePerAppResponse.ProtoReflect.Descriptor instead.
 func (*GetTokenUsagePerAppResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{129}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{131}
 }
 
 func (x *GetTokenUsagePerAppResponse) GetUsage() []*AppTokenUsage {
@@ -8645,7 +8791,7 @@ type GetToolUsageStatisticsRequest struct {
 
 func (x *GetToolUsageStatisticsRequest) Reset() {
 	*x = GetToolUsageStatisticsRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[130]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[132]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8657,7 +8803,7 @@ func (x *GetToolUsageStatisticsRequest) String() string {
 func (*GetToolUsageStatisticsRequest) ProtoMessage() {}
 
 func (x *GetToolUsageStatisticsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[130]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[132]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8670,7 +8816,7 @@ func (x *GetToolUsageStatisticsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolUsageStatisticsRequest.ProtoReflect.Descriptor instead.
 func (*GetToolUsageStatisticsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{130}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{132}
 }
 
 func (x *GetToolUsageStatisticsRequest) GetContext() *PluginContext {
@@ -8703,7 +8849,7 @@ type GetToolUsageStatisticsResponse struct {
 
 func (x *GetToolUsageStatisticsResponse) Reset() {
 	*x = GetToolUsageStatisticsResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[131]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[133]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8715,7 +8861,7 @@ func (x *GetToolUsageStatisticsResponse) String() string {
 func (*GetToolUsageStatisticsResponse) ProtoMessage() {}
 
 func (x *GetToolUsageStatisticsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[131]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[133]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8728,7 +8874,7 @@ func (x *GetToolUsageStatisticsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetToolUsageStatisticsResponse.ProtoReflect.Descriptor instead.
 func (*GetToolUsageStatisticsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{131}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{133}
 }
 
 func (x *GetToolUsageStatisticsResponse) GetUsage() []*ToolUsageRecord {
@@ -8750,7 +8896,7 @@ type DayRecord struct {
 
 func (x *DayRecord) Reset() {
 	*x = DayRecord{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[132]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[134]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8762,7 +8908,7 @@ func (x *DayRecord) String() string {
 func (*DayRecord) ProtoMessage() {}
 
 func (x *DayRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[132]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[134]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8775,7 +8921,7 @@ func (x *DayRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DayRecord.ProtoReflect.Descriptor instead.
 func (*DayRecord) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{132}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{134}
 }
 
 func (x *DayRecord) GetDate() string {
@@ -8820,7 +8966,7 @@ type ModelUsageRecord struct {
 
 func (x *ModelUsageRecord) Reset() {
 	*x = ModelUsageRecord{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[133]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[135]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8832,7 +8978,7 @@ func (x *ModelUsageRecord) String() string {
 func (*ModelUsageRecord) ProtoMessage() {}
 
 func (x *ModelUsageRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[133]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[135]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8845,7 +8991,7 @@ func (x *ModelUsageRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelUsageRecord.ProtoReflect.Descriptor instead.
 func (*ModelUsageRecord) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{133}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{135}
 }
 
 func (x *ModelUsageRecord) GetModelName() string {
@@ -8902,7 +9048,7 @@ type VendorUsageRecord struct {
 
 func (x *VendorUsageRecord) Reset() {
 	*x = VendorUsageRecord{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[134]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[136]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8914,7 +9060,7 @@ func (x *VendorUsageRecord) String() string {
 func (*VendorUsageRecord) ProtoMessage() {}
 
 func (x *VendorUsageRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[134]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[136]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8927,7 +9073,7 @@ func (x *VendorUsageRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VendorUsageRecord.ProtoReflect.Descriptor instead.
 func (*VendorUsageRecord) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{134}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{136}
 }
 
 func (x *VendorUsageRecord) GetDate() string {
@@ -8971,7 +9117,7 @@ type AppTokenUsage struct {
 
 func (x *AppTokenUsage) Reset() {
 	*x = AppTokenUsage{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[135]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[137]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -8983,7 +9129,7 @@ func (x *AppTokenUsage) String() string {
 func (*AppTokenUsage) ProtoMessage() {}
 
 func (x *AppTokenUsage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[135]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[137]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -8996,7 +9142,7 @@ func (x *AppTokenUsage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AppTokenUsage.ProtoReflect.Descriptor instead.
 func (*AppTokenUsage) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{135}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{137}
 }
 
 func (x *AppTokenUsage) GetAppId() uint32 {
@@ -9048,7 +9194,7 @@ type ToolUsageRecord struct {
 
 func (x *ToolUsageRecord) Reset() {
 	*x = ToolUsageRecord{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[136]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[138]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9060,7 +9206,7 @@ func (x *ToolUsageRecord) String() string {
 func (*ToolUsageRecord) ProtoMessage() {}
 
 func (x *ToolUsageRecord) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[136]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[138]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9073,7 +9219,7 @@ func (x *ToolUsageRecord) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolUsageRecord.ProtoReflect.Descriptor instead.
 func (*ToolUsageRecord) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{136}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{138}
 }
 
 func (x *ToolUsageRecord) GetToolId() uint32 {
@@ -9130,7 +9276,7 @@ type ListModelPricesRequest struct {
 
 func (x *ListModelPricesRequest) Reset() {
 	*x = ListModelPricesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[137]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[139]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9142,7 +9288,7 @@ func (x *ListModelPricesRequest) String() string {
 func (*ListModelPricesRequest) ProtoMessage() {}
 
 func (x *ListModelPricesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[137]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[139]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9155,7 +9301,7 @@ func (x *ListModelPricesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListModelPricesRequest.ProtoReflect.Descriptor instead.
 func (*ListModelPricesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{137}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{139}
 }
 
 func (x *ListModelPricesRequest) GetContext() *PluginContext {
@@ -9196,7 +9342,7 @@ type ListModelPricesResponse struct {
 
 func (x *ListModelPricesResponse) Reset() {
 	*x = ListModelPricesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[138]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[140]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9208,7 +9354,7 @@ func (x *ListModelPricesResponse) String() string {
 func (*ListModelPricesResponse) ProtoMessage() {}
 
 func (x *ListModelPricesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[138]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[140]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9221,7 +9367,7 @@ func (x *ListModelPricesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListModelPricesResponse.ProtoReflect.Descriptor instead.
 func (*ListModelPricesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{138}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{140}
 }
 
 func (x *ListModelPricesResponse) GetModelPrices() []*ModelPriceInfo {
@@ -9248,7 +9394,7 @@ type GetModelPriceRequest struct {
 
 func (x *GetModelPriceRequest) Reset() {
 	*x = GetModelPriceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[139]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[141]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9260,7 +9406,7 @@ func (x *GetModelPriceRequest) String() string {
 func (*GetModelPriceRequest) ProtoMessage() {}
 
 func (x *GetModelPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[139]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[141]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9273,7 +9419,7 @@ func (x *GetModelPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelPriceRequest.ProtoReflect.Descriptor instead.
 func (*GetModelPriceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{139}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{141}
 }
 
 func (x *GetModelPriceRequest) GetContext() *PluginContext {
@@ -9299,7 +9445,7 @@ type GetModelPriceResponse struct {
 
 func (x *GetModelPriceResponse) Reset() {
 	*x = GetModelPriceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[140]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[142]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9311,7 +9457,7 @@ func (x *GetModelPriceResponse) String() string {
 func (*GetModelPriceResponse) ProtoMessage() {}
 
 func (x *GetModelPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[140]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[142]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9324,7 +9470,7 @@ func (x *GetModelPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelPriceResponse.ProtoReflect.Descriptor instead.
 func (*GetModelPriceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{140}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{142}
 }
 
 func (x *GetModelPriceResponse) GetModelPrice() *ModelPriceInfo {
@@ -9350,7 +9496,7 @@ type CreateModelPriceRequest struct {
 
 func (x *CreateModelPriceRequest) Reset() {
 	*x = CreateModelPriceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[141]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[143]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9362,7 +9508,7 @@ func (x *CreateModelPriceRequest) String() string {
 func (*CreateModelPriceRequest) ProtoMessage() {}
 
 func (x *CreateModelPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[141]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[143]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9375,7 +9521,7 @@ func (x *CreateModelPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateModelPriceRequest.ProtoReflect.Descriptor instead.
 func (*CreateModelPriceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{141}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{143}
 }
 
 func (x *CreateModelPriceRequest) GetContext() *PluginContext {
@@ -9443,7 +9589,7 @@ type CreateModelPriceResponse struct {
 
 func (x *CreateModelPriceResponse) Reset() {
 	*x = CreateModelPriceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[142]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[144]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9455,7 +9601,7 @@ func (x *CreateModelPriceResponse) String() string {
 func (*CreateModelPriceResponse) ProtoMessage() {}
 
 func (x *CreateModelPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[142]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[144]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9468,7 +9614,7 @@ func (x *CreateModelPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateModelPriceResponse.ProtoReflect.Descriptor instead.
 func (*CreateModelPriceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{142}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{144}
 }
 
 func (x *CreateModelPriceResponse) GetModelPrice() *ModelPriceInfo {
@@ -9495,7 +9641,7 @@ type UpdateModelPriceRequest struct {
 
 func (x *UpdateModelPriceRequest) Reset() {
 	*x = UpdateModelPriceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[143]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[145]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9507,7 +9653,7 @@ func (x *UpdateModelPriceRequest) String() string {
 func (*UpdateModelPriceRequest) ProtoMessage() {}
 
 func (x *UpdateModelPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[143]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[145]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9520,7 +9666,7 @@ func (x *UpdateModelPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateModelPriceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateModelPriceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{143}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{145}
 }
 
 func (x *UpdateModelPriceRequest) GetContext() *PluginContext {
@@ -9595,7 +9741,7 @@ type UpdateModelPriceResponse struct {
 
 func (x *UpdateModelPriceResponse) Reset() {
 	*x = UpdateModelPriceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[144]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[146]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9607,7 +9753,7 @@ func (x *UpdateModelPriceResponse) String() string {
 func (*UpdateModelPriceResponse) ProtoMessage() {}
 
 func (x *UpdateModelPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[144]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[146]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9620,7 +9766,7 @@ func (x *UpdateModelPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateModelPriceResponse.ProtoReflect.Descriptor instead.
 func (*UpdateModelPriceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{144}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{146}
 }
 
 func (x *UpdateModelPriceResponse) GetModelPrice() *ModelPriceInfo {
@@ -9640,7 +9786,7 @@ type DeleteModelPriceRequest struct {
 
 func (x *DeleteModelPriceRequest) Reset() {
 	*x = DeleteModelPriceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[145]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[147]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9652,7 +9798,7 @@ func (x *DeleteModelPriceRequest) String() string {
 func (*DeleteModelPriceRequest) ProtoMessage() {}
 
 func (x *DeleteModelPriceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[145]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[147]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9665,7 +9811,7 @@ func (x *DeleteModelPriceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteModelPriceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteModelPriceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{145}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{147}
 }
 
 func (x *DeleteModelPriceRequest) GetContext() *PluginContext {
@@ -9692,7 +9838,7 @@ type DeleteModelPriceResponse struct {
 
 func (x *DeleteModelPriceResponse) Reset() {
 	*x = DeleteModelPriceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[146]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[148]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9704,7 +9850,7 @@ func (x *DeleteModelPriceResponse) String() string {
 func (*DeleteModelPriceResponse) ProtoMessage() {}
 
 func (x *DeleteModelPriceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[146]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[148]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9717,7 +9863,7 @@ func (x *DeleteModelPriceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteModelPriceResponse.ProtoReflect.Descriptor instead.
 func (*DeleteModelPriceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{146}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{148}
 }
 
 func (x *DeleteModelPriceResponse) GetSuccess() bool {
@@ -9744,7 +9890,7 @@ type GetModelPricesByVendorRequest struct {
 
 func (x *GetModelPricesByVendorRequest) Reset() {
 	*x = GetModelPricesByVendorRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[147]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[149]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9756,7 +9902,7 @@ func (x *GetModelPricesByVendorRequest) String() string {
 func (*GetModelPricesByVendorRequest) ProtoMessage() {}
 
 func (x *GetModelPricesByVendorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[147]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[149]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9769,7 +9915,7 @@ func (x *GetModelPricesByVendorRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelPricesByVendorRequest.ProtoReflect.Descriptor instead.
 func (*GetModelPricesByVendorRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{147}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{149}
 }
 
 func (x *GetModelPricesByVendorRequest) GetContext() *PluginContext {
@@ -9795,7 +9941,7 @@ type GetModelPricesByVendorResponse struct {
 
 func (x *GetModelPricesByVendorResponse) Reset() {
 	*x = GetModelPricesByVendorResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[148]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[150]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9807,7 +9953,7 @@ func (x *GetModelPricesByVendorResponse) String() string {
 func (*GetModelPricesByVendorResponse) ProtoMessage() {}
 
 func (x *GetModelPricesByVendorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[148]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[150]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9820,7 +9966,7 @@ func (x *GetModelPricesByVendorResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetModelPricesByVendorResponse.ProtoReflect.Descriptor instead.
 func (*GetModelPricesByVendorResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{148}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{150}
 }
 
 func (x *GetModelPricesByVendorResponse) GetModelPrices() []*ModelPriceInfo {
@@ -9848,7 +9994,7 @@ type ModelPriceInfo struct {
 
 func (x *ModelPriceInfo) Reset() {
 	*x = ModelPriceInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[149]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[151]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9860,7 +10006,7 @@ func (x *ModelPriceInfo) String() string {
 func (*ModelPriceInfo) ProtoMessage() {}
 
 func (x *ModelPriceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[149]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[151]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9873,7 +10019,7 @@ func (x *ModelPriceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ModelPriceInfo.ProtoReflect.Descriptor instead.
 func (*ModelPriceInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{149}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{151}
 }
 
 func (x *ModelPriceInfo) GetId() uint32 {
@@ -9958,7 +10104,7 @@ type ListFiltersRequest struct {
 
 func (x *ListFiltersRequest) Reset() {
 	*x = ListFiltersRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[150]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[152]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -9970,7 +10116,7 @@ func (x *ListFiltersRequest) String() string {
 func (*ListFiltersRequest) ProtoMessage() {}
 
 func (x *ListFiltersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[150]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[152]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -9983,7 +10129,7 @@ func (x *ListFiltersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFiltersRequest.ProtoReflect.Descriptor instead.
 func (*ListFiltersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{150}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{152}
 }
 
 func (x *ListFiltersRequest) GetContext() *PluginContext {
@@ -10024,7 +10170,7 @@ type ListFiltersResponse struct {
 
 func (x *ListFiltersResponse) Reset() {
 	*x = ListFiltersResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[151]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[153]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10036,7 +10182,7 @@ func (x *ListFiltersResponse) String() string {
 func (*ListFiltersResponse) ProtoMessage() {}
 
 func (x *ListFiltersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[151]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[153]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10049,7 +10195,7 @@ func (x *ListFiltersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListFiltersResponse.ProtoReflect.Descriptor instead.
 func (*ListFiltersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{151}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{153}
 }
 
 func (x *ListFiltersResponse) GetFilters() []*FilterInfo {
@@ -10076,7 +10222,7 @@ type GetFilterRequest struct {
 
 func (x *GetFilterRequest) Reset() {
 	*x = GetFilterRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[152]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[154]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10088,7 +10234,7 @@ func (x *GetFilterRequest) String() string {
 func (*GetFilterRequest) ProtoMessage() {}
 
 func (x *GetFilterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[152]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[154]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10101,7 +10247,7 @@ func (x *GetFilterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFilterRequest.ProtoReflect.Descriptor instead.
 func (*GetFilterRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{152}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{154}
 }
 
 func (x *GetFilterRequest) GetContext() *PluginContext {
@@ -10127,7 +10273,7 @@ type GetFilterResponse struct {
 
 func (x *GetFilterResponse) Reset() {
 	*x = GetFilterResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[153]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[155]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10139,7 +10285,7 @@ func (x *GetFilterResponse) String() string {
 func (*GetFilterResponse) ProtoMessage() {}
 
 func (x *GetFilterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[153]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[155]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10152,7 +10298,7 @@ func (x *GetFilterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetFilterResponse.ProtoReflect.Descriptor instead.
 func (*GetFilterResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{153}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{155}
 }
 
 func (x *GetFilterResponse) GetFilter() *FilterInfo {
@@ -10176,7 +10322,7 @@ type CreateFilterRequest struct {
 
 func (x *CreateFilterRequest) Reset() {
 	*x = CreateFilterRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[154]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[156]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10188,7 +10334,7 @@ func (x *CreateFilterRequest) String() string {
 func (*CreateFilterRequest) ProtoMessage() {}
 
 func (x *CreateFilterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[154]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[156]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10201,7 +10347,7 @@ func (x *CreateFilterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateFilterRequest.ProtoReflect.Descriptor instead.
 func (*CreateFilterRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{154}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{156}
 }
 
 func (x *CreateFilterRequest) GetContext() *PluginContext {
@@ -10255,7 +10401,7 @@ type CreateFilterResponse struct {
 
 func (x *CreateFilterResponse) Reset() {
 	*x = CreateFilterResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[155]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[157]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10267,7 +10413,7 @@ func (x *CreateFilterResponse) String() string {
 func (*CreateFilterResponse) ProtoMessage() {}
 
 func (x *CreateFilterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[155]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[157]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10280,7 +10426,7 @@ func (x *CreateFilterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateFilterResponse.ProtoReflect.Descriptor instead.
 func (*CreateFilterResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{155}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{157}
 }
 
 func (x *CreateFilterResponse) GetFilter() *FilterInfo {
@@ -10305,7 +10451,7 @@ type UpdateFilterRequest struct {
 
 func (x *UpdateFilterRequest) Reset() {
 	*x = UpdateFilterRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[156]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[158]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10317,7 +10463,7 @@ func (x *UpdateFilterRequest) String() string {
 func (*UpdateFilterRequest) ProtoMessage() {}
 
 func (x *UpdateFilterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[156]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[158]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10330,7 +10476,7 @@ func (x *UpdateFilterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFilterRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFilterRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{156}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{158}
 }
 
 func (x *UpdateFilterRequest) GetContext() *PluginContext {
@@ -10391,7 +10537,7 @@ type UpdateFilterResponse struct {
 
 func (x *UpdateFilterResponse) Reset() {
 	*x = UpdateFilterResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[157]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[159]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10403,7 +10549,7 @@ func (x *UpdateFilterResponse) String() string {
 func (*UpdateFilterResponse) ProtoMessage() {}
 
 func (x *UpdateFilterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[157]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[159]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10416,7 +10562,7 @@ func (x *UpdateFilterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateFilterResponse.ProtoReflect.Descriptor instead.
 func (*UpdateFilterResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{157}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{159}
 }
 
 func (x *UpdateFilterResponse) GetFilter() *FilterInfo {
@@ -10436,7 +10582,7 @@ type DeleteFilterRequest struct {
 
 func (x *DeleteFilterRequest) Reset() {
 	*x = DeleteFilterRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[158]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[160]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10448,7 +10594,7 @@ func (x *DeleteFilterRequest) String() string {
 func (*DeleteFilterRequest) ProtoMessage() {}
 
 func (x *DeleteFilterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[158]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[160]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10461,7 +10607,7 @@ func (x *DeleteFilterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFilterRequest.ProtoReflect.Descriptor instead.
 func (*DeleteFilterRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{158}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{160}
 }
 
 func (x *DeleteFilterRequest) GetContext() *PluginContext {
@@ -10488,7 +10634,7 @@ type DeleteFilterResponse struct {
 
 func (x *DeleteFilterResponse) Reset() {
 	*x = DeleteFilterResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[159]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[161]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10500,7 +10646,7 @@ func (x *DeleteFilterResponse) String() string {
 func (*DeleteFilterResponse) ProtoMessage() {}
 
 func (x *DeleteFilterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[159]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[161]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10513,7 +10659,7 @@ func (x *DeleteFilterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteFilterResponse.ProtoReflect.Descriptor instead.
 func (*DeleteFilterResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{159}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{161}
 }
 
 func (x *DeleteFilterResponse) GetSuccess() bool {
@@ -10549,7 +10695,7 @@ type FilterInfo struct {
 
 func (x *FilterInfo) Reset() {
 	*x = FilterInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[160]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[162]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10561,7 +10707,7 @@ func (x *FilterInfo) String() string {
 func (*FilterInfo) ProtoMessage() {}
 
 func (x *FilterInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[160]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[162]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10574,7 +10720,7 @@ func (x *FilterInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FilterInfo.ProtoReflect.Descriptor instead.
 func (*FilterInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{160}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{162}
 }
 
 func (x *FilterInfo) GetId() uint32 {
@@ -10663,7 +10809,7 @@ type GetAvailableLLMDriversRequest struct {
 
 func (x *GetAvailableLLMDriversRequest) Reset() {
 	*x = GetAvailableLLMDriversRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[161]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[163]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10675,7 +10821,7 @@ func (x *GetAvailableLLMDriversRequest) String() string {
 func (*GetAvailableLLMDriversRequest) ProtoMessage() {}
 
 func (x *GetAvailableLLMDriversRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[161]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[163]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10688,7 +10834,7 @@ func (x *GetAvailableLLMDriversRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableLLMDriversRequest.ProtoReflect.Descriptor instead.
 func (*GetAvailableLLMDriversRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{161}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{163}
 }
 
 func (x *GetAvailableLLMDriversRequest) GetContext() *PluginContext {
@@ -10707,7 +10853,7 @@ type GetAvailableLLMDriversResponse struct {
 
 func (x *GetAvailableLLMDriversResponse) Reset() {
 	*x = GetAvailableLLMDriversResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[162]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[164]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10719,7 +10865,7 @@ func (x *GetAvailableLLMDriversResponse) String() string {
 func (*GetAvailableLLMDriversResponse) ProtoMessage() {}
 
 func (x *GetAvailableLLMDriversResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[162]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[164]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10732,7 +10878,7 @@ func (x *GetAvailableLLMDriversResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableLLMDriversResponse.ProtoReflect.Descriptor instead.
 func (*GetAvailableLLMDriversResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{162}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{164}
 }
 
 func (x *GetAvailableLLMDriversResponse) GetDrivers() []*VendorDriverInfo {
@@ -10751,7 +10897,7 @@ type GetAvailableEmbeddersRequest struct {
 
 func (x *GetAvailableEmbeddersRequest) Reset() {
 	*x = GetAvailableEmbeddersRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[163]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[165]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10763,7 +10909,7 @@ func (x *GetAvailableEmbeddersRequest) String() string {
 func (*GetAvailableEmbeddersRequest) ProtoMessage() {}
 
 func (x *GetAvailableEmbeddersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[163]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[165]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10776,7 +10922,7 @@ func (x *GetAvailableEmbeddersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableEmbeddersRequest.ProtoReflect.Descriptor instead.
 func (*GetAvailableEmbeddersRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{163}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{165}
 }
 
 func (x *GetAvailableEmbeddersRequest) GetContext() *PluginContext {
@@ -10795,7 +10941,7 @@ type GetAvailableEmbeddersResponse struct {
 
 func (x *GetAvailableEmbeddersResponse) Reset() {
 	*x = GetAvailableEmbeddersResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[164]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[166]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10807,7 +10953,7 @@ func (x *GetAvailableEmbeddersResponse) String() string {
 func (*GetAvailableEmbeddersResponse) ProtoMessage() {}
 
 func (x *GetAvailableEmbeddersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[164]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[166]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10820,7 +10966,7 @@ func (x *GetAvailableEmbeddersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableEmbeddersResponse.ProtoReflect.Descriptor instead.
 func (*GetAvailableEmbeddersResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{164}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{166}
 }
 
 func (x *GetAvailableEmbeddersResponse) GetEmbedders() []*VendorDriverInfo {
@@ -10839,7 +10985,7 @@ type GetAvailableVectorStoresRequest struct {
 
 func (x *GetAvailableVectorStoresRequest) Reset() {
 	*x = GetAvailableVectorStoresRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[165]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[167]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10851,7 +10997,7 @@ func (x *GetAvailableVectorStoresRequest) String() string {
 func (*GetAvailableVectorStoresRequest) ProtoMessage() {}
 
 func (x *GetAvailableVectorStoresRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[165]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[167]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10864,7 +11010,7 @@ func (x *GetAvailableVectorStoresRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableVectorStoresRequest.ProtoReflect.Descriptor instead.
 func (*GetAvailableVectorStoresRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{165}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{167}
 }
 
 func (x *GetAvailableVectorStoresRequest) GetContext() *PluginContext {
@@ -10883,7 +11029,7 @@ type GetAvailableVectorStoresResponse struct {
 
 func (x *GetAvailableVectorStoresResponse) Reset() {
 	*x = GetAvailableVectorStoresResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[166]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[168]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10895,7 +11041,7 @@ func (x *GetAvailableVectorStoresResponse) String() string {
 func (*GetAvailableVectorStoresResponse) ProtoMessage() {}
 
 func (x *GetAvailableVectorStoresResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[166]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[168]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10908,7 +11054,7 @@ func (x *GetAvailableVectorStoresResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAvailableVectorStoresResponse.ProtoReflect.Descriptor instead.
 func (*GetAvailableVectorStoresResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{166}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{168}
 }
 
 func (x *GetAvailableVectorStoresResponse) GetVectorStores() []*VendorDriverInfo {
@@ -10931,7 +11077,7 @@ type VendorDriverInfo struct {
 
 func (x *VendorDriverInfo) Reset() {
 	*x = VendorDriverInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[167]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[169]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -10943,7 +11089,7 @@ func (x *VendorDriverInfo) String() string {
 func (*VendorDriverInfo) ProtoMessage() {}
 
 func (x *VendorDriverInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[167]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[169]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -10956,7 +11102,7 @@ func (x *VendorDriverInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VendorDriverInfo.ProtoReflect.Descriptor instead.
 func (*VendorDriverInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{167}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{169}
 }
 
 func (x *VendorDriverInfo) GetName() string {
@@ -11006,7 +11152,7 @@ type WritePluginKVRequest struct {
 
 func (x *WritePluginKVRequest) Reset() {
 	*x = WritePluginKVRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[168]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[170]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11018,7 +11164,7 @@ func (x *WritePluginKVRequest) String() string {
 func (*WritePluginKVRequest) ProtoMessage() {}
 
 func (x *WritePluginKVRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[168]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[170]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11031,7 +11177,7 @@ func (x *WritePluginKVRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WritePluginKVRequest.ProtoReflect.Descriptor instead.
 func (*WritePluginKVRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{168}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{170}
 }
 
 func (x *WritePluginKVRequest) GetContext() *PluginContext {
@@ -11072,7 +11218,7 @@ type WritePluginKVResponse struct {
 
 func (x *WritePluginKVResponse) Reset() {
 	*x = WritePluginKVResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[169]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[171]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11084,7 +11230,7 @@ func (x *WritePluginKVResponse) String() string {
 func (*WritePluginKVResponse) ProtoMessage() {}
 
 func (x *WritePluginKVResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[169]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[171]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11097,7 +11243,7 @@ func (x *WritePluginKVResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WritePluginKVResponse.ProtoReflect.Descriptor instead.
 func (*WritePluginKVResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{169}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{171}
 }
 
 func (x *WritePluginKVResponse) GetCreated() bool {
@@ -11124,7 +11270,7 @@ type ReadPluginKVRequest struct {
 
 func (x *ReadPluginKVRequest) Reset() {
 	*x = ReadPluginKVRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[170]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[172]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11136,7 +11282,7 @@ func (x *ReadPluginKVRequest) String() string {
 func (*ReadPluginKVRequest) ProtoMessage() {}
 
 func (x *ReadPluginKVRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[170]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[172]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11149,7 +11295,7 @@ func (x *ReadPluginKVRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadPluginKVRequest.ProtoReflect.Descriptor instead.
 func (*ReadPluginKVRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{170}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{172}
 }
 
 func (x *ReadPluginKVRequest) GetContext() *PluginContext {
@@ -11176,7 +11322,7 @@ type ReadPluginKVResponse struct {
 
 func (x *ReadPluginKVResponse) Reset() {
 	*x = ReadPluginKVResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[171]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[173]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11188,7 +11334,7 @@ func (x *ReadPluginKVResponse) String() string {
 func (*ReadPluginKVResponse) ProtoMessage() {}
 
 func (x *ReadPluginKVResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[171]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[173]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11201,7 +11347,7 @@ func (x *ReadPluginKVResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadPluginKVResponse.ProtoReflect.Descriptor instead.
 func (*ReadPluginKVResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{171}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{173}
 }
 
 func (x *ReadPluginKVResponse) GetValue() []byte {
@@ -11228,7 +11374,7 @@ type DeletePluginKVRequest struct {
 
 func (x *DeletePluginKVRequest) Reset() {
 	*x = DeletePluginKVRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[172]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[174]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11240,7 +11386,7 @@ func (x *DeletePluginKVRequest) String() string {
 func (*DeletePluginKVRequest) ProtoMessage() {}
 
 func (x *DeletePluginKVRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[172]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[174]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11253,7 +11399,7 @@ func (x *DeletePluginKVRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePluginKVRequest.ProtoReflect.Descriptor instead.
 func (*DeletePluginKVRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{172}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{174}
 }
 
 func (x *DeletePluginKVRequest) GetContext() *PluginContext {
@@ -11280,7 +11426,7 @@ type DeletePluginKVResponse struct {
 
 func (x *DeletePluginKVResponse) Reset() {
 	*x = DeletePluginKVResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[173]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[175]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11292,7 +11438,7 @@ func (x *DeletePluginKVResponse) String() string {
 func (*DeletePluginKVResponse) ProtoMessage() {}
 
 func (x *DeletePluginKVResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[173]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[175]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11305,7 +11451,7 @@ func (x *DeletePluginKVResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeletePluginKVResponse.ProtoReflect.Descriptor instead.
 func (*DeletePluginKVResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{173}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{175}
 }
 
 func (x *DeletePluginKVResponse) GetDeleted() bool {
@@ -11336,7 +11482,7 @@ type ExecuteToolRequest struct {
 
 func (x *ExecuteToolRequest) Reset() {
 	*x = ExecuteToolRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[174]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[176]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11348,7 +11494,7 @@ func (x *ExecuteToolRequest) String() string {
 func (*ExecuteToolRequest) ProtoMessage() {}
 
 func (x *ExecuteToolRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[174]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[176]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11361,7 +11507,7 @@ func (x *ExecuteToolRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteToolRequest.ProtoReflect.Descriptor instead.
 func (*ExecuteToolRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{174}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{176}
 }
 
 func (x *ExecuteToolRequest) GetContext() *PluginContext {
@@ -11418,7 +11564,7 @@ type ExecuteToolResponse struct {
 
 func (x *ExecuteToolResponse) Reset() {
 	*x = ExecuteToolResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[175]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[177]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11430,7 +11576,7 @@ func (x *ExecuteToolResponse) String() string {
 func (*ExecuteToolResponse) ProtoMessage() {}
 
 func (x *ExecuteToolResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[175]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[177]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11443,7 +11589,7 @@ func (x *ExecuteToolResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecuteToolResponse.ProtoReflect.Descriptor instead.
 func (*ExecuteToolResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{175}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{177}
 }
 
 func (x *ExecuteToolResponse) GetSuccess() bool {
@@ -11487,7 +11633,7 @@ type QueryDatasourceRequest struct {
 
 func (x *QueryDatasourceRequest) Reset() {
 	*x = QueryDatasourceRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[176]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[178]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11499,7 +11645,7 @@ func (x *QueryDatasourceRequest) String() string {
 func (*QueryDatasourceRequest) ProtoMessage() {}
 
 func (x *QueryDatasourceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[176]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[178]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11512,7 +11658,7 @@ func (x *QueryDatasourceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryDatasourceRequest.ProtoReflect.Descriptor instead.
 func (*QueryDatasourceRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{176}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{178}
 }
 
 func (x *QueryDatasourceRequest) GetContext() *PluginContext {
@@ -11561,7 +11707,7 @@ type QueryDatasourceResponse struct {
 
 func (x *QueryDatasourceResponse) Reset() {
 	*x = QueryDatasourceResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[177]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[179]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11573,7 +11719,7 @@ func (x *QueryDatasourceResponse) String() string {
 func (*QueryDatasourceResponse) ProtoMessage() {}
 
 func (x *QueryDatasourceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[177]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[179]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11586,7 +11732,7 @@ func (x *QueryDatasourceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryDatasourceResponse.ProtoReflect.Descriptor instead.
 func (*QueryDatasourceResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{177}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{179}
 }
 
 func (x *QueryDatasourceResponse) GetSuccess() bool {
@@ -11621,7 +11767,7 @@ type DatasourceResult struct {
 
 func (x *DatasourceResult) Reset() {
 	*x = DatasourceResult{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[178]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[180]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11633,7 +11779,7 @@ func (x *DatasourceResult) String() string {
 func (*DatasourceResult) ProtoMessage() {}
 
 func (x *DatasourceResult) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[178]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[180]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11646,7 +11792,7 @@ func (x *DatasourceResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DatasourceResult.ProtoReflect.Descriptor instead.
 func (*DatasourceResult) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{178}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{180}
 }
 
 func (x *DatasourceResult) GetContent() string {
@@ -11686,7 +11832,7 @@ type CallLLMRequest struct {
 
 func (x *CallLLMRequest) Reset() {
 	*x = CallLLMRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[179]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[181]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11698,7 +11844,7 @@ func (x *CallLLMRequest) String() string {
 func (*CallLLMRequest) ProtoMessage() {}
 
 func (x *CallLLMRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[179]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[181]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11711,7 +11857,7 @@ func (x *CallLLMRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallLLMRequest.ProtoReflect.Descriptor instead.
 func (*CallLLMRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{179}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{181}
 }
 
 func (x *CallLLMRequest) GetContext() *PluginContext {
@@ -11784,7 +11930,7 @@ type CallLLMResponse struct {
 
 func (x *CallLLMResponse) Reset() {
 	*x = CallLLMResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[180]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[182]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11796,7 +11942,7 @@ func (x *CallLLMResponse) String() string {
 func (*CallLLMResponse) ProtoMessage() {}
 
 func (x *CallLLMResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[180]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[182]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11809,7 +11955,7 @@ func (x *CallLLMResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CallLLMResponse.ProtoReflect.Descriptor instead.
 func (*CallLLMResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{180}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{182}
 }
 
 func (x *CallLLMResponse) GetSuccess() bool {
@@ -11866,7 +12012,7 @@ type LLMMessage struct {
 
 func (x *LLMMessage) Reset() {
 	*x = LLMMessage{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[181]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[183]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11878,7 +12024,7 @@ func (x *LLMMessage) String() string {
 func (*LLMMessage) ProtoMessage() {}
 
 func (x *LLMMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[181]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[183]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11891,7 +12037,7 @@ func (x *LLMMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMMessage.ProtoReflect.Descriptor instead.
 func (*LLMMessage) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{181}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{183}
 }
 
 func (x *LLMMessage) GetRole() string {
@@ -11932,7 +12078,7 @@ type LLMTool struct {
 
 func (x *LLMTool) Reset() {
 	*x = LLMTool{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[182]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[184]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11944,7 +12090,7 @@ func (x *LLMTool) String() string {
 func (*LLMTool) ProtoMessage() {}
 
 func (x *LLMTool) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[182]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[184]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -11957,7 +12103,7 @@ func (x *LLMTool) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMTool.ProtoReflect.Descriptor instead.
 func (*LLMTool) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{182}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{184}
 }
 
 func (x *LLMTool) GetType() string {
@@ -11985,7 +12131,7 @@ type LLMFunction struct {
 
 func (x *LLMFunction) Reset() {
 	*x = LLMFunction{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[183]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[185]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -11997,7 +12143,7 @@ func (x *LLMFunction) String() string {
 func (*LLMFunction) ProtoMessage() {}
 
 func (x *LLMFunction) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[183]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[185]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12010,7 +12156,7 @@ func (x *LLMFunction) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMFunction.ProtoReflect.Descriptor instead.
 func (*LLMFunction) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{183}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{185}
 }
 
 func (x *LLMFunction) GetName() string {
@@ -12045,7 +12191,7 @@ type LLMToolCall struct {
 
 func (x *LLMToolCall) Reset() {
 	*x = LLMToolCall{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[184]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[186]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12057,7 +12203,7 @@ func (x *LLMToolCall) String() string {
 func (*LLMToolCall) ProtoMessage() {}
 
 func (x *LLMToolCall) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[184]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[186]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12070,7 +12216,7 @@ func (x *LLMToolCall) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMToolCall.ProtoReflect.Descriptor instead.
 func (*LLMToolCall) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{184}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{186}
 }
 
 func (x *LLMToolCall) GetId() string {
@@ -12104,7 +12250,7 @@ type LLMFunctionCall struct {
 
 func (x *LLMFunctionCall) Reset() {
 	*x = LLMFunctionCall{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[185]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[187]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12116,7 +12262,7 @@ func (x *LLMFunctionCall) String() string {
 func (*LLMFunctionCall) ProtoMessage() {}
 
 func (x *LLMFunctionCall) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[185]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[187]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12129,7 +12275,7 @@ func (x *LLMFunctionCall) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMFunctionCall.ProtoReflect.Descriptor instead.
 func (*LLMFunctionCall) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{185}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{187}
 }
 
 func (x *LLMFunctionCall) GetName() string {
@@ -12159,7 +12305,7 @@ type LLMUsage struct {
 
 func (x *LLMUsage) Reset() {
 	*x = LLMUsage{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[186]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[188]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12171,7 +12317,7 @@ func (x *LLMUsage) String() string {
 func (*LLMUsage) ProtoMessage() {}
 
 func (x *LLMUsage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[186]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[188]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12184,7 +12330,7 @@ func (x *LLMUsage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LLMUsage.ProtoReflect.Descriptor instead.
 func (*LLMUsage) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{186}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{188}
 }
 
 func (x *LLMUsage) GetPromptTokens() int32 {
@@ -12238,7 +12384,7 @@ type CreateScheduleRequest struct {
 
 func (x *CreateScheduleRequest) Reset() {
 	*x = CreateScheduleRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[187]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[189]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12250,7 +12396,7 @@ func (x *CreateScheduleRequest) String() string {
 func (*CreateScheduleRequest) ProtoMessage() {}
 
 func (x *CreateScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[187]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[189]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12263,7 +12409,7 @@ func (x *CreateScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateScheduleRequest.ProtoReflect.Descriptor instead.
 func (*CreateScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{187}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{189}
 }
 
 func (x *CreateScheduleRequest) GetContext() *PluginContext {
@@ -12331,7 +12477,7 @@ type CreateScheduleResponse struct {
 
 func (x *CreateScheduleResponse) Reset() {
 	*x = CreateScheduleResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[188]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[190]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12343,7 +12489,7 @@ func (x *CreateScheduleResponse) String() string {
 func (*CreateScheduleResponse) ProtoMessage() {}
 
 func (x *CreateScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[188]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[190]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12356,7 +12502,7 @@ func (x *CreateScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateScheduleResponse.ProtoReflect.Descriptor instead.
 func (*CreateScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{188}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{190}
 }
 
 func (x *CreateScheduleResponse) GetSchedule() *ScheduleInfo {
@@ -12376,7 +12522,7 @@ type GetScheduleRequest struct {
 
 func (x *GetScheduleRequest) Reset() {
 	*x = GetScheduleRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[189]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[191]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12388,7 +12534,7 @@ func (x *GetScheduleRequest) String() string {
 func (*GetScheduleRequest) ProtoMessage() {}
 
 func (x *GetScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[189]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[191]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12401,7 +12547,7 @@ func (x *GetScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetScheduleRequest.ProtoReflect.Descriptor instead.
 func (*GetScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{189}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{191}
 }
 
 func (x *GetScheduleRequest) GetContext() *PluginContext {
@@ -12427,7 +12573,7 @@ type GetScheduleResponse struct {
 
 func (x *GetScheduleResponse) Reset() {
 	*x = GetScheduleResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[190]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[192]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12439,7 +12585,7 @@ func (x *GetScheduleResponse) String() string {
 func (*GetScheduleResponse) ProtoMessage() {}
 
 func (x *GetScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[190]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[192]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12452,7 +12598,7 @@ func (x *GetScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetScheduleResponse.ProtoReflect.Descriptor instead.
 func (*GetScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{190}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{192}
 }
 
 func (x *GetScheduleResponse) GetSchedule() *ScheduleInfo {
@@ -12471,7 +12617,7 @@ type ListSchedulesRequest struct {
 
 func (x *ListSchedulesRequest) Reset() {
 	*x = ListSchedulesRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[191]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[193]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12483,7 +12629,7 @@ func (x *ListSchedulesRequest) String() string {
 func (*ListSchedulesRequest) ProtoMessage() {}
 
 func (x *ListSchedulesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[191]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[193]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12496,7 +12642,7 @@ func (x *ListSchedulesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSchedulesRequest.ProtoReflect.Descriptor instead.
 func (*ListSchedulesRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{191}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{193}
 }
 
 func (x *ListSchedulesRequest) GetContext() *PluginContext {
@@ -12516,7 +12662,7 @@ type ListSchedulesResponse struct {
 
 func (x *ListSchedulesResponse) Reset() {
 	*x = ListSchedulesResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[192]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[194]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12528,7 +12674,7 @@ func (x *ListSchedulesResponse) String() string {
 func (*ListSchedulesResponse) ProtoMessage() {}
 
 func (x *ListSchedulesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[192]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[194]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12541,7 +12687,7 @@ func (x *ListSchedulesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSchedulesResponse.ProtoReflect.Descriptor instead.
 func (*ListSchedulesResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{192}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{194}
 }
 
 func (x *ListSchedulesResponse) GetSchedules() []*ScheduleInfo {
@@ -12575,7 +12721,7 @@ type UpdateScheduleRequest struct {
 
 func (x *UpdateScheduleRequest) Reset() {
 	*x = UpdateScheduleRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[193]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[195]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12587,7 +12733,7 @@ func (x *UpdateScheduleRequest) String() string {
 func (*UpdateScheduleRequest) ProtoMessage() {}
 
 func (x *UpdateScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[193]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[195]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12600,7 +12746,7 @@ func (x *UpdateScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateScheduleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{193}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{195}
 }
 
 func (x *UpdateScheduleRequest) GetContext() *PluginContext {
@@ -12668,7 +12814,7 @@ type UpdateScheduleResponse struct {
 
 func (x *UpdateScheduleResponse) Reset() {
 	*x = UpdateScheduleResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[194]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[196]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12680,7 +12826,7 @@ func (x *UpdateScheduleResponse) String() string {
 func (*UpdateScheduleResponse) ProtoMessage() {}
 
 func (x *UpdateScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[194]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[196]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12693,7 +12839,7 @@ func (x *UpdateScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateScheduleResponse.ProtoReflect.Descriptor instead.
 func (*UpdateScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{194}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{196}
 }
 
 func (x *UpdateScheduleResponse) GetSchedule() *ScheduleInfo {
@@ -12713,7 +12859,7 @@ type DeleteScheduleRequest struct {
 
 func (x *DeleteScheduleRequest) Reset() {
 	*x = DeleteScheduleRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[195]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[197]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12725,7 +12871,7 @@ func (x *DeleteScheduleRequest) String() string {
 func (*DeleteScheduleRequest) ProtoMessage() {}
 
 func (x *DeleteScheduleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[195]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[197]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12738,7 +12884,7 @@ func (x *DeleteScheduleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteScheduleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteScheduleRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{195}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{197}
 }
 
 func (x *DeleteScheduleRequest) GetContext() *PluginContext {
@@ -12765,7 +12911,7 @@ type DeleteScheduleResponse struct {
 
 func (x *DeleteScheduleResponse) Reset() {
 	*x = DeleteScheduleResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[196]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[198]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12777,7 +12923,7 @@ func (x *DeleteScheduleResponse) String() string {
 func (*DeleteScheduleResponse) ProtoMessage() {}
 
 func (x *DeleteScheduleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[196]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[198]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12790,7 +12936,7 @@ func (x *DeleteScheduleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteScheduleResponse.ProtoReflect.Descriptor instead.
 func (*DeleteScheduleResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{196}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{198}
 }
 
 func (x *DeleteScheduleResponse) GetSuccess() bool {
@@ -12828,7 +12974,7 @@ type ScheduleInfo struct {
 
 func (x *ScheduleInfo) Reset() {
 	*x = ScheduleInfo{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[197]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[199]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12840,7 +12986,7 @@ func (x *ScheduleInfo) String() string {
 func (*ScheduleInfo) ProtoMessage() {}
 
 func (x *ScheduleInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[197]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[199]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12853,7 +12999,7 @@ func (x *ScheduleInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScheduleInfo.ProtoReflect.Descriptor instead.
 func (*ScheduleInfo) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{197}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{199}
 }
 
 func (x *ScheduleInfo) GetId() uint32 {
@@ -12956,7 +13102,7 @@ type GetLicenseInfoRequest struct {
 
 func (x *GetLicenseInfoRequest) Reset() {
 	*x = GetLicenseInfoRequest{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[198]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[200]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -12968,7 +13114,7 @@ func (x *GetLicenseInfoRequest) String() string {
 func (*GetLicenseInfoRequest) ProtoMessage() {}
 
 func (x *GetLicenseInfoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[198]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[200]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -12981,7 +13127,7 @@ func (x *GetLicenseInfoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLicenseInfoRequest.ProtoReflect.Descriptor instead.
 func (*GetLicenseInfoRequest) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{198}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{200}
 }
 
 func (x *GetLicenseInfoRequest) GetContext() *PluginContext {
@@ -13005,7 +13151,7 @@ type GetLicenseInfoResponse struct {
 
 func (x *GetLicenseInfoResponse) Reset() {
 	*x = GetLicenseInfoResponse{}
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[199]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[201]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -13017,7 +13163,7 @@ func (x *GetLicenseInfoResponse) String() string {
 func (*GetLicenseInfoResponse) ProtoMessage() {}
 
 func (x *GetLicenseInfoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[199]
+	mi := &file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[201]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -13030,7 +13176,7 @@ func (x *GetLicenseInfoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetLicenseInfoResponse.ProtoReflect.Descriptor instead.
 func (*GetLicenseInfoResponse) Descriptor() ([]byte, []int) {
-	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{199}
+	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP(), []int{201}
 }
 
 func (x *GetLicenseInfoResponse) GetLicenseValid() bool {
@@ -13299,15 +13445,18 @@ const file_proto_ai_studio_management_ai_studio_management_proto_rawDesc = "" +
 	"\x04cost\x18\x03 \x01(\x01R\x04cost\x12\x1e\n" +
 	"\n" +
 	"percentage\x18\x04 \x01(\x01R\n" +
-	"percentage\"\xc8\x01\n" +
+	"percentage\"\xf2\x01\n" +
 	"\x0fListAppsRequest\x12=\n" +
 	"\acontext\x18\x01 \x01(\v2#.ai_studio_management.PluginContextR\acontext\x12 \n" +
 	"\tis_active\x18\x02 \x01(\bH\x00R\bisActive\x88\x01\x01\x12\x1c\n" +
 	"\tnamespace\x18\x03 \x01(\tR\tnamespace\x12\x12\n" +
 	"\x04page\x18\x04 \x01(\x05R\x04page\x12\x14\n" +
-	"\x05limit\x18\x05 \x01(\x05R\x05limitB\f\n" +
+	"\x05limit\x18\x05 \x01(\x05R\x05limit\x12\x1c\n" +
+	"\auser_id\x18\x06 \x01(\rH\x01R\x06userId\x88\x01\x01B\f\n" +
 	"\n" +
-	"_is_active\"f\n" +
+	"_is_activeB\n" +
+	"\n" +
+	"\b_user_id\"f\n" +
 	"\x10ListAppsResponse\x121\n" +
 	"\x04apps\x18\x01 \x03(\v2\x1d.ai_studio_management.AppInfoR\x04apps\x12\x1f\n" +
 	"\vtotal_count\x18\x02 \x01(\x03R\n" +
@@ -13372,7 +13521,17 @@ const file_proto_ai_studio_management_ai_studio_management_proto_rawDesc = "" +
 	"\x06app_id\x18\x02 \x01(\rR\x05appId\"G\n" +
 	"\x11DeleteAppResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage\"\xe6\x01\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xaf\x01\n" +
+	"\x17PatchAppMetadataRequest\x12=\n" +
+	"\acontext\x18\x01 \x01(\v2#.ai_studio_management.PluginContextR\acontext\x12\x15\n" +
+	"\x06app_id\x18\x02 \x01(\rR\x05appId\x12\x10\n" +
+	"\x03key\x18\x03 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x04 \x01(\tR\x05value\x12\x16\n" +
+	"\x06delete\x18\x05 \x01(\bR\x06delete\"j\n" +
+	"\x18PatchAppMetadataResponse\x12\x18\n" +
+	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1a\n" +
+	"\bmetadata\x18\x03 \x01(\tR\bmetadata\"\xe6\x01\n" +
 	"\x10ListToolsRequest\x12=\n" +
 	"\acontext\x18\x01 \x01(\v2#.ai_studio_management.PluginContextR\acontext\x12\x1b\n" +
 	"\ttool_type\x18\x02 \x01(\tR\btoolType\x12 \n" +
@@ -14189,7 +14348,7 @@ const file_proto_ai_studio_management_ai_studio_management_proto_rawDesc = "" +
 	"\fentitlements\x18\x04 \x03(\tR\fentitlements\x12\"\n" +
 	"\forganization\x18\x05 \x01(\tR\forganization\x129\n" +
 	"\n" +
-	"expires_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt2\xdaF\n" +
+	"expires_at\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt2\xcdG\n" +
 	"\x19AIStudioManagementService\x12b\n" +
 	"\vListPlugins\x12(.ai_studio_management.ListPluginsRequest\x1a).ai_studio_management.ListPluginsResponse\x12\\\n" +
 	"\tGetPlugin\x12&.ai_studio_management.GetPluginRequest\x1a'.ai_studio_management.GetPluginResponse\x12w\n" +
@@ -14213,7 +14372,8 @@ const file_proto_ai_studio_management_ai_studio_management_proto_rawDesc = "" +
 	"\x06GetApp\x12#.ai_studio_management.GetAppRequest\x1a$.ai_studio_management.GetAppResponse\x12\\\n" +
 	"\tCreateApp\x12&.ai_studio_management.CreateAppRequest\x1a'.ai_studio_management.CreateAppResponse\x12\\\n" +
 	"\tUpdateApp\x12&.ai_studio_management.UpdateAppRequest\x1a'.ai_studio_management.UpdateAppResponse\x12\\\n" +
-	"\tDeleteApp\x12&.ai_studio_management.DeleteAppRequest\x1a'.ai_studio_management.DeleteAppResponse\x12\\\n" +
+	"\tDeleteApp\x12&.ai_studio_management.DeleteAppRequest\x1a'.ai_studio_management.DeleteAppResponse\x12q\n" +
+	"\x10PatchAppMetadata\x12-.ai_studio_management.PatchAppMetadataRequest\x1a..ai_studio_management.PatchAppMetadataResponse\x12\\\n" +
 	"\tListTools\x12&.ai_studio_management.ListToolsRequest\x1a'.ai_studio_management.ListToolsResponse\x12V\n" +
 	"\aGetTool\x12$.ai_studio_management.GetToolRequest\x1a%.ai_studio_management.GetToolResponse\x12t\n" +
 	"\x11GetToolOperations\x12..ai_studio_management.GetToolOperationsRequest\x1a/.ai_studio_management.GetToolOperationsResponse\x12t\n" +
@@ -14291,7 +14451,7 @@ func file_proto_ai_studio_management_ai_studio_management_proto_rawDescGZIP() []
 	return file_proto_ai_studio_management_ai_studio_management_proto_rawDescData
 }
 
-var file_proto_ai_studio_management_ai_studio_management_proto_msgTypes = make([]protoimpl.MessageInfo, 208)
+var file_proto_ai_studio_management_ai_studio_management_proto_msgTypes = make([]protoimpl.MessageInfo, 210)
 var file_proto_ai_studio_management_ai_studio_management_proto_goTypes = []any{
 	(*PluginContext)(nil),                     // 0: ai_studio_management.PluginContext
 	(*ListPluginsRequest)(nil),                // 1: ai_studio_management.ListPluginsRequest
@@ -14337,171 +14497,173 @@ var file_proto_ai_studio_management_ai_studio_management_proto_goTypes = []any{
 	(*UpdateAppResponse)(nil),                 // 41: ai_studio_management.UpdateAppResponse
 	(*DeleteAppRequest)(nil),                  // 42: ai_studio_management.DeleteAppRequest
 	(*DeleteAppResponse)(nil),                 // 43: ai_studio_management.DeleteAppResponse
-	(*ListToolsRequest)(nil),                  // 44: ai_studio_management.ListToolsRequest
-	(*ListToolsResponse)(nil),                 // 45: ai_studio_management.ListToolsResponse
-	(*GetToolRequest)(nil),                    // 46: ai_studio_management.GetToolRequest
-	(*GetToolResponse)(nil),                   // 47: ai_studio_management.GetToolResponse
-	(*GetToolOperationsRequest)(nil),          // 48: ai_studio_management.GetToolOperationsRequest
-	(*GetToolOperationsResponse)(nil),         // 49: ai_studio_management.GetToolOperationsResponse
-	(*CallToolOperationRequest)(nil),          // 50: ai_studio_management.CallToolOperationRequest
-	(*CallToolOperationResponse)(nil),         // 51: ai_studio_management.CallToolOperationResponse
-	(*ToolInfo)(nil),                          // 52: ai_studio_management.ToolInfo
-	(*ToolOperation)(nil),                     // 53: ai_studio_management.ToolOperation
-	(*ToolParameter)(nil),                     // 54: ai_studio_management.ToolParameter
-	(*ToolRequestBody)(nil),                   // 55: ai_studio_management.ToolRequestBody
-	(*CreateToolRequest)(nil),                 // 56: ai_studio_management.CreateToolRequest
-	(*CreateToolResponse)(nil),                // 57: ai_studio_management.CreateToolResponse
-	(*UpdateToolRequest)(nil),                 // 58: ai_studio_management.UpdateToolRequest
-	(*UpdateToolResponse)(nil),                // 59: ai_studio_management.UpdateToolResponse
-	(*DeleteToolRequest)(nil),                 // 60: ai_studio_management.DeleteToolRequest
-	(*DeleteToolResponse)(nil),                // 61: ai_studio_management.DeleteToolResponse
-	(*ListDatasourcesRequest)(nil),            // 62: ai_studio_management.ListDatasourcesRequest
-	(*ListDatasourcesResponse)(nil),           // 63: ai_studio_management.ListDatasourcesResponse
-	(*GetDatasourceRequest)(nil),              // 64: ai_studio_management.GetDatasourceRequest
-	(*GetDatasourceResponse)(nil),             // 65: ai_studio_management.GetDatasourceResponse
-	(*CreateDatasourceRequest)(nil),           // 66: ai_studio_management.CreateDatasourceRequest
-	(*CreateDatasourceResponse)(nil),          // 67: ai_studio_management.CreateDatasourceResponse
-	(*UpdateDatasourceRequest)(nil),           // 68: ai_studio_management.UpdateDatasourceRequest
-	(*UpdateDatasourceResponse)(nil),          // 69: ai_studio_management.UpdateDatasourceResponse
-	(*DeleteDatasourceRequest)(nil),           // 70: ai_studio_management.DeleteDatasourceRequest
-	(*DeleteDatasourceResponse)(nil),          // 71: ai_studio_management.DeleteDatasourceResponse
-	(*CloneDatasourceRequest)(nil),            // 72: ai_studio_management.CloneDatasourceRequest
-	(*CloneDatasourceResponse)(nil),           // 73: ai_studio_management.CloneDatasourceResponse
-	(*SearchDatasourcesRequest)(nil),          // 74: ai_studio_management.SearchDatasourcesRequest
-	(*SearchDatasourcesResponse)(nil),         // 75: ai_studio_management.SearchDatasourcesResponse
-	(*ProcessEmbeddingsRequest)(nil),          // 76: ai_studio_management.ProcessEmbeddingsRequest
-	(*ProcessEmbeddingsResponse)(nil),         // 77: ai_studio_management.ProcessEmbeddingsResponse
-	(*GenerateEmbeddingRequest)(nil),          // 78: ai_studio_management.GenerateEmbeddingRequest
-	(*GenerateEmbeddingResponse)(nil),         // 79: ai_studio_management.GenerateEmbeddingResponse
-	(*EmbeddingVector)(nil),                   // 80: ai_studio_management.EmbeddingVector
-	(*StoreDocumentsRequest)(nil),             // 81: ai_studio_management.StoreDocumentsRequest
-	(*DocumentWithEmbedding)(nil),             // 82: ai_studio_management.DocumentWithEmbedding
-	(*StoreDocumentsResponse)(nil),            // 83: ai_studio_management.StoreDocumentsResponse
-	(*ProcessAndStoreRequest)(nil),            // 84: ai_studio_management.ProcessAndStoreRequest
-	(*DocumentChunk)(nil),                     // 85: ai_studio_management.DocumentChunk
-	(*ProcessAndStoreResponse)(nil),           // 86: ai_studio_management.ProcessAndStoreResponse
-	(*DeleteDocumentsByMetadataRequest)(nil),  // 87: ai_studio_management.DeleteDocumentsByMetadataRequest
-	(*DeleteDocumentsByMetadataResponse)(nil), // 88: ai_studio_management.DeleteDocumentsByMetadataResponse
-	(*QueryByMetadataOnlyRequest)(nil),        // 89: ai_studio_management.QueryByMetadataOnlyRequest
-	(*QueryByMetadataOnlyResponse)(nil),       // 90: ai_studio_management.QueryByMetadataOnlyResponse
-	(*ListNamespacesRequest)(nil),             // 91: ai_studio_management.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),            // 92: ai_studio_management.ListNamespacesResponse
-	(*NamespaceInfo)(nil),                     // 93: ai_studio_management.NamespaceInfo
-	(*DeleteNamespaceRequest)(nil),            // 94: ai_studio_management.DeleteNamespaceRequest
-	(*DeleteNamespaceResponse)(nil),           // 95: ai_studio_management.DeleteNamespaceResponse
-	(*QueryByVectorRequest)(nil),              // 96: ai_studio_management.QueryByVectorRequest
-	(*DatasourceInfo)(nil),                    // 97: ai_studio_management.DatasourceInfo
-	(*ListDataCataloguesRequest)(nil),         // 98: ai_studio_management.ListDataCataloguesRequest
-	(*ListDataCataloguesResponse)(nil),        // 99: ai_studio_management.ListDataCataloguesResponse
-	(*GetDataCatalogueRequest)(nil),           // 100: ai_studio_management.GetDataCatalogueRequest
-	(*GetDataCatalogueResponse)(nil),          // 101: ai_studio_management.GetDataCatalogueResponse
-	(*CreateDataCatalogueRequest)(nil),        // 102: ai_studio_management.CreateDataCatalogueRequest
-	(*CreateDataCatalogueResponse)(nil),       // 103: ai_studio_management.CreateDataCatalogueResponse
-	(*UpdateDataCatalogueRequest)(nil),        // 104: ai_studio_management.UpdateDataCatalogueRequest
-	(*UpdateDataCatalogueResponse)(nil),       // 105: ai_studio_management.UpdateDataCatalogueResponse
-	(*DeleteDataCatalogueRequest)(nil),        // 106: ai_studio_management.DeleteDataCatalogueRequest
-	(*DeleteDataCatalogueResponse)(nil),       // 107: ai_studio_management.DeleteDataCatalogueResponse
-	(*DataCatalogueInfo)(nil),                 // 108: ai_studio_management.DataCatalogueInfo
-	(*ListTagsRequest)(nil),                   // 109: ai_studio_management.ListTagsRequest
-	(*ListTagsResponse)(nil),                  // 110: ai_studio_management.ListTagsResponse
-	(*GetTagRequest)(nil),                     // 111: ai_studio_management.GetTagRequest
-	(*GetTagResponse)(nil),                    // 112: ai_studio_management.GetTagResponse
-	(*CreateTagRequest)(nil),                  // 113: ai_studio_management.CreateTagRequest
-	(*CreateTagResponse)(nil),                 // 114: ai_studio_management.CreateTagResponse
-	(*UpdateTagRequest)(nil),                  // 115: ai_studio_management.UpdateTagRequest
-	(*UpdateTagResponse)(nil),                 // 116: ai_studio_management.UpdateTagResponse
-	(*DeleteTagRequest)(nil),                  // 117: ai_studio_management.DeleteTagRequest
-	(*DeleteTagResponse)(nil),                 // 118: ai_studio_management.DeleteTagResponse
-	(*SearchTagsRequest)(nil),                 // 119: ai_studio_management.SearchTagsRequest
-	(*SearchTagsResponse)(nil),                // 120: ai_studio_management.SearchTagsResponse
-	(*TagInfo)(nil),                           // 121: ai_studio_management.TagInfo
-	(*GetChatRecordsPerDayRequest)(nil),       // 122: ai_studio_management.GetChatRecordsPerDayRequest
-	(*GetChatRecordsPerDayResponse)(nil),      // 123: ai_studio_management.GetChatRecordsPerDayResponse
-	(*GetModelUsageRequest)(nil),              // 124: ai_studio_management.GetModelUsageRequest
-	(*GetModelUsageResponse)(nil),             // 125: ai_studio_management.GetModelUsageResponse
-	(*GetVendorUsageRequest)(nil),             // 126: ai_studio_management.GetVendorUsageRequest
-	(*GetVendorUsageResponse)(nil),            // 127: ai_studio_management.GetVendorUsageResponse
-	(*GetTokenUsagePerAppRequest)(nil),        // 128: ai_studio_management.GetTokenUsagePerAppRequest
-	(*GetTokenUsagePerAppResponse)(nil),       // 129: ai_studio_management.GetTokenUsagePerAppResponse
-	(*GetToolUsageStatisticsRequest)(nil),     // 130: ai_studio_management.GetToolUsageStatisticsRequest
-	(*GetToolUsageStatisticsResponse)(nil),    // 131: ai_studio_management.GetToolUsageStatisticsResponse
-	(*DayRecord)(nil),                         // 132: ai_studio_management.DayRecord
-	(*ModelUsageRecord)(nil),                  // 133: ai_studio_management.ModelUsageRecord
-	(*VendorUsageRecord)(nil),                 // 134: ai_studio_management.VendorUsageRecord
-	(*AppTokenUsage)(nil),                     // 135: ai_studio_management.AppTokenUsage
-	(*ToolUsageRecord)(nil),                   // 136: ai_studio_management.ToolUsageRecord
-	(*ListModelPricesRequest)(nil),            // 137: ai_studio_management.ListModelPricesRequest
-	(*ListModelPricesResponse)(nil),           // 138: ai_studio_management.ListModelPricesResponse
-	(*GetModelPriceRequest)(nil),              // 139: ai_studio_management.GetModelPriceRequest
-	(*GetModelPriceResponse)(nil),             // 140: ai_studio_management.GetModelPriceResponse
-	(*CreateModelPriceRequest)(nil),           // 141: ai_studio_management.CreateModelPriceRequest
-	(*CreateModelPriceResponse)(nil),          // 142: ai_studio_management.CreateModelPriceResponse
-	(*UpdateModelPriceRequest)(nil),           // 143: ai_studio_management.UpdateModelPriceRequest
-	(*UpdateModelPriceResponse)(nil),          // 144: ai_studio_management.UpdateModelPriceResponse
-	(*DeleteModelPriceRequest)(nil),           // 145: ai_studio_management.DeleteModelPriceRequest
-	(*DeleteModelPriceResponse)(nil),          // 146: ai_studio_management.DeleteModelPriceResponse
-	(*GetModelPricesByVendorRequest)(nil),     // 147: ai_studio_management.GetModelPricesByVendorRequest
-	(*GetModelPricesByVendorResponse)(nil),    // 148: ai_studio_management.GetModelPricesByVendorResponse
-	(*ModelPriceInfo)(nil),                    // 149: ai_studio_management.ModelPriceInfo
-	(*ListFiltersRequest)(nil),                // 150: ai_studio_management.ListFiltersRequest
-	(*ListFiltersResponse)(nil),               // 151: ai_studio_management.ListFiltersResponse
-	(*GetFilterRequest)(nil),                  // 152: ai_studio_management.GetFilterRequest
-	(*GetFilterResponse)(nil),                 // 153: ai_studio_management.GetFilterResponse
-	(*CreateFilterRequest)(nil),               // 154: ai_studio_management.CreateFilterRequest
-	(*CreateFilterResponse)(nil),              // 155: ai_studio_management.CreateFilterResponse
-	(*UpdateFilterRequest)(nil),               // 156: ai_studio_management.UpdateFilterRequest
-	(*UpdateFilterResponse)(nil),              // 157: ai_studio_management.UpdateFilterResponse
-	(*DeleteFilterRequest)(nil),               // 158: ai_studio_management.DeleteFilterRequest
-	(*DeleteFilterResponse)(nil),              // 159: ai_studio_management.DeleteFilterResponse
-	(*FilterInfo)(nil),                        // 160: ai_studio_management.FilterInfo
-	(*GetAvailableLLMDriversRequest)(nil),     // 161: ai_studio_management.GetAvailableLLMDriversRequest
-	(*GetAvailableLLMDriversResponse)(nil),    // 162: ai_studio_management.GetAvailableLLMDriversResponse
-	(*GetAvailableEmbeddersRequest)(nil),      // 163: ai_studio_management.GetAvailableEmbeddersRequest
-	(*GetAvailableEmbeddersResponse)(nil),     // 164: ai_studio_management.GetAvailableEmbeddersResponse
-	(*GetAvailableVectorStoresRequest)(nil),   // 165: ai_studio_management.GetAvailableVectorStoresRequest
-	(*GetAvailableVectorStoresResponse)(nil),  // 166: ai_studio_management.GetAvailableVectorStoresResponse
-	(*VendorDriverInfo)(nil),                  // 167: ai_studio_management.VendorDriverInfo
-	(*WritePluginKVRequest)(nil),              // 168: ai_studio_management.WritePluginKVRequest
-	(*WritePluginKVResponse)(nil),             // 169: ai_studio_management.WritePluginKVResponse
-	(*ReadPluginKVRequest)(nil),               // 170: ai_studio_management.ReadPluginKVRequest
-	(*ReadPluginKVResponse)(nil),              // 171: ai_studio_management.ReadPluginKVResponse
-	(*DeletePluginKVRequest)(nil),             // 172: ai_studio_management.DeletePluginKVRequest
-	(*DeletePluginKVResponse)(nil),            // 173: ai_studio_management.DeletePluginKVResponse
-	(*ExecuteToolRequest)(nil),                // 174: ai_studio_management.ExecuteToolRequest
-	(*ExecuteToolResponse)(nil),               // 175: ai_studio_management.ExecuteToolResponse
-	(*QueryDatasourceRequest)(nil),            // 176: ai_studio_management.QueryDatasourceRequest
-	(*QueryDatasourceResponse)(nil),           // 177: ai_studio_management.QueryDatasourceResponse
-	(*DatasourceResult)(nil),                  // 178: ai_studio_management.DatasourceResult
-	(*CallLLMRequest)(nil),                    // 179: ai_studio_management.CallLLMRequest
-	(*CallLLMResponse)(nil),                   // 180: ai_studio_management.CallLLMResponse
-	(*LLMMessage)(nil),                        // 181: ai_studio_management.LLMMessage
-	(*LLMTool)(nil),                           // 182: ai_studio_management.LLMTool
-	(*LLMFunction)(nil),                       // 183: ai_studio_management.LLMFunction
-	(*LLMToolCall)(nil),                       // 184: ai_studio_management.LLMToolCall
-	(*LLMFunctionCall)(nil),                   // 185: ai_studio_management.LLMFunctionCall
-	(*LLMUsage)(nil),                          // 186: ai_studio_management.LLMUsage
-	(*CreateScheduleRequest)(nil),             // 187: ai_studio_management.CreateScheduleRequest
-	(*CreateScheduleResponse)(nil),            // 188: ai_studio_management.CreateScheduleResponse
-	(*GetScheduleRequest)(nil),                // 189: ai_studio_management.GetScheduleRequest
-	(*GetScheduleResponse)(nil),               // 190: ai_studio_management.GetScheduleResponse
-	(*ListSchedulesRequest)(nil),              // 191: ai_studio_management.ListSchedulesRequest
-	(*ListSchedulesResponse)(nil),             // 192: ai_studio_management.ListSchedulesResponse
-	(*UpdateScheduleRequest)(nil),             // 193: ai_studio_management.UpdateScheduleRequest
-	(*UpdateScheduleResponse)(nil),            // 194: ai_studio_management.UpdateScheduleResponse
-	(*DeleteScheduleRequest)(nil),             // 195: ai_studio_management.DeleteScheduleRequest
-	(*DeleteScheduleResponse)(nil),            // 196: ai_studio_management.DeleteScheduleResponse
-	(*ScheduleInfo)(nil),                      // 197: ai_studio_management.ScheduleInfo
-	(*GetLicenseInfoRequest)(nil),             // 198: ai_studio_management.GetLicenseInfoRequest
-	(*GetLicenseInfoResponse)(nil),            // 199: ai_studio_management.GetLicenseInfoResponse
-	nil,                                       // 200: ai_studio_management.LLMInfo.MetadataEntry
-	nil,                                       // 201: ai_studio_management.ToolInfo.MetadataEntry
-	nil,                                       // 202: ai_studio_management.DocumentWithEmbedding.MetadataEntry
-	nil,                                       // 203: ai_studio_management.DocumentChunk.MetadataEntry
-	nil,                                       // 204: ai_studio_management.DeleteDocumentsByMetadataRequest.MetadataFilterEntry
-	nil,                                       // 205: ai_studio_management.QueryByMetadataOnlyRequest.MetadataFilterEntry
-	nil,                                       // 206: ai_studio_management.DatasourceInfo.MetadataEntry
-	nil,                                       // 207: ai_studio_management.DatasourceResult.MetadataEntry
-	(*timestamppb.Timestamp)(nil),             // 208: google.protobuf.Timestamp
+	(*PatchAppMetadataRequest)(nil),           // 44: ai_studio_management.PatchAppMetadataRequest
+	(*PatchAppMetadataResponse)(nil),          // 45: ai_studio_management.PatchAppMetadataResponse
+	(*ListToolsRequest)(nil),                  // 46: ai_studio_management.ListToolsRequest
+	(*ListToolsResponse)(nil),                 // 47: ai_studio_management.ListToolsResponse
+	(*GetToolRequest)(nil),                    // 48: ai_studio_management.GetToolRequest
+	(*GetToolResponse)(nil),                   // 49: ai_studio_management.GetToolResponse
+	(*GetToolOperationsRequest)(nil),          // 50: ai_studio_management.GetToolOperationsRequest
+	(*GetToolOperationsResponse)(nil),         // 51: ai_studio_management.GetToolOperationsResponse
+	(*CallToolOperationRequest)(nil),          // 52: ai_studio_management.CallToolOperationRequest
+	(*CallToolOperationResponse)(nil),         // 53: ai_studio_management.CallToolOperationResponse
+	(*ToolInfo)(nil),                          // 54: ai_studio_management.ToolInfo
+	(*ToolOperation)(nil),                     // 55: ai_studio_management.ToolOperation
+	(*ToolParameter)(nil),                     // 56: ai_studio_management.ToolParameter
+	(*ToolRequestBody)(nil),                   // 57: ai_studio_management.ToolRequestBody
+	(*CreateToolRequest)(nil),                 // 58: ai_studio_management.CreateToolRequest
+	(*CreateToolResponse)(nil),                // 59: ai_studio_management.CreateToolResponse
+	(*UpdateToolRequest)(nil),                 // 60: ai_studio_management.UpdateToolRequest
+	(*UpdateToolResponse)(nil),                // 61: ai_studio_management.UpdateToolResponse
+	(*DeleteToolRequest)(nil),                 // 62: ai_studio_management.DeleteToolRequest
+	(*DeleteToolResponse)(nil),                // 63: ai_studio_management.DeleteToolResponse
+	(*ListDatasourcesRequest)(nil),            // 64: ai_studio_management.ListDatasourcesRequest
+	(*ListDatasourcesResponse)(nil),           // 65: ai_studio_management.ListDatasourcesResponse
+	(*GetDatasourceRequest)(nil),              // 66: ai_studio_management.GetDatasourceRequest
+	(*GetDatasourceResponse)(nil),             // 67: ai_studio_management.GetDatasourceResponse
+	(*CreateDatasourceRequest)(nil),           // 68: ai_studio_management.CreateDatasourceRequest
+	(*CreateDatasourceResponse)(nil),          // 69: ai_studio_management.CreateDatasourceResponse
+	(*UpdateDatasourceRequest)(nil),           // 70: ai_studio_management.UpdateDatasourceRequest
+	(*UpdateDatasourceResponse)(nil),          // 71: ai_studio_management.UpdateDatasourceResponse
+	(*DeleteDatasourceRequest)(nil),           // 72: ai_studio_management.DeleteDatasourceRequest
+	(*DeleteDatasourceResponse)(nil),          // 73: ai_studio_management.DeleteDatasourceResponse
+	(*CloneDatasourceRequest)(nil),            // 74: ai_studio_management.CloneDatasourceRequest
+	(*CloneDatasourceResponse)(nil),           // 75: ai_studio_management.CloneDatasourceResponse
+	(*SearchDatasourcesRequest)(nil),          // 76: ai_studio_management.SearchDatasourcesRequest
+	(*SearchDatasourcesResponse)(nil),         // 77: ai_studio_management.SearchDatasourcesResponse
+	(*ProcessEmbeddingsRequest)(nil),          // 78: ai_studio_management.ProcessEmbeddingsRequest
+	(*ProcessEmbeddingsResponse)(nil),         // 79: ai_studio_management.ProcessEmbeddingsResponse
+	(*GenerateEmbeddingRequest)(nil),          // 80: ai_studio_management.GenerateEmbeddingRequest
+	(*GenerateEmbeddingResponse)(nil),         // 81: ai_studio_management.GenerateEmbeddingResponse
+	(*EmbeddingVector)(nil),                   // 82: ai_studio_management.EmbeddingVector
+	(*StoreDocumentsRequest)(nil),             // 83: ai_studio_management.StoreDocumentsRequest
+	(*DocumentWithEmbedding)(nil),             // 84: ai_studio_management.DocumentWithEmbedding
+	(*StoreDocumentsResponse)(nil),            // 85: ai_studio_management.StoreDocumentsResponse
+	(*ProcessAndStoreRequest)(nil),            // 86: ai_studio_management.ProcessAndStoreRequest
+	(*DocumentChunk)(nil),                     // 87: ai_studio_management.DocumentChunk
+	(*ProcessAndStoreResponse)(nil),           // 88: ai_studio_management.ProcessAndStoreResponse
+	(*DeleteDocumentsByMetadataRequest)(nil),  // 89: ai_studio_management.DeleteDocumentsByMetadataRequest
+	(*DeleteDocumentsByMetadataResponse)(nil), // 90: ai_studio_management.DeleteDocumentsByMetadataResponse
+	(*QueryByMetadataOnlyRequest)(nil),        // 91: ai_studio_management.QueryByMetadataOnlyRequest
+	(*QueryByMetadataOnlyResponse)(nil),       // 92: ai_studio_management.QueryByMetadataOnlyResponse
+	(*ListNamespacesRequest)(nil),             // 93: ai_studio_management.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),            // 94: ai_studio_management.ListNamespacesResponse
+	(*NamespaceInfo)(nil),                     // 95: ai_studio_management.NamespaceInfo
+	(*DeleteNamespaceRequest)(nil),            // 96: ai_studio_management.DeleteNamespaceRequest
+	(*DeleteNamespaceResponse)(nil),           // 97: ai_studio_management.DeleteNamespaceResponse
+	(*QueryByVectorRequest)(nil),              // 98: ai_studio_management.QueryByVectorRequest
+	(*DatasourceInfo)(nil),                    // 99: ai_studio_management.DatasourceInfo
+	(*ListDataCataloguesRequest)(nil),         // 100: ai_studio_management.ListDataCataloguesRequest
+	(*ListDataCataloguesResponse)(nil),        // 101: ai_studio_management.ListDataCataloguesResponse
+	(*GetDataCatalogueRequest)(nil),           // 102: ai_studio_management.GetDataCatalogueRequest
+	(*GetDataCatalogueResponse)(nil),          // 103: ai_studio_management.GetDataCatalogueResponse
+	(*CreateDataCatalogueRequest)(nil),        // 104: ai_studio_management.CreateDataCatalogueRequest
+	(*CreateDataCatalogueResponse)(nil),       // 105: ai_studio_management.CreateDataCatalogueResponse
+	(*UpdateDataCatalogueRequest)(nil),        // 106: ai_studio_management.UpdateDataCatalogueRequest
+	(*UpdateDataCatalogueResponse)(nil),       // 107: ai_studio_management.UpdateDataCatalogueResponse
+	(*DeleteDataCatalogueRequest)(nil),        // 108: ai_studio_management.DeleteDataCatalogueRequest
+	(*DeleteDataCatalogueResponse)(nil),       // 109: ai_studio_management.DeleteDataCatalogueResponse
+	(*DataCatalogueInfo)(nil),                 // 110: ai_studio_management.DataCatalogueInfo
+	(*ListTagsRequest)(nil),                   // 111: ai_studio_management.ListTagsRequest
+	(*ListTagsResponse)(nil),                  // 112: ai_studio_management.ListTagsResponse
+	(*GetTagRequest)(nil),                     // 113: ai_studio_management.GetTagRequest
+	(*GetTagResponse)(nil),                    // 114: ai_studio_management.GetTagResponse
+	(*CreateTagRequest)(nil),                  // 115: ai_studio_management.CreateTagRequest
+	(*CreateTagResponse)(nil),                 // 116: ai_studio_management.CreateTagResponse
+	(*UpdateTagRequest)(nil),                  // 117: ai_studio_management.UpdateTagRequest
+	(*UpdateTagResponse)(nil),                 // 118: ai_studio_management.UpdateTagResponse
+	(*DeleteTagRequest)(nil),                  // 119: ai_studio_management.DeleteTagRequest
+	(*DeleteTagResponse)(nil),                 // 120: ai_studio_management.DeleteTagResponse
+	(*SearchTagsRequest)(nil),                 // 121: ai_studio_management.SearchTagsRequest
+	(*SearchTagsResponse)(nil),                // 122: ai_studio_management.SearchTagsResponse
+	(*TagInfo)(nil),                           // 123: ai_studio_management.TagInfo
+	(*GetChatRecordsPerDayRequest)(nil),       // 124: ai_studio_management.GetChatRecordsPerDayRequest
+	(*GetChatRecordsPerDayResponse)(nil),      // 125: ai_studio_management.GetChatRecordsPerDayResponse
+	(*GetModelUsageRequest)(nil),              // 126: ai_studio_management.GetModelUsageRequest
+	(*GetModelUsageResponse)(nil),             // 127: ai_studio_management.GetModelUsageResponse
+	(*GetVendorUsageRequest)(nil),             // 128: ai_studio_management.GetVendorUsageRequest
+	(*GetVendorUsageResponse)(nil),            // 129: ai_studio_management.GetVendorUsageResponse
+	(*GetTokenUsagePerAppRequest)(nil),        // 130: ai_studio_management.GetTokenUsagePerAppRequest
+	(*GetTokenUsagePerAppResponse)(nil),       // 131: ai_studio_management.GetTokenUsagePerAppResponse
+	(*GetToolUsageStatisticsRequest)(nil),     // 132: ai_studio_management.GetToolUsageStatisticsRequest
+	(*GetToolUsageStatisticsResponse)(nil),    // 133: ai_studio_management.GetToolUsageStatisticsResponse
+	(*DayRecord)(nil),                         // 134: ai_studio_management.DayRecord
+	(*ModelUsageRecord)(nil),                  // 135: ai_studio_management.ModelUsageRecord
+	(*VendorUsageRecord)(nil),                 // 136: ai_studio_management.VendorUsageRecord
+	(*AppTokenUsage)(nil),                     // 137: ai_studio_management.AppTokenUsage
+	(*ToolUsageRecord)(nil),                   // 138: ai_studio_management.ToolUsageRecord
+	(*ListModelPricesRequest)(nil),            // 139: ai_studio_management.ListModelPricesRequest
+	(*ListModelPricesResponse)(nil),           // 140: ai_studio_management.ListModelPricesResponse
+	(*GetModelPriceRequest)(nil),              // 141: ai_studio_management.GetModelPriceRequest
+	(*GetModelPriceResponse)(nil),             // 142: ai_studio_management.GetModelPriceResponse
+	(*CreateModelPriceRequest)(nil),           // 143: ai_studio_management.CreateModelPriceRequest
+	(*CreateModelPriceResponse)(nil),          // 144: ai_studio_management.CreateModelPriceResponse
+	(*UpdateModelPriceRequest)(nil),           // 145: ai_studio_management.UpdateModelPriceRequest
+	(*UpdateModelPriceResponse)(nil),          // 146: ai_studio_management.UpdateModelPriceResponse
+	(*DeleteModelPriceRequest)(nil),           // 147: ai_studio_management.DeleteModelPriceRequest
+	(*DeleteModelPriceResponse)(nil),          // 148: ai_studio_management.DeleteModelPriceResponse
+	(*GetModelPricesByVendorRequest)(nil),     // 149: ai_studio_management.GetModelPricesByVendorRequest
+	(*GetModelPricesByVendorResponse)(nil),    // 150: ai_studio_management.GetModelPricesByVendorResponse
+	(*ModelPriceInfo)(nil),                    // 151: ai_studio_management.ModelPriceInfo
+	(*ListFiltersRequest)(nil),                // 152: ai_studio_management.ListFiltersRequest
+	(*ListFiltersResponse)(nil),               // 153: ai_studio_management.ListFiltersResponse
+	(*GetFilterRequest)(nil),                  // 154: ai_studio_management.GetFilterRequest
+	(*GetFilterResponse)(nil),                 // 155: ai_studio_management.GetFilterResponse
+	(*CreateFilterRequest)(nil),               // 156: ai_studio_management.CreateFilterRequest
+	(*CreateFilterResponse)(nil),              // 157: ai_studio_management.CreateFilterResponse
+	(*UpdateFilterRequest)(nil),               // 158: ai_studio_management.UpdateFilterRequest
+	(*UpdateFilterResponse)(nil),              // 159: ai_studio_management.UpdateFilterResponse
+	(*DeleteFilterRequest)(nil),               // 160: ai_studio_management.DeleteFilterRequest
+	(*DeleteFilterResponse)(nil),              // 161: ai_studio_management.DeleteFilterResponse
+	(*FilterInfo)(nil),                        // 162: ai_studio_management.FilterInfo
+	(*GetAvailableLLMDriversRequest)(nil),     // 163: ai_studio_management.GetAvailableLLMDriversRequest
+	(*GetAvailableLLMDriversResponse)(nil),    // 164: ai_studio_management.GetAvailableLLMDriversResponse
+	(*GetAvailableEmbeddersRequest)(nil),      // 165: ai_studio_management.GetAvailableEmbeddersRequest
+	(*GetAvailableEmbeddersResponse)(nil),     // 166: ai_studio_management.GetAvailableEmbeddersResponse
+	(*GetAvailableVectorStoresRequest)(nil),   // 167: ai_studio_management.GetAvailableVectorStoresRequest
+	(*GetAvailableVectorStoresResponse)(nil),  // 168: ai_studio_management.GetAvailableVectorStoresResponse
+	(*VendorDriverInfo)(nil),                  // 169: ai_studio_management.VendorDriverInfo
+	(*WritePluginKVRequest)(nil),              // 170: ai_studio_management.WritePluginKVRequest
+	(*WritePluginKVResponse)(nil),             // 171: ai_studio_management.WritePluginKVResponse
+	(*ReadPluginKVRequest)(nil),               // 172: ai_studio_management.ReadPluginKVRequest
+	(*ReadPluginKVResponse)(nil),              // 173: ai_studio_management.ReadPluginKVResponse
+	(*DeletePluginKVRequest)(nil),             // 174: ai_studio_management.DeletePluginKVRequest
+	(*DeletePluginKVResponse)(nil),            // 175: ai_studio_management.DeletePluginKVResponse
+	(*ExecuteToolRequest)(nil),                // 176: ai_studio_management.ExecuteToolRequest
+	(*ExecuteToolResponse)(nil),               // 177: ai_studio_management.ExecuteToolResponse
+	(*QueryDatasourceRequest)(nil),            // 178: ai_studio_management.QueryDatasourceRequest
+	(*QueryDatasourceResponse)(nil),           // 179: ai_studio_management.QueryDatasourceResponse
+	(*DatasourceResult)(nil),                  // 180: ai_studio_management.DatasourceResult
+	(*CallLLMRequest)(nil),                    // 181: ai_studio_management.CallLLMRequest
+	(*CallLLMResponse)(nil),                   // 182: ai_studio_management.CallLLMResponse
+	(*LLMMessage)(nil),                        // 183: ai_studio_management.LLMMessage
+	(*LLMTool)(nil),                           // 184: ai_studio_management.LLMTool
+	(*LLMFunction)(nil),                       // 185: ai_studio_management.LLMFunction
+	(*LLMToolCall)(nil),                       // 186: ai_studio_management.LLMToolCall
+	(*LLMFunctionCall)(nil),                   // 187: ai_studio_management.LLMFunctionCall
+	(*LLMUsage)(nil),                          // 188: ai_studio_management.LLMUsage
+	(*CreateScheduleRequest)(nil),             // 189: ai_studio_management.CreateScheduleRequest
+	(*CreateScheduleResponse)(nil),            // 190: ai_studio_management.CreateScheduleResponse
+	(*GetScheduleRequest)(nil),                // 191: ai_studio_management.GetScheduleRequest
+	(*GetScheduleResponse)(nil),               // 192: ai_studio_management.GetScheduleResponse
+	(*ListSchedulesRequest)(nil),              // 193: ai_studio_management.ListSchedulesRequest
+	(*ListSchedulesResponse)(nil),             // 194: ai_studio_management.ListSchedulesResponse
+	(*UpdateScheduleRequest)(nil),             // 195: ai_studio_management.UpdateScheduleRequest
+	(*UpdateScheduleResponse)(nil),            // 196: ai_studio_management.UpdateScheduleResponse
+	(*DeleteScheduleRequest)(nil),             // 197: ai_studio_management.DeleteScheduleRequest
+	(*DeleteScheduleResponse)(nil),            // 198: ai_studio_management.DeleteScheduleResponse
+	(*ScheduleInfo)(nil),                      // 199: ai_studio_management.ScheduleInfo
+	(*GetLicenseInfoRequest)(nil),             // 200: ai_studio_management.GetLicenseInfoRequest
+	(*GetLicenseInfoResponse)(nil),            // 201: ai_studio_management.GetLicenseInfoResponse
+	nil,                                       // 202: ai_studio_management.LLMInfo.MetadataEntry
+	nil,                                       // 203: ai_studio_management.ToolInfo.MetadataEntry
+	nil,                                       // 204: ai_studio_management.DocumentWithEmbedding.MetadataEntry
+	nil,                                       // 205: ai_studio_management.DocumentChunk.MetadataEntry
+	nil,                                       // 206: ai_studio_management.DeleteDocumentsByMetadataRequest.MetadataFilterEntry
+	nil,                                       // 207: ai_studio_management.QueryByMetadataOnlyRequest.MetadataFilterEntry
+	nil,                                       // 208: ai_studio_management.DatasourceInfo.MetadataEntry
+	nil,                                       // 209: ai_studio_management.DatasourceResult.MetadataEntry
+	(*timestamppb.Timestamp)(nil),             // 210: google.protobuf.Timestamp
 }
 var file_proto_ai_studio_management_ai_studio_management_proto_depIdxs = []int32{
 	0,   // 0: ai_studio_management.ListPluginsRequest.context:type_name -> ai_studio_management.PluginContext
@@ -14509,17 +14671,17 @@ var file_proto_ai_studio_management_ai_studio_management_proto_depIdxs = []int32
 	0,   // 2: ai_studio_management.GetPluginRequest.context:type_name -> ai_studio_management.PluginContext
 	7,   // 3: ai_studio_management.GetPluginResponse.plugin:type_name -> ai_studio_management.PluginInfo
 	0,   // 4: ai_studio_management.UpdatePluginConfigRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 5: ai_studio_management.PluginInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 6: ai_studio_management.PluginInfo.updated_at:type_name -> google.protobuf.Timestamp
+	210, // 5: ai_studio_management.PluginInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 6: ai_studio_management.PluginInfo.updated_at:type_name -> google.protobuf.Timestamp
 	0,   // 7: ai_studio_management.ListLLMsRequest.context:type_name -> ai_studio_management.PluginContext
 	14,  // 8: ai_studio_management.ListLLMsResponse.llms:type_name -> ai_studio_management.LLMInfo
 	0,   // 9: ai_studio_management.GetLLMRequest.context:type_name -> ai_studio_management.PluginContext
 	14,  // 10: ai_studio_management.GetLLMResponse.llm:type_name -> ai_studio_management.LLMInfo
 	0,   // 11: ai_studio_management.GetLLMPluginsRequest.context:type_name -> ai_studio_management.PluginContext
 	7,   // 12: ai_studio_management.GetLLMPluginsResponse.plugins:type_name -> ai_studio_management.PluginInfo
-	208, // 13: ai_studio_management.LLMInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 14: ai_studio_management.LLMInfo.updated_at:type_name -> google.protobuf.Timestamp
-	200, // 15: ai_studio_management.LLMInfo.metadata:type_name -> ai_studio_management.LLMInfo.MetadataEntry
+	210, // 13: ai_studio_management.LLMInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 14: ai_studio_management.LLMInfo.updated_at:type_name -> google.protobuf.Timestamp
+	202, // 15: ai_studio_management.LLMInfo.metadata:type_name -> ai_studio_management.LLMInfo.MetadataEntry
 	0,   // 16: ai_studio_management.CreateLLMRequest.context:type_name -> ai_studio_management.PluginContext
 	14,  // 17: ai_studio_management.CreateLLMResponse.llm:type_name -> ai_studio_management.LLMInfo
 	0,   // 18: ai_studio_management.UpdateLLMRequest.context:type_name -> ai_studio_management.PluginContext
@@ -14533,337 +14695,340 @@ var file_proto_ai_studio_management_ai_studio_management_proto_depIdxs = []int32
 	31,  // 26: ai_studio_management.GetUsageStatisticsResponse.statistics:type_name -> ai_studio_management.UsageStatistic
 	0,   // 27: ai_studio_management.GetCostAnalysisRequest.context:type_name -> ai_studio_management.PluginContext
 	32,  // 28: ai_studio_management.GetCostAnalysisResponse.breakdown:type_name -> ai_studio_management.CostBreakdown
-	208, // 29: ai_studio_management.UsageStatistic.timestamp:type_name -> google.protobuf.Timestamp
+	210, // 29: ai_studio_management.UsageStatistic.timestamp:type_name -> google.protobuf.Timestamp
 	0,   // 30: ai_studio_management.ListAppsRequest.context:type_name -> ai_studio_management.PluginContext
 	37,  // 31: ai_studio_management.ListAppsResponse.apps:type_name -> ai_studio_management.AppInfo
 	0,   // 32: ai_studio_management.GetAppRequest.context:type_name -> ai_studio_management.PluginContext
 	37,  // 33: ai_studio_management.GetAppResponse.app:type_name -> ai_studio_management.AppInfo
-	208, // 34: ai_studio_management.AppInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 35: ai_studio_management.AppInfo.updated_at:type_name -> google.protobuf.Timestamp
+	210, // 34: ai_studio_management.AppInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 35: ai_studio_management.AppInfo.updated_at:type_name -> google.protobuf.Timestamp
 	0,   // 36: ai_studio_management.CreateAppRequest.context:type_name -> ai_studio_management.PluginContext
 	37,  // 37: ai_studio_management.CreateAppResponse.app:type_name -> ai_studio_management.AppInfo
 	0,   // 38: ai_studio_management.UpdateAppRequest.context:type_name -> ai_studio_management.PluginContext
 	37,  // 39: ai_studio_management.UpdateAppResponse.app:type_name -> ai_studio_management.AppInfo
 	0,   // 40: ai_studio_management.DeleteAppRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 41: ai_studio_management.ListToolsRequest.context:type_name -> ai_studio_management.PluginContext
-	52,  // 42: ai_studio_management.ListToolsResponse.tools:type_name -> ai_studio_management.ToolInfo
-	0,   // 43: ai_studio_management.GetToolRequest.context:type_name -> ai_studio_management.PluginContext
-	52,  // 44: ai_studio_management.GetToolResponse.tool:type_name -> ai_studio_management.ToolInfo
-	0,   // 45: ai_studio_management.GetToolOperationsRequest.context:type_name -> ai_studio_management.PluginContext
-	53,  // 46: ai_studio_management.GetToolOperationsResponse.operations:type_name -> ai_studio_management.ToolOperation
-	0,   // 47: ai_studio_management.CallToolOperationRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 48: ai_studio_management.ToolInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 49: ai_studio_management.ToolInfo.updated_at:type_name -> google.protobuf.Timestamp
-	201, // 50: ai_studio_management.ToolInfo.metadata:type_name -> ai_studio_management.ToolInfo.MetadataEntry
-	54,  // 51: ai_studio_management.ToolOperation.parameters:type_name -> ai_studio_management.ToolParameter
-	55,  // 52: ai_studio_management.ToolOperation.request_body:type_name -> ai_studio_management.ToolRequestBody
-	0,   // 53: ai_studio_management.CreateToolRequest.context:type_name -> ai_studio_management.PluginContext
-	52,  // 54: ai_studio_management.CreateToolResponse.tool:type_name -> ai_studio_management.ToolInfo
-	0,   // 55: ai_studio_management.UpdateToolRequest.context:type_name -> ai_studio_management.PluginContext
-	52,  // 56: ai_studio_management.UpdateToolResponse.tool:type_name -> ai_studio_management.ToolInfo
-	0,   // 57: ai_studio_management.DeleteToolRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 58: ai_studio_management.ListDatasourcesRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 59: ai_studio_management.ListDatasourcesResponse.datasources:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 60: ai_studio_management.GetDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 61: ai_studio_management.GetDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 62: ai_studio_management.CreateDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 63: ai_studio_management.CreateDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 64: ai_studio_management.UpdateDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 65: ai_studio_management.UpdateDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 66: ai_studio_management.DeleteDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 67: ai_studio_management.CloneDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 68: ai_studio_management.CloneDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 69: ai_studio_management.SearchDatasourcesRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 70: ai_studio_management.SearchDatasourcesResponse.datasources:type_name -> ai_studio_management.DatasourceInfo
-	0,   // 71: ai_studio_management.ProcessEmbeddingsRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 72: ai_studio_management.GenerateEmbeddingRequest.context:type_name -> ai_studio_management.PluginContext
-	80,  // 73: ai_studio_management.GenerateEmbeddingResponse.vectors:type_name -> ai_studio_management.EmbeddingVector
-	0,   // 74: ai_studio_management.StoreDocumentsRequest.context:type_name -> ai_studio_management.PluginContext
-	82,  // 75: ai_studio_management.StoreDocumentsRequest.documents:type_name -> ai_studio_management.DocumentWithEmbedding
-	202, // 76: ai_studio_management.DocumentWithEmbedding.metadata:type_name -> ai_studio_management.DocumentWithEmbedding.MetadataEntry
-	0,   // 77: ai_studio_management.ProcessAndStoreRequest.context:type_name -> ai_studio_management.PluginContext
-	85,  // 78: ai_studio_management.ProcessAndStoreRequest.chunks:type_name -> ai_studio_management.DocumentChunk
-	203, // 79: ai_studio_management.DocumentChunk.metadata:type_name -> ai_studio_management.DocumentChunk.MetadataEntry
-	0,   // 80: ai_studio_management.DeleteDocumentsByMetadataRequest.context:type_name -> ai_studio_management.PluginContext
-	204, // 81: ai_studio_management.DeleteDocumentsByMetadataRequest.metadata_filter:type_name -> ai_studio_management.DeleteDocumentsByMetadataRequest.MetadataFilterEntry
-	0,   // 82: ai_studio_management.QueryByMetadataOnlyRequest.context:type_name -> ai_studio_management.PluginContext
-	205, // 83: ai_studio_management.QueryByMetadataOnlyRequest.metadata_filter:type_name -> ai_studio_management.QueryByMetadataOnlyRequest.MetadataFilterEntry
-	178, // 84: ai_studio_management.QueryByMetadataOnlyResponse.results:type_name -> ai_studio_management.DatasourceResult
-	0,   // 85: ai_studio_management.ListNamespacesRequest.context:type_name -> ai_studio_management.PluginContext
-	93,  // 86: ai_studio_management.ListNamespacesResponse.namespaces:type_name -> ai_studio_management.NamespaceInfo
-	0,   // 87: ai_studio_management.DeleteNamespaceRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 88: ai_studio_management.QueryByVectorRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 89: ai_studio_management.DatasourceInfo.tags:type_name -> ai_studio_management.TagInfo
-	208, // 90: ai_studio_management.DatasourceInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 91: ai_studio_management.DatasourceInfo.updated_at:type_name -> google.protobuf.Timestamp
-	206, // 92: ai_studio_management.DatasourceInfo.metadata:type_name -> ai_studio_management.DatasourceInfo.MetadataEntry
-	0,   // 93: ai_studio_management.ListDataCataloguesRequest.context:type_name -> ai_studio_management.PluginContext
-	108, // 94: ai_studio_management.ListDataCataloguesResponse.data_catalogues:type_name -> ai_studio_management.DataCatalogueInfo
-	0,   // 95: ai_studio_management.GetDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
-	108, // 96: ai_studio_management.GetDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
-	0,   // 97: ai_studio_management.CreateDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
-	108, // 98: ai_studio_management.CreateDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
-	0,   // 99: ai_studio_management.UpdateDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
-	108, // 100: ai_studio_management.UpdateDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
-	0,   // 101: ai_studio_management.DeleteDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
-	97,  // 102: ai_studio_management.DataCatalogueInfo.datasources:type_name -> ai_studio_management.DatasourceInfo
-	121, // 103: ai_studio_management.DataCatalogueInfo.tags:type_name -> ai_studio_management.TagInfo
-	208, // 104: ai_studio_management.DataCatalogueInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 105: ai_studio_management.DataCatalogueInfo.updated_at:type_name -> google.protobuf.Timestamp
-	0,   // 106: ai_studio_management.ListTagsRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 107: ai_studio_management.ListTagsResponse.tags:type_name -> ai_studio_management.TagInfo
-	0,   // 108: ai_studio_management.GetTagRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 109: ai_studio_management.GetTagResponse.tag:type_name -> ai_studio_management.TagInfo
-	0,   // 110: ai_studio_management.CreateTagRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 111: ai_studio_management.CreateTagResponse.tag:type_name -> ai_studio_management.TagInfo
-	0,   // 112: ai_studio_management.UpdateTagRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 113: ai_studio_management.UpdateTagResponse.tag:type_name -> ai_studio_management.TagInfo
-	0,   // 114: ai_studio_management.DeleteTagRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 115: ai_studio_management.SearchTagsRequest.context:type_name -> ai_studio_management.PluginContext
-	121, // 116: ai_studio_management.SearchTagsResponse.tags:type_name -> ai_studio_management.TagInfo
-	208, // 117: ai_studio_management.TagInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 118: ai_studio_management.TagInfo.updated_at:type_name -> google.protobuf.Timestamp
-	0,   // 119: ai_studio_management.GetChatRecordsPerDayRequest.context:type_name -> ai_studio_management.PluginContext
-	132, // 120: ai_studio_management.GetChatRecordsPerDayResponse.records:type_name -> ai_studio_management.DayRecord
-	0,   // 121: ai_studio_management.GetModelUsageRequest.context:type_name -> ai_studio_management.PluginContext
-	133, // 122: ai_studio_management.GetModelUsageResponse.usage:type_name -> ai_studio_management.ModelUsageRecord
-	0,   // 123: ai_studio_management.GetVendorUsageRequest.context:type_name -> ai_studio_management.PluginContext
-	134, // 124: ai_studio_management.GetVendorUsageResponse.usage:type_name -> ai_studio_management.VendorUsageRecord
-	0,   // 125: ai_studio_management.GetTokenUsagePerAppRequest.context:type_name -> ai_studio_management.PluginContext
-	135, // 126: ai_studio_management.GetTokenUsagePerAppResponse.usage:type_name -> ai_studio_management.AppTokenUsage
-	0,   // 127: ai_studio_management.GetToolUsageStatisticsRequest.context:type_name -> ai_studio_management.PluginContext
-	136, // 128: ai_studio_management.GetToolUsageStatisticsResponse.usage:type_name -> ai_studio_management.ToolUsageRecord
-	0,   // 129: ai_studio_management.ListModelPricesRequest.context:type_name -> ai_studio_management.PluginContext
-	149, // 130: ai_studio_management.ListModelPricesResponse.model_prices:type_name -> ai_studio_management.ModelPriceInfo
-	0,   // 131: ai_studio_management.GetModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
-	149, // 132: ai_studio_management.GetModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
-	0,   // 133: ai_studio_management.CreateModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
-	149, // 134: ai_studio_management.CreateModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
-	0,   // 135: ai_studio_management.UpdateModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
-	149, // 136: ai_studio_management.UpdateModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
-	0,   // 137: ai_studio_management.DeleteModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 138: ai_studio_management.GetModelPricesByVendorRequest.context:type_name -> ai_studio_management.PluginContext
-	149, // 139: ai_studio_management.GetModelPricesByVendorResponse.model_prices:type_name -> ai_studio_management.ModelPriceInfo
-	208, // 140: ai_studio_management.ModelPriceInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 141: ai_studio_management.ModelPriceInfo.updated_at:type_name -> google.protobuf.Timestamp
-	0,   // 142: ai_studio_management.ListFiltersRequest.context:type_name -> ai_studio_management.PluginContext
-	160, // 143: ai_studio_management.ListFiltersResponse.filters:type_name -> ai_studio_management.FilterInfo
-	0,   // 144: ai_studio_management.GetFilterRequest.context:type_name -> ai_studio_management.PluginContext
-	160, // 145: ai_studio_management.GetFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
-	0,   // 146: ai_studio_management.CreateFilterRequest.context:type_name -> ai_studio_management.PluginContext
-	160, // 147: ai_studio_management.CreateFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
-	0,   // 148: ai_studio_management.UpdateFilterRequest.context:type_name -> ai_studio_management.PluginContext
-	160, // 149: ai_studio_management.UpdateFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
-	0,   // 150: ai_studio_management.DeleteFilterRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 151: ai_studio_management.FilterInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 152: ai_studio_management.FilterInfo.updated_at:type_name -> google.protobuf.Timestamp
-	0,   // 153: ai_studio_management.GetAvailableLLMDriversRequest.context:type_name -> ai_studio_management.PluginContext
-	167, // 154: ai_studio_management.GetAvailableLLMDriversResponse.drivers:type_name -> ai_studio_management.VendorDriverInfo
-	0,   // 155: ai_studio_management.GetAvailableEmbeddersRequest.context:type_name -> ai_studio_management.PluginContext
-	167, // 156: ai_studio_management.GetAvailableEmbeddersResponse.embedders:type_name -> ai_studio_management.VendorDriverInfo
-	0,   // 157: ai_studio_management.GetAvailableVectorStoresRequest.context:type_name -> ai_studio_management.PluginContext
-	167, // 158: ai_studio_management.GetAvailableVectorStoresResponse.vector_stores:type_name -> ai_studio_management.VendorDriverInfo
-	0,   // 159: ai_studio_management.WritePluginKVRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 160: ai_studio_management.WritePluginKVRequest.expire_at:type_name -> google.protobuf.Timestamp
-	0,   // 161: ai_studio_management.ReadPluginKVRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 162: ai_studio_management.DeletePluginKVRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 163: ai_studio_management.ExecuteToolRequest.context:type_name -> ai_studio_management.PluginContext
-	0,   // 164: ai_studio_management.QueryDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
-	178, // 165: ai_studio_management.QueryDatasourceResponse.results:type_name -> ai_studio_management.DatasourceResult
-	207, // 166: ai_studio_management.DatasourceResult.metadata:type_name -> ai_studio_management.DatasourceResult.MetadataEntry
-	0,   // 167: ai_studio_management.CallLLMRequest.context:type_name -> ai_studio_management.PluginContext
-	181, // 168: ai_studio_management.CallLLMRequest.messages:type_name -> ai_studio_management.LLMMessage
-	182, // 169: ai_studio_management.CallLLMRequest.tools:type_name -> ai_studio_management.LLMTool
-	186, // 170: ai_studio_management.CallLLMResponse.usage:type_name -> ai_studio_management.LLMUsage
-	184, // 171: ai_studio_management.CallLLMResponse.tool_calls:type_name -> ai_studio_management.LLMToolCall
-	183, // 172: ai_studio_management.LLMTool.function:type_name -> ai_studio_management.LLMFunction
-	185, // 173: ai_studio_management.LLMToolCall.function:type_name -> ai_studio_management.LLMFunctionCall
-	0,   // 174: ai_studio_management.CreateScheduleRequest.context:type_name -> ai_studio_management.PluginContext
-	197, // 175: ai_studio_management.CreateScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
-	0,   // 176: ai_studio_management.GetScheduleRequest.context:type_name -> ai_studio_management.PluginContext
-	197, // 177: ai_studio_management.GetScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
-	0,   // 178: ai_studio_management.ListSchedulesRequest.context:type_name -> ai_studio_management.PluginContext
-	197, // 179: ai_studio_management.ListSchedulesResponse.schedules:type_name -> ai_studio_management.ScheduleInfo
-	0,   // 180: ai_studio_management.UpdateScheduleRequest.context:type_name -> ai_studio_management.PluginContext
-	197, // 181: ai_studio_management.UpdateScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
-	0,   // 182: ai_studio_management.DeleteScheduleRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 183: ai_studio_management.ScheduleInfo.last_run:type_name -> google.protobuf.Timestamp
-	208, // 184: ai_studio_management.ScheduleInfo.next_run:type_name -> google.protobuf.Timestamp
-	208, // 185: ai_studio_management.ScheduleInfo.created_at:type_name -> google.protobuf.Timestamp
-	208, // 186: ai_studio_management.ScheduleInfo.updated_at:type_name -> google.protobuf.Timestamp
-	0,   // 187: ai_studio_management.GetLicenseInfoRequest.context:type_name -> ai_studio_management.PluginContext
-	208, // 188: ai_studio_management.GetLicenseInfoResponse.expires_at:type_name -> google.protobuf.Timestamp
-	1,   // 189: ai_studio_management.AIStudioManagementService.ListPlugins:input_type -> ai_studio_management.ListPluginsRequest
-	3,   // 190: ai_studio_management.AIStudioManagementService.GetPlugin:input_type -> ai_studio_management.GetPluginRequest
-	5,   // 191: ai_studio_management.AIStudioManagementService.UpdatePluginConfig:input_type -> ai_studio_management.UpdatePluginConfigRequest
-	8,   // 192: ai_studio_management.AIStudioManagementService.ListLLMs:input_type -> ai_studio_management.ListLLMsRequest
-	10,  // 193: ai_studio_management.AIStudioManagementService.GetLLM:input_type -> ai_studio_management.GetLLMRequest
-	12,  // 194: ai_studio_management.AIStudioManagementService.GetLLMPlugins:input_type -> ai_studio_management.GetLLMPluginsRequest
-	15,  // 195: ai_studio_management.AIStudioManagementService.CreateLLM:input_type -> ai_studio_management.CreateLLMRequest
-	17,  // 196: ai_studio_management.AIStudioManagementService.UpdateLLM:input_type -> ai_studio_management.UpdateLLMRequest
-	19,  // 197: ai_studio_management.AIStudioManagementService.DeleteLLM:input_type -> ai_studio_management.DeleteLLMRequest
-	21,  // 198: ai_studio_management.AIStudioManagementService.UpdateLLMPlugins:input_type -> ai_studio_management.UpdateLLMPluginsRequest
-	23,  // 199: ai_studio_management.AIStudioManagementService.GetAnalyticsSummary:input_type -> ai_studio_management.GetAnalyticsSummaryRequest
-	25,  // 200: ai_studio_management.AIStudioManagementService.GetUsageStatistics:input_type -> ai_studio_management.GetUsageStatisticsRequest
-	27,  // 201: ai_studio_management.AIStudioManagementService.GetCostAnalysis:input_type -> ai_studio_management.GetCostAnalysisRequest
-	122, // 202: ai_studio_management.AIStudioManagementService.GetChatRecordsPerDay:input_type -> ai_studio_management.GetChatRecordsPerDayRequest
-	124, // 203: ai_studio_management.AIStudioManagementService.GetModelUsage:input_type -> ai_studio_management.GetModelUsageRequest
-	126, // 204: ai_studio_management.AIStudioManagementService.GetVendorUsage:input_type -> ai_studio_management.GetVendorUsageRequest
-	128, // 205: ai_studio_management.AIStudioManagementService.GetTokenUsagePerApp:input_type -> ai_studio_management.GetTokenUsagePerAppRequest
-	130, // 206: ai_studio_management.AIStudioManagementService.GetToolUsageStatistics:input_type -> ai_studio_management.GetToolUsageStatisticsRequest
-	33,  // 207: ai_studio_management.AIStudioManagementService.ListApps:input_type -> ai_studio_management.ListAppsRequest
-	35,  // 208: ai_studio_management.AIStudioManagementService.GetApp:input_type -> ai_studio_management.GetAppRequest
-	38,  // 209: ai_studio_management.AIStudioManagementService.CreateApp:input_type -> ai_studio_management.CreateAppRequest
-	40,  // 210: ai_studio_management.AIStudioManagementService.UpdateApp:input_type -> ai_studio_management.UpdateAppRequest
-	42,  // 211: ai_studio_management.AIStudioManagementService.DeleteApp:input_type -> ai_studio_management.DeleteAppRequest
-	44,  // 212: ai_studio_management.AIStudioManagementService.ListTools:input_type -> ai_studio_management.ListToolsRequest
-	46,  // 213: ai_studio_management.AIStudioManagementService.GetTool:input_type -> ai_studio_management.GetToolRequest
-	48,  // 214: ai_studio_management.AIStudioManagementService.GetToolOperations:input_type -> ai_studio_management.GetToolOperationsRequest
-	50,  // 215: ai_studio_management.AIStudioManagementService.CallToolOperation:input_type -> ai_studio_management.CallToolOperationRequest
-	56,  // 216: ai_studio_management.AIStudioManagementService.CreateTool:input_type -> ai_studio_management.CreateToolRequest
-	58,  // 217: ai_studio_management.AIStudioManagementService.UpdateTool:input_type -> ai_studio_management.UpdateToolRequest
-	60,  // 218: ai_studio_management.AIStudioManagementService.DeleteTool:input_type -> ai_studio_management.DeleteToolRequest
-	62,  // 219: ai_studio_management.AIStudioManagementService.ListDatasources:input_type -> ai_studio_management.ListDatasourcesRequest
-	64,  // 220: ai_studio_management.AIStudioManagementService.GetDatasource:input_type -> ai_studio_management.GetDatasourceRequest
-	66,  // 221: ai_studio_management.AIStudioManagementService.CreateDatasource:input_type -> ai_studio_management.CreateDatasourceRequest
-	68,  // 222: ai_studio_management.AIStudioManagementService.UpdateDatasource:input_type -> ai_studio_management.UpdateDatasourceRequest
-	70,  // 223: ai_studio_management.AIStudioManagementService.DeleteDatasource:input_type -> ai_studio_management.DeleteDatasourceRequest
-	72,  // 224: ai_studio_management.AIStudioManagementService.CloneDatasource:input_type -> ai_studio_management.CloneDatasourceRequest
-	74,  // 225: ai_studio_management.AIStudioManagementService.SearchDatasources:input_type -> ai_studio_management.SearchDatasourcesRequest
-	76,  // 226: ai_studio_management.AIStudioManagementService.ProcessDatasourceEmbeddings:input_type -> ai_studio_management.ProcessEmbeddingsRequest
-	78,  // 227: ai_studio_management.AIStudioManagementService.GenerateEmbedding:input_type -> ai_studio_management.GenerateEmbeddingRequest
-	81,  // 228: ai_studio_management.AIStudioManagementService.StoreDocuments:input_type -> ai_studio_management.StoreDocumentsRequest
-	84,  // 229: ai_studio_management.AIStudioManagementService.ProcessAndStoreDocuments:input_type -> ai_studio_management.ProcessAndStoreRequest
-	96,  // 230: ai_studio_management.AIStudioManagementService.QueryDatasourceByVector:input_type -> ai_studio_management.QueryByVectorRequest
-	87,  // 231: ai_studio_management.AIStudioManagementService.DeleteDocumentsByMetadata:input_type -> ai_studio_management.DeleteDocumentsByMetadataRequest
-	89,  // 232: ai_studio_management.AIStudioManagementService.QueryByMetadataOnly:input_type -> ai_studio_management.QueryByMetadataOnlyRequest
-	91,  // 233: ai_studio_management.AIStudioManagementService.ListNamespaces:input_type -> ai_studio_management.ListNamespacesRequest
-	94,  // 234: ai_studio_management.AIStudioManagementService.DeleteNamespace:input_type -> ai_studio_management.DeleteNamespaceRequest
-	98,  // 235: ai_studio_management.AIStudioManagementService.ListDataCatalogues:input_type -> ai_studio_management.ListDataCataloguesRequest
-	100, // 236: ai_studio_management.AIStudioManagementService.GetDataCatalogue:input_type -> ai_studio_management.GetDataCatalogueRequest
-	102, // 237: ai_studio_management.AIStudioManagementService.CreateDataCatalogue:input_type -> ai_studio_management.CreateDataCatalogueRequest
-	104, // 238: ai_studio_management.AIStudioManagementService.UpdateDataCatalogue:input_type -> ai_studio_management.UpdateDataCatalogueRequest
-	106, // 239: ai_studio_management.AIStudioManagementService.DeleteDataCatalogue:input_type -> ai_studio_management.DeleteDataCatalogueRequest
-	109, // 240: ai_studio_management.AIStudioManagementService.ListTags:input_type -> ai_studio_management.ListTagsRequest
-	111, // 241: ai_studio_management.AIStudioManagementService.GetTag:input_type -> ai_studio_management.GetTagRequest
-	113, // 242: ai_studio_management.AIStudioManagementService.CreateTag:input_type -> ai_studio_management.CreateTagRequest
-	115, // 243: ai_studio_management.AIStudioManagementService.UpdateTag:input_type -> ai_studio_management.UpdateTagRequest
-	117, // 244: ai_studio_management.AIStudioManagementService.DeleteTag:input_type -> ai_studio_management.DeleteTagRequest
-	119, // 245: ai_studio_management.AIStudioManagementService.SearchTags:input_type -> ai_studio_management.SearchTagsRequest
-	137, // 246: ai_studio_management.AIStudioManagementService.ListModelPrices:input_type -> ai_studio_management.ListModelPricesRequest
-	139, // 247: ai_studio_management.AIStudioManagementService.GetModelPrice:input_type -> ai_studio_management.GetModelPriceRequest
-	141, // 248: ai_studio_management.AIStudioManagementService.CreateModelPrice:input_type -> ai_studio_management.CreateModelPriceRequest
-	143, // 249: ai_studio_management.AIStudioManagementService.UpdateModelPrice:input_type -> ai_studio_management.UpdateModelPriceRequest
-	145, // 250: ai_studio_management.AIStudioManagementService.DeleteModelPrice:input_type -> ai_studio_management.DeleteModelPriceRequest
-	147, // 251: ai_studio_management.AIStudioManagementService.GetModelPricesByVendor:input_type -> ai_studio_management.GetModelPricesByVendorRequest
-	150, // 252: ai_studio_management.AIStudioManagementService.ListFilters:input_type -> ai_studio_management.ListFiltersRequest
-	152, // 253: ai_studio_management.AIStudioManagementService.GetFilter:input_type -> ai_studio_management.GetFilterRequest
-	154, // 254: ai_studio_management.AIStudioManagementService.CreateFilter:input_type -> ai_studio_management.CreateFilterRequest
-	156, // 255: ai_studio_management.AIStudioManagementService.UpdateFilter:input_type -> ai_studio_management.UpdateFilterRequest
-	158, // 256: ai_studio_management.AIStudioManagementService.DeleteFilter:input_type -> ai_studio_management.DeleteFilterRequest
-	161, // 257: ai_studio_management.AIStudioManagementService.GetAvailableLLMDrivers:input_type -> ai_studio_management.GetAvailableLLMDriversRequest
-	163, // 258: ai_studio_management.AIStudioManagementService.GetAvailableEmbedders:input_type -> ai_studio_management.GetAvailableEmbeddersRequest
-	165, // 259: ai_studio_management.AIStudioManagementService.GetAvailableVectorStores:input_type -> ai_studio_management.GetAvailableVectorStoresRequest
-	168, // 260: ai_studio_management.AIStudioManagementService.WritePluginKV:input_type -> ai_studio_management.WritePluginKVRequest
-	170, // 261: ai_studio_management.AIStudioManagementService.ReadPluginKV:input_type -> ai_studio_management.ReadPluginKVRequest
-	172, // 262: ai_studio_management.AIStudioManagementService.DeletePluginKV:input_type -> ai_studio_management.DeletePluginKVRequest
-	174, // 263: ai_studio_management.AIStudioManagementService.ExecuteTool:input_type -> ai_studio_management.ExecuteToolRequest
-	176, // 264: ai_studio_management.AIStudioManagementService.QueryDatasource:input_type -> ai_studio_management.QueryDatasourceRequest
-	179, // 265: ai_studio_management.AIStudioManagementService.CallLLM:input_type -> ai_studio_management.CallLLMRequest
-	187, // 266: ai_studio_management.AIStudioManagementService.CreateSchedule:input_type -> ai_studio_management.CreateScheduleRequest
-	189, // 267: ai_studio_management.AIStudioManagementService.GetSchedule:input_type -> ai_studio_management.GetScheduleRequest
-	191, // 268: ai_studio_management.AIStudioManagementService.ListSchedules:input_type -> ai_studio_management.ListSchedulesRequest
-	193, // 269: ai_studio_management.AIStudioManagementService.UpdateSchedule:input_type -> ai_studio_management.UpdateScheduleRequest
-	195, // 270: ai_studio_management.AIStudioManagementService.DeleteSchedule:input_type -> ai_studio_management.DeleteScheduleRequest
-	198, // 271: ai_studio_management.AIStudioManagementService.GetLicenseInfo:input_type -> ai_studio_management.GetLicenseInfoRequest
-	2,   // 272: ai_studio_management.AIStudioManagementService.ListPlugins:output_type -> ai_studio_management.ListPluginsResponse
-	4,   // 273: ai_studio_management.AIStudioManagementService.GetPlugin:output_type -> ai_studio_management.GetPluginResponse
-	6,   // 274: ai_studio_management.AIStudioManagementService.UpdatePluginConfig:output_type -> ai_studio_management.UpdatePluginConfigResponse
-	9,   // 275: ai_studio_management.AIStudioManagementService.ListLLMs:output_type -> ai_studio_management.ListLLMsResponse
-	11,  // 276: ai_studio_management.AIStudioManagementService.GetLLM:output_type -> ai_studio_management.GetLLMResponse
-	13,  // 277: ai_studio_management.AIStudioManagementService.GetLLMPlugins:output_type -> ai_studio_management.GetLLMPluginsResponse
-	16,  // 278: ai_studio_management.AIStudioManagementService.CreateLLM:output_type -> ai_studio_management.CreateLLMResponse
-	18,  // 279: ai_studio_management.AIStudioManagementService.UpdateLLM:output_type -> ai_studio_management.UpdateLLMResponse
-	20,  // 280: ai_studio_management.AIStudioManagementService.DeleteLLM:output_type -> ai_studio_management.DeleteLLMResponse
-	22,  // 281: ai_studio_management.AIStudioManagementService.UpdateLLMPlugins:output_type -> ai_studio_management.UpdateLLMPluginsResponse
-	24,  // 282: ai_studio_management.AIStudioManagementService.GetAnalyticsSummary:output_type -> ai_studio_management.GetAnalyticsSummaryResponse
-	26,  // 283: ai_studio_management.AIStudioManagementService.GetUsageStatistics:output_type -> ai_studio_management.GetUsageStatisticsResponse
-	28,  // 284: ai_studio_management.AIStudioManagementService.GetCostAnalysis:output_type -> ai_studio_management.GetCostAnalysisResponse
-	123, // 285: ai_studio_management.AIStudioManagementService.GetChatRecordsPerDay:output_type -> ai_studio_management.GetChatRecordsPerDayResponse
-	125, // 286: ai_studio_management.AIStudioManagementService.GetModelUsage:output_type -> ai_studio_management.GetModelUsageResponse
-	127, // 287: ai_studio_management.AIStudioManagementService.GetVendorUsage:output_type -> ai_studio_management.GetVendorUsageResponse
-	129, // 288: ai_studio_management.AIStudioManagementService.GetTokenUsagePerApp:output_type -> ai_studio_management.GetTokenUsagePerAppResponse
-	131, // 289: ai_studio_management.AIStudioManagementService.GetToolUsageStatistics:output_type -> ai_studio_management.GetToolUsageStatisticsResponse
-	34,  // 290: ai_studio_management.AIStudioManagementService.ListApps:output_type -> ai_studio_management.ListAppsResponse
-	36,  // 291: ai_studio_management.AIStudioManagementService.GetApp:output_type -> ai_studio_management.GetAppResponse
-	39,  // 292: ai_studio_management.AIStudioManagementService.CreateApp:output_type -> ai_studio_management.CreateAppResponse
-	41,  // 293: ai_studio_management.AIStudioManagementService.UpdateApp:output_type -> ai_studio_management.UpdateAppResponse
-	43,  // 294: ai_studio_management.AIStudioManagementService.DeleteApp:output_type -> ai_studio_management.DeleteAppResponse
-	45,  // 295: ai_studio_management.AIStudioManagementService.ListTools:output_type -> ai_studio_management.ListToolsResponse
-	47,  // 296: ai_studio_management.AIStudioManagementService.GetTool:output_type -> ai_studio_management.GetToolResponse
-	49,  // 297: ai_studio_management.AIStudioManagementService.GetToolOperations:output_type -> ai_studio_management.GetToolOperationsResponse
-	51,  // 298: ai_studio_management.AIStudioManagementService.CallToolOperation:output_type -> ai_studio_management.CallToolOperationResponse
-	57,  // 299: ai_studio_management.AIStudioManagementService.CreateTool:output_type -> ai_studio_management.CreateToolResponse
-	59,  // 300: ai_studio_management.AIStudioManagementService.UpdateTool:output_type -> ai_studio_management.UpdateToolResponse
-	61,  // 301: ai_studio_management.AIStudioManagementService.DeleteTool:output_type -> ai_studio_management.DeleteToolResponse
-	63,  // 302: ai_studio_management.AIStudioManagementService.ListDatasources:output_type -> ai_studio_management.ListDatasourcesResponse
-	65,  // 303: ai_studio_management.AIStudioManagementService.GetDatasource:output_type -> ai_studio_management.GetDatasourceResponse
-	67,  // 304: ai_studio_management.AIStudioManagementService.CreateDatasource:output_type -> ai_studio_management.CreateDatasourceResponse
-	69,  // 305: ai_studio_management.AIStudioManagementService.UpdateDatasource:output_type -> ai_studio_management.UpdateDatasourceResponse
-	71,  // 306: ai_studio_management.AIStudioManagementService.DeleteDatasource:output_type -> ai_studio_management.DeleteDatasourceResponse
-	73,  // 307: ai_studio_management.AIStudioManagementService.CloneDatasource:output_type -> ai_studio_management.CloneDatasourceResponse
-	75,  // 308: ai_studio_management.AIStudioManagementService.SearchDatasources:output_type -> ai_studio_management.SearchDatasourcesResponse
-	77,  // 309: ai_studio_management.AIStudioManagementService.ProcessDatasourceEmbeddings:output_type -> ai_studio_management.ProcessEmbeddingsResponse
-	79,  // 310: ai_studio_management.AIStudioManagementService.GenerateEmbedding:output_type -> ai_studio_management.GenerateEmbeddingResponse
-	83,  // 311: ai_studio_management.AIStudioManagementService.StoreDocuments:output_type -> ai_studio_management.StoreDocumentsResponse
-	86,  // 312: ai_studio_management.AIStudioManagementService.ProcessAndStoreDocuments:output_type -> ai_studio_management.ProcessAndStoreResponse
-	177, // 313: ai_studio_management.AIStudioManagementService.QueryDatasourceByVector:output_type -> ai_studio_management.QueryDatasourceResponse
-	88,  // 314: ai_studio_management.AIStudioManagementService.DeleteDocumentsByMetadata:output_type -> ai_studio_management.DeleteDocumentsByMetadataResponse
-	90,  // 315: ai_studio_management.AIStudioManagementService.QueryByMetadataOnly:output_type -> ai_studio_management.QueryByMetadataOnlyResponse
-	92,  // 316: ai_studio_management.AIStudioManagementService.ListNamespaces:output_type -> ai_studio_management.ListNamespacesResponse
-	95,  // 317: ai_studio_management.AIStudioManagementService.DeleteNamespace:output_type -> ai_studio_management.DeleteNamespaceResponse
-	99,  // 318: ai_studio_management.AIStudioManagementService.ListDataCatalogues:output_type -> ai_studio_management.ListDataCataloguesResponse
-	101, // 319: ai_studio_management.AIStudioManagementService.GetDataCatalogue:output_type -> ai_studio_management.GetDataCatalogueResponse
-	103, // 320: ai_studio_management.AIStudioManagementService.CreateDataCatalogue:output_type -> ai_studio_management.CreateDataCatalogueResponse
-	105, // 321: ai_studio_management.AIStudioManagementService.UpdateDataCatalogue:output_type -> ai_studio_management.UpdateDataCatalogueResponse
-	107, // 322: ai_studio_management.AIStudioManagementService.DeleteDataCatalogue:output_type -> ai_studio_management.DeleteDataCatalogueResponse
-	110, // 323: ai_studio_management.AIStudioManagementService.ListTags:output_type -> ai_studio_management.ListTagsResponse
-	112, // 324: ai_studio_management.AIStudioManagementService.GetTag:output_type -> ai_studio_management.GetTagResponse
-	114, // 325: ai_studio_management.AIStudioManagementService.CreateTag:output_type -> ai_studio_management.CreateTagResponse
-	116, // 326: ai_studio_management.AIStudioManagementService.UpdateTag:output_type -> ai_studio_management.UpdateTagResponse
-	118, // 327: ai_studio_management.AIStudioManagementService.DeleteTag:output_type -> ai_studio_management.DeleteTagResponse
-	120, // 328: ai_studio_management.AIStudioManagementService.SearchTags:output_type -> ai_studio_management.SearchTagsResponse
-	138, // 329: ai_studio_management.AIStudioManagementService.ListModelPrices:output_type -> ai_studio_management.ListModelPricesResponse
-	140, // 330: ai_studio_management.AIStudioManagementService.GetModelPrice:output_type -> ai_studio_management.GetModelPriceResponse
-	142, // 331: ai_studio_management.AIStudioManagementService.CreateModelPrice:output_type -> ai_studio_management.CreateModelPriceResponse
-	144, // 332: ai_studio_management.AIStudioManagementService.UpdateModelPrice:output_type -> ai_studio_management.UpdateModelPriceResponse
-	146, // 333: ai_studio_management.AIStudioManagementService.DeleteModelPrice:output_type -> ai_studio_management.DeleteModelPriceResponse
-	148, // 334: ai_studio_management.AIStudioManagementService.GetModelPricesByVendor:output_type -> ai_studio_management.GetModelPricesByVendorResponse
-	151, // 335: ai_studio_management.AIStudioManagementService.ListFilters:output_type -> ai_studio_management.ListFiltersResponse
-	153, // 336: ai_studio_management.AIStudioManagementService.GetFilter:output_type -> ai_studio_management.GetFilterResponse
-	155, // 337: ai_studio_management.AIStudioManagementService.CreateFilter:output_type -> ai_studio_management.CreateFilterResponse
-	157, // 338: ai_studio_management.AIStudioManagementService.UpdateFilter:output_type -> ai_studio_management.UpdateFilterResponse
-	159, // 339: ai_studio_management.AIStudioManagementService.DeleteFilter:output_type -> ai_studio_management.DeleteFilterResponse
-	162, // 340: ai_studio_management.AIStudioManagementService.GetAvailableLLMDrivers:output_type -> ai_studio_management.GetAvailableLLMDriversResponse
-	164, // 341: ai_studio_management.AIStudioManagementService.GetAvailableEmbedders:output_type -> ai_studio_management.GetAvailableEmbeddersResponse
-	166, // 342: ai_studio_management.AIStudioManagementService.GetAvailableVectorStores:output_type -> ai_studio_management.GetAvailableVectorStoresResponse
-	169, // 343: ai_studio_management.AIStudioManagementService.WritePluginKV:output_type -> ai_studio_management.WritePluginKVResponse
-	171, // 344: ai_studio_management.AIStudioManagementService.ReadPluginKV:output_type -> ai_studio_management.ReadPluginKVResponse
-	173, // 345: ai_studio_management.AIStudioManagementService.DeletePluginKV:output_type -> ai_studio_management.DeletePluginKVResponse
-	175, // 346: ai_studio_management.AIStudioManagementService.ExecuteTool:output_type -> ai_studio_management.ExecuteToolResponse
-	177, // 347: ai_studio_management.AIStudioManagementService.QueryDatasource:output_type -> ai_studio_management.QueryDatasourceResponse
-	180, // 348: ai_studio_management.AIStudioManagementService.CallLLM:output_type -> ai_studio_management.CallLLMResponse
-	188, // 349: ai_studio_management.AIStudioManagementService.CreateSchedule:output_type -> ai_studio_management.CreateScheduleResponse
-	190, // 350: ai_studio_management.AIStudioManagementService.GetSchedule:output_type -> ai_studio_management.GetScheduleResponse
-	192, // 351: ai_studio_management.AIStudioManagementService.ListSchedules:output_type -> ai_studio_management.ListSchedulesResponse
-	194, // 352: ai_studio_management.AIStudioManagementService.UpdateSchedule:output_type -> ai_studio_management.UpdateScheduleResponse
-	196, // 353: ai_studio_management.AIStudioManagementService.DeleteSchedule:output_type -> ai_studio_management.DeleteScheduleResponse
-	199, // 354: ai_studio_management.AIStudioManagementService.GetLicenseInfo:output_type -> ai_studio_management.GetLicenseInfoResponse
-	272, // [272:355] is the sub-list for method output_type
-	189, // [189:272] is the sub-list for method input_type
-	189, // [189:189] is the sub-list for extension type_name
-	189, // [189:189] is the sub-list for extension extendee
-	0,   // [0:189] is the sub-list for field type_name
+	0,   // 41: ai_studio_management.PatchAppMetadataRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 42: ai_studio_management.ListToolsRequest.context:type_name -> ai_studio_management.PluginContext
+	54,  // 43: ai_studio_management.ListToolsResponse.tools:type_name -> ai_studio_management.ToolInfo
+	0,   // 44: ai_studio_management.GetToolRequest.context:type_name -> ai_studio_management.PluginContext
+	54,  // 45: ai_studio_management.GetToolResponse.tool:type_name -> ai_studio_management.ToolInfo
+	0,   // 46: ai_studio_management.GetToolOperationsRequest.context:type_name -> ai_studio_management.PluginContext
+	55,  // 47: ai_studio_management.GetToolOperationsResponse.operations:type_name -> ai_studio_management.ToolOperation
+	0,   // 48: ai_studio_management.CallToolOperationRequest.context:type_name -> ai_studio_management.PluginContext
+	210, // 49: ai_studio_management.ToolInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 50: ai_studio_management.ToolInfo.updated_at:type_name -> google.protobuf.Timestamp
+	203, // 51: ai_studio_management.ToolInfo.metadata:type_name -> ai_studio_management.ToolInfo.MetadataEntry
+	56,  // 52: ai_studio_management.ToolOperation.parameters:type_name -> ai_studio_management.ToolParameter
+	57,  // 53: ai_studio_management.ToolOperation.request_body:type_name -> ai_studio_management.ToolRequestBody
+	0,   // 54: ai_studio_management.CreateToolRequest.context:type_name -> ai_studio_management.PluginContext
+	54,  // 55: ai_studio_management.CreateToolResponse.tool:type_name -> ai_studio_management.ToolInfo
+	0,   // 56: ai_studio_management.UpdateToolRequest.context:type_name -> ai_studio_management.PluginContext
+	54,  // 57: ai_studio_management.UpdateToolResponse.tool:type_name -> ai_studio_management.ToolInfo
+	0,   // 58: ai_studio_management.DeleteToolRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 59: ai_studio_management.ListDatasourcesRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 60: ai_studio_management.ListDatasourcesResponse.datasources:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 61: ai_studio_management.GetDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 62: ai_studio_management.GetDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 63: ai_studio_management.CreateDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 64: ai_studio_management.CreateDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 65: ai_studio_management.UpdateDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 66: ai_studio_management.UpdateDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 67: ai_studio_management.DeleteDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 68: ai_studio_management.CloneDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 69: ai_studio_management.CloneDatasourceResponse.datasource:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 70: ai_studio_management.SearchDatasourcesRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 71: ai_studio_management.SearchDatasourcesResponse.datasources:type_name -> ai_studio_management.DatasourceInfo
+	0,   // 72: ai_studio_management.ProcessEmbeddingsRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 73: ai_studio_management.GenerateEmbeddingRequest.context:type_name -> ai_studio_management.PluginContext
+	82,  // 74: ai_studio_management.GenerateEmbeddingResponse.vectors:type_name -> ai_studio_management.EmbeddingVector
+	0,   // 75: ai_studio_management.StoreDocumentsRequest.context:type_name -> ai_studio_management.PluginContext
+	84,  // 76: ai_studio_management.StoreDocumentsRequest.documents:type_name -> ai_studio_management.DocumentWithEmbedding
+	204, // 77: ai_studio_management.DocumentWithEmbedding.metadata:type_name -> ai_studio_management.DocumentWithEmbedding.MetadataEntry
+	0,   // 78: ai_studio_management.ProcessAndStoreRequest.context:type_name -> ai_studio_management.PluginContext
+	87,  // 79: ai_studio_management.ProcessAndStoreRequest.chunks:type_name -> ai_studio_management.DocumentChunk
+	205, // 80: ai_studio_management.DocumentChunk.metadata:type_name -> ai_studio_management.DocumentChunk.MetadataEntry
+	0,   // 81: ai_studio_management.DeleteDocumentsByMetadataRequest.context:type_name -> ai_studio_management.PluginContext
+	206, // 82: ai_studio_management.DeleteDocumentsByMetadataRequest.metadata_filter:type_name -> ai_studio_management.DeleteDocumentsByMetadataRequest.MetadataFilterEntry
+	0,   // 83: ai_studio_management.QueryByMetadataOnlyRequest.context:type_name -> ai_studio_management.PluginContext
+	207, // 84: ai_studio_management.QueryByMetadataOnlyRequest.metadata_filter:type_name -> ai_studio_management.QueryByMetadataOnlyRequest.MetadataFilterEntry
+	180, // 85: ai_studio_management.QueryByMetadataOnlyResponse.results:type_name -> ai_studio_management.DatasourceResult
+	0,   // 86: ai_studio_management.ListNamespacesRequest.context:type_name -> ai_studio_management.PluginContext
+	95,  // 87: ai_studio_management.ListNamespacesResponse.namespaces:type_name -> ai_studio_management.NamespaceInfo
+	0,   // 88: ai_studio_management.DeleteNamespaceRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 89: ai_studio_management.QueryByVectorRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 90: ai_studio_management.DatasourceInfo.tags:type_name -> ai_studio_management.TagInfo
+	210, // 91: ai_studio_management.DatasourceInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 92: ai_studio_management.DatasourceInfo.updated_at:type_name -> google.protobuf.Timestamp
+	208, // 93: ai_studio_management.DatasourceInfo.metadata:type_name -> ai_studio_management.DatasourceInfo.MetadataEntry
+	0,   // 94: ai_studio_management.ListDataCataloguesRequest.context:type_name -> ai_studio_management.PluginContext
+	110, // 95: ai_studio_management.ListDataCataloguesResponse.data_catalogues:type_name -> ai_studio_management.DataCatalogueInfo
+	0,   // 96: ai_studio_management.GetDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
+	110, // 97: ai_studio_management.GetDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
+	0,   // 98: ai_studio_management.CreateDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
+	110, // 99: ai_studio_management.CreateDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
+	0,   // 100: ai_studio_management.UpdateDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
+	110, // 101: ai_studio_management.UpdateDataCatalogueResponse.data_catalogue:type_name -> ai_studio_management.DataCatalogueInfo
+	0,   // 102: ai_studio_management.DeleteDataCatalogueRequest.context:type_name -> ai_studio_management.PluginContext
+	99,  // 103: ai_studio_management.DataCatalogueInfo.datasources:type_name -> ai_studio_management.DatasourceInfo
+	123, // 104: ai_studio_management.DataCatalogueInfo.tags:type_name -> ai_studio_management.TagInfo
+	210, // 105: ai_studio_management.DataCatalogueInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 106: ai_studio_management.DataCatalogueInfo.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 107: ai_studio_management.ListTagsRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 108: ai_studio_management.ListTagsResponse.tags:type_name -> ai_studio_management.TagInfo
+	0,   // 109: ai_studio_management.GetTagRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 110: ai_studio_management.GetTagResponse.tag:type_name -> ai_studio_management.TagInfo
+	0,   // 111: ai_studio_management.CreateTagRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 112: ai_studio_management.CreateTagResponse.tag:type_name -> ai_studio_management.TagInfo
+	0,   // 113: ai_studio_management.UpdateTagRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 114: ai_studio_management.UpdateTagResponse.tag:type_name -> ai_studio_management.TagInfo
+	0,   // 115: ai_studio_management.DeleteTagRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 116: ai_studio_management.SearchTagsRequest.context:type_name -> ai_studio_management.PluginContext
+	123, // 117: ai_studio_management.SearchTagsResponse.tags:type_name -> ai_studio_management.TagInfo
+	210, // 118: ai_studio_management.TagInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 119: ai_studio_management.TagInfo.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 120: ai_studio_management.GetChatRecordsPerDayRequest.context:type_name -> ai_studio_management.PluginContext
+	134, // 121: ai_studio_management.GetChatRecordsPerDayResponse.records:type_name -> ai_studio_management.DayRecord
+	0,   // 122: ai_studio_management.GetModelUsageRequest.context:type_name -> ai_studio_management.PluginContext
+	135, // 123: ai_studio_management.GetModelUsageResponse.usage:type_name -> ai_studio_management.ModelUsageRecord
+	0,   // 124: ai_studio_management.GetVendorUsageRequest.context:type_name -> ai_studio_management.PluginContext
+	136, // 125: ai_studio_management.GetVendorUsageResponse.usage:type_name -> ai_studio_management.VendorUsageRecord
+	0,   // 126: ai_studio_management.GetTokenUsagePerAppRequest.context:type_name -> ai_studio_management.PluginContext
+	137, // 127: ai_studio_management.GetTokenUsagePerAppResponse.usage:type_name -> ai_studio_management.AppTokenUsage
+	0,   // 128: ai_studio_management.GetToolUsageStatisticsRequest.context:type_name -> ai_studio_management.PluginContext
+	138, // 129: ai_studio_management.GetToolUsageStatisticsResponse.usage:type_name -> ai_studio_management.ToolUsageRecord
+	0,   // 130: ai_studio_management.ListModelPricesRequest.context:type_name -> ai_studio_management.PluginContext
+	151, // 131: ai_studio_management.ListModelPricesResponse.model_prices:type_name -> ai_studio_management.ModelPriceInfo
+	0,   // 132: ai_studio_management.GetModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
+	151, // 133: ai_studio_management.GetModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
+	0,   // 134: ai_studio_management.CreateModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
+	151, // 135: ai_studio_management.CreateModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
+	0,   // 136: ai_studio_management.UpdateModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
+	151, // 137: ai_studio_management.UpdateModelPriceResponse.model_price:type_name -> ai_studio_management.ModelPriceInfo
+	0,   // 138: ai_studio_management.DeleteModelPriceRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 139: ai_studio_management.GetModelPricesByVendorRequest.context:type_name -> ai_studio_management.PluginContext
+	151, // 140: ai_studio_management.GetModelPricesByVendorResponse.model_prices:type_name -> ai_studio_management.ModelPriceInfo
+	210, // 141: ai_studio_management.ModelPriceInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 142: ai_studio_management.ModelPriceInfo.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 143: ai_studio_management.ListFiltersRequest.context:type_name -> ai_studio_management.PluginContext
+	162, // 144: ai_studio_management.ListFiltersResponse.filters:type_name -> ai_studio_management.FilterInfo
+	0,   // 145: ai_studio_management.GetFilterRequest.context:type_name -> ai_studio_management.PluginContext
+	162, // 146: ai_studio_management.GetFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
+	0,   // 147: ai_studio_management.CreateFilterRequest.context:type_name -> ai_studio_management.PluginContext
+	162, // 148: ai_studio_management.CreateFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
+	0,   // 149: ai_studio_management.UpdateFilterRequest.context:type_name -> ai_studio_management.PluginContext
+	162, // 150: ai_studio_management.UpdateFilterResponse.filter:type_name -> ai_studio_management.FilterInfo
+	0,   // 151: ai_studio_management.DeleteFilterRequest.context:type_name -> ai_studio_management.PluginContext
+	210, // 152: ai_studio_management.FilterInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 153: ai_studio_management.FilterInfo.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 154: ai_studio_management.GetAvailableLLMDriversRequest.context:type_name -> ai_studio_management.PluginContext
+	169, // 155: ai_studio_management.GetAvailableLLMDriversResponse.drivers:type_name -> ai_studio_management.VendorDriverInfo
+	0,   // 156: ai_studio_management.GetAvailableEmbeddersRequest.context:type_name -> ai_studio_management.PluginContext
+	169, // 157: ai_studio_management.GetAvailableEmbeddersResponse.embedders:type_name -> ai_studio_management.VendorDriverInfo
+	0,   // 158: ai_studio_management.GetAvailableVectorStoresRequest.context:type_name -> ai_studio_management.PluginContext
+	169, // 159: ai_studio_management.GetAvailableVectorStoresResponse.vector_stores:type_name -> ai_studio_management.VendorDriverInfo
+	0,   // 160: ai_studio_management.WritePluginKVRequest.context:type_name -> ai_studio_management.PluginContext
+	210, // 161: ai_studio_management.WritePluginKVRequest.expire_at:type_name -> google.protobuf.Timestamp
+	0,   // 162: ai_studio_management.ReadPluginKVRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 163: ai_studio_management.DeletePluginKVRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 164: ai_studio_management.ExecuteToolRequest.context:type_name -> ai_studio_management.PluginContext
+	0,   // 165: ai_studio_management.QueryDatasourceRequest.context:type_name -> ai_studio_management.PluginContext
+	180, // 166: ai_studio_management.QueryDatasourceResponse.results:type_name -> ai_studio_management.DatasourceResult
+	209, // 167: ai_studio_management.DatasourceResult.metadata:type_name -> ai_studio_management.DatasourceResult.MetadataEntry
+	0,   // 168: ai_studio_management.CallLLMRequest.context:type_name -> ai_studio_management.PluginContext
+	183, // 169: ai_studio_management.CallLLMRequest.messages:type_name -> ai_studio_management.LLMMessage
+	184, // 170: ai_studio_management.CallLLMRequest.tools:type_name -> ai_studio_management.LLMTool
+	188, // 171: ai_studio_management.CallLLMResponse.usage:type_name -> ai_studio_management.LLMUsage
+	186, // 172: ai_studio_management.CallLLMResponse.tool_calls:type_name -> ai_studio_management.LLMToolCall
+	185, // 173: ai_studio_management.LLMTool.function:type_name -> ai_studio_management.LLMFunction
+	187, // 174: ai_studio_management.LLMToolCall.function:type_name -> ai_studio_management.LLMFunctionCall
+	0,   // 175: ai_studio_management.CreateScheduleRequest.context:type_name -> ai_studio_management.PluginContext
+	199, // 176: ai_studio_management.CreateScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
+	0,   // 177: ai_studio_management.GetScheduleRequest.context:type_name -> ai_studio_management.PluginContext
+	199, // 178: ai_studio_management.GetScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
+	0,   // 179: ai_studio_management.ListSchedulesRequest.context:type_name -> ai_studio_management.PluginContext
+	199, // 180: ai_studio_management.ListSchedulesResponse.schedules:type_name -> ai_studio_management.ScheduleInfo
+	0,   // 181: ai_studio_management.UpdateScheduleRequest.context:type_name -> ai_studio_management.PluginContext
+	199, // 182: ai_studio_management.UpdateScheduleResponse.schedule:type_name -> ai_studio_management.ScheduleInfo
+	0,   // 183: ai_studio_management.DeleteScheduleRequest.context:type_name -> ai_studio_management.PluginContext
+	210, // 184: ai_studio_management.ScheduleInfo.last_run:type_name -> google.protobuf.Timestamp
+	210, // 185: ai_studio_management.ScheduleInfo.next_run:type_name -> google.protobuf.Timestamp
+	210, // 186: ai_studio_management.ScheduleInfo.created_at:type_name -> google.protobuf.Timestamp
+	210, // 187: ai_studio_management.ScheduleInfo.updated_at:type_name -> google.protobuf.Timestamp
+	0,   // 188: ai_studio_management.GetLicenseInfoRequest.context:type_name -> ai_studio_management.PluginContext
+	210, // 189: ai_studio_management.GetLicenseInfoResponse.expires_at:type_name -> google.protobuf.Timestamp
+	1,   // 190: ai_studio_management.AIStudioManagementService.ListPlugins:input_type -> ai_studio_management.ListPluginsRequest
+	3,   // 191: ai_studio_management.AIStudioManagementService.GetPlugin:input_type -> ai_studio_management.GetPluginRequest
+	5,   // 192: ai_studio_management.AIStudioManagementService.UpdatePluginConfig:input_type -> ai_studio_management.UpdatePluginConfigRequest
+	8,   // 193: ai_studio_management.AIStudioManagementService.ListLLMs:input_type -> ai_studio_management.ListLLMsRequest
+	10,  // 194: ai_studio_management.AIStudioManagementService.GetLLM:input_type -> ai_studio_management.GetLLMRequest
+	12,  // 195: ai_studio_management.AIStudioManagementService.GetLLMPlugins:input_type -> ai_studio_management.GetLLMPluginsRequest
+	15,  // 196: ai_studio_management.AIStudioManagementService.CreateLLM:input_type -> ai_studio_management.CreateLLMRequest
+	17,  // 197: ai_studio_management.AIStudioManagementService.UpdateLLM:input_type -> ai_studio_management.UpdateLLMRequest
+	19,  // 198: ai_studio_management.AIStudioManagementService.DeleteLLM:input_type -> ai_studio_management.DeleteLLMRequest
+	21,  // 199: ai_studio_management.AIStudioManagementService.UpdateLLMPlugins:input_type -> ai_studio_management.UpdateLLMPluginsRequest
+	23,  // 200: ai_studio_management.AIStudioManagementService.GetAnalyticsSummary:input_type -> ai_studio_management.GetAnalyticsSummaryRequest
+	25,  // 201: ai_studio_management.AIStudioManagementService.GetUsageStatistics:input_type -> ai_studio_management.GetUsageStatisticsRequest
+	27,  // 202: ai_studio_management.AIStudioManagementService.GetCostAnalysis:input_type -> ai_studio_management.GetCostAnalysisRequest
+	124, // 203: ai_studio_management.AIStudioManagementService.GetChatRecordsPerDay:input_type -> ai_studio_management.GetChatRecordsPerDayRequest
+	126, // 204: ai_studio_management.AIStudioManagementService.GetModelUsage:input_type -> ai_studio_management.GetModelUsageRequest
+	128, // 205: ai_studio_management.AIStudioManagementService.GetVendorUsage:input_type -> ai_studio_management.GetVendorUsageRequest
+	130, // 206: ai_studio_management.AIStudioManagementService.GetTokenUsagePerApp:input_type -> ai_studio_management.GetTokenUsagePerAppRequest
+	132, // 207: ai_studio_management.AIStudioManagementService.GetToolUsageStatistics:input_type -> ai_studio_management.GetToolUsageStatisticsRequest
+	33,  // 208: ai_studio_management.AIStudioManagementService.ListApps:input_type -> ai_studio_management.ListAppsRequest
+	35,  // 209: ai_studio_management.AIStudioManagementService.GetApp:input_type -> ai_studio_management.GetAppRequest
+	38,  // 210: ai_studio_management.AIStudioManagementService.CreateApp:input_type -> ai_studio_management.CreateAppRequest
+	40,  // 211: ai_studio_management.AIStudioManagementService.UpdateApp:input_type -> ai_studio_management.UpdateAppRequest
+	42,  // 212: ai_studio_management.AIStudioManagementService.DeleteApp:input_type -> ai_studio_management.DeleteAppRequest
+	44,  // 213: ai_studio_management.AIStudioManagementService.PatchAppMetadata:input_type -> ai_studio_management.PatchAppMetadataRequest
+	46,  // 214: ai_studio_management.AIStudioManagementService.ListTools:input_type -> ai_studio_management.ListToolsRequest
+	48,  // 215: ai_studio_management.AIStudioManagementService.GetTool:input_type -> ai_studio_management.GetToolRequest
+	50,  // 216: ai_studio_management.AIStudioManagementService.GetToolOperations:input_type -> ai_studio_management.GetToolOperationsRequest
+	52,  // 217: ai_studio_management.AIStudioManagementService.CallToolOperation:input_type -> ai_studio_management.CallToolOperationRequest
+	58,  // 218: ai_studio_management.AIStudioManagementService.CreateTool:input_type -> ai_studio_management.CreateToolRequest
+	60,  // 219: ai_studio_management.AIStudioManagementService.UpdateTool:input_type -> ai_studio_management.UpdateToolRequest
+	62,  // 220: ai_studio_management.AIStudioManagementService.DeleteTool:input_type -> ai_studio_management.DeleteToolRequest
+	64,  // 221: ai_studio_management.AIStudioManagementService.ListDatasources:input_type -> ai_studio_management.ListDatasourcesRequest
+	66,  // 222: ai_studio_management.AIStudioManagementService.GetDatasource:input_type -> ai_studio_management.GetDatasourceRequest
+	68,  // 223: ai_studio_management.AIStudioManagementService.CreateDatasource:input_type -> ai_studio_management.CreateDatasourceRequest
+	70,  // 224: ai_studio_management.AIStudioManagementService.UpdateDatasource:input_type -> ai_studio_management.UpdateDatasourceRequest
+	72,  // 225: ai_studio_management.AIStudioManagementService.DeleteDatasource:input_type -> ai_studio_management.DeleteDatasourceRequest
+	74,  // 226: ai_studio_management.AIStudioManagementService.CloneDatasource:input_type -> ai_studio_management.CloneDatasourceRequest
+	76,  // 227: ai_studio_management.AIStudioManagementService.SearchDatasources:input_type -> ai_studio_management.SearchDatasourcesRequest
+	78,  // 228: ai_studio_management.AIStudioManagementService.ProcessDatasourceEmbeddings:input_type -> ai_studio_management.ProcessEmbeddingsRequest
+	80,  // 229: ai_studio_management.AIStudioManagementService.GenerateEmbedding:input_type -> ai_studio_management.GenerateEmbeddingRequest
+	83,  // 230: ai_studio_management.AIStudioManagementService.StoreDocuments:input_type -> ai_studio_management.StoreDocumentsRequest
+	86,  // 231: ai_studio_management.AIStudioManagementService.ProcessAndStoreDocuments:input_type -> ai_studio_management.ProcessAndStoreRequest
+	98,  // 232: ai_studio_management.AIStudioManagementService.QueryDatasourceByVector:input_type -> ai_studio_management.QueryByVectorRequest
+	89,  // 233: ai_studio_management.AIStudioManagementService.DeleteDocumentsByMetadata:input_type -> ai_studio_management.DeleteDocumentsByMetadataRequest
+	91,  // 234: ai_studio_management.AIStudioManagementService.QueryByMetadataOnly:input_type -> ai_studio_management.QueryByMetadataOnlyRequest
+	93,  // 235: ai_studio_management.AIStudioManagementService.ListNamespaces:input_type -> ai_studio_management.ListNamespacesRequest
+	96,  // 236: ai_studio_management.AIStudioManagementService.DeleteNamespace:input_type -> ai_studio_management.DeleteNamespaceRequest
+	100, // 237: ai_studio_management.AIStudioManagementService.ListDataCatalogues:input_type -> ai_studio_management.ListDataCataloguesRequest
+	102, // 238: ai_studio_management.AIStudioManagementService.GetDataCatalogue:input_type -> ai_studio_management.GetDataCatalogueRequest
+	104, // 239: ai_studio_management.AIStudioManagementService.CreateDataCatalogue:input_type -> ai_studio_management.CreateDataCatalogueRequest
+	106, // 240: ai_studio_management.AIStudioManagementService.UpdateDataCatalogue:input_type -> ai_studio_management.UpdateDataCatalogueRequest
+	108, // 241: ai_studio_management.AIStudioManagementService.DeleteDataCatalogue:input_type -> ai_studio_management.DeleteDataCatalogueRequest
+	111, // 242: ai_studio_management.AIStudioManagementService.ListTags:input_type -> ai_studio_management.ListTagsRequest
+	113, // 243: ai_studio_management.AIStudioManagementService.GetTag:input_type -> ai_studio_management.GetTagRequest
+	115, // 244: ai_studio_management.AIStudioManagementService.CreateTag:input_type -> ai_studio_management.CreateTagRequest
+	117, // 245: ai_studio_management.AIStudioManagementService.UpdateTag:input_type -> ai_studio_management.UpdateTagRequest
+	119, // 246: ai_studio_management.AIStudioManagementService.DeleteTag:input_type -> ai_studio_management.DeleteTagRequest
+	121, // 247: ai_studio_management.AIStudioManagementService.SearchTags:input_type -> ai_studio_management.SearchTagsRequest
+	139, // 248: ai_studio_management.AIStudioManagementService.ListModelPrices:input_type -> ai_studio_management.ListModelPricesRequest
+	141, // 249: ai_studio_management.AIStudioManagementService.GetModelPrice:input_type -> ai_studio_management.GetModelPriceRequest
+	143, // 250: ai_studio_management.AIStudioManagementService.CreateModelPrice:input_type -> ai_studio_management.CreateModelPriceRequest
+	145, // 251: ai_studio_management.AIStudioManagementService.UpdateModelPrice:input_type -> ai_studio_management.UpdateModelPriceRequest
+	147, // 252: ai_studio_management.AIStudioManagementService.DeleteModelPrice:input_type -> ai_studio_management.DeleteModelPriceRequest
+	149, // 253: ai_studio_management.AIStudioManagementService.GetModelPricesByVendor:input_type -> ai_studio_management.GetModelPricesByVendorRequest
+	152, // 254: ai_studio_management.AIStudioManagementService.ListFilters:input_type -> ai_studio_management.ListFiltersRequest
+	154, // 255: ai_studio_management.AIStudioManagementService.GetFilter:input_type -> ai_studio_management.GetFilterRequest
+	156, // 256: ai_studio_management.AIStudioManagementService.CreateFilter:input_type -> ai_studio_management.CreateFilterRequest
+	158, // 257: ai_studio_management.AIStudioManagementService.UpdateFilter:input_type -> ai_studio_management.UpdateFilterRequest
+	160, // 258: ai_studio_management.AIStudioManagementService.DeleteFilter:input_type -> ai_studio_management.DeleteFilterRequest
+	163, // 259: ai_studio_management.AIStudioManagementService.GetAvailableLLMDrivers:input_type -> ai_studio_management.GetAvailableLLMDriversRequest
+	165, // 260: ai_studio_management.AIStudioManagementService.GetAvailableEmbedders:input_type -> ai_studio_management.GetAvailableEmbeddersRequest
+	167, // 261: ai_studio_management.AIStudioManagementService.GetAvailableVectorStores:input_type -> ai_studio_management.GetAvailableVectorStoresRequest
+	170, // 262: ai_studio_management.AIStudioManagementService.WritePluginKV:input_type -> ai_studio_management.WritePluginKVRequest
+	172, // 263: ai_studio_management.AIStudioManagementService.ReadPluginKV:input_type -> ai_studio_management.ReadPluginKVRequest
+	174, // 264: ai_studio_management.AIStudioManagementService.DeletePluginKV:input_type -> ai_studio_management.DeletePluginKVRequest
+	176, // 265: ai_studio_management.AIStudioManagementService.ExecuteTool:input_type -> ai_studio_management.ExecuteToolRequest
+	178, // 266: ai_studio_management.AIStudioManagementService.QueryDatasource:input_type -> ai_studio_management.QueryDatasourceRequest
+	181, // 267: ai_studio_management.AIStudioManagementService.CallLLM:input_type -> ai_studio_management.CallLLMRequest
+	189, // 268: ai_studio_management.AIStudioManagementService.CreateSchedule:input_type -> ai_studio_management.CreateScheduleRequest
+	191, // 269: ai_studio_management.AIStudioManagementService.GetSchedule:input_type -> ai_studio_management.GetScheduleRequest
+	193, // 270: ai_studio_management.AIStudioManagementService.ListSchedules:input_type -> ai_studio_management.ListSchedulesRequest
+	195, // 271: ai_studio_management.AIStudioManagementService.UpdateSchedule:input_type -> ai_studio_management.UpdateScheduleRequest
+	197, // 272: ai_studio_management.AIStudioManagementService.DeleteSchedule:input_type -> ai_studio_management.DeleteScheduleRequest
+	200, // 273: ai_studio_management.AIStudioManagementService.GetLicenseInfo:input_type -> ai_studio_management.GetLicenseInfoRequest
+	2,   // 274: ai_studio_management.AIStudioManagementService.ListPlugins:output_type -> ai_studio_management.ListPluginsResponse
+	4,   // 275: ai_studio_management.AIStudioManagementService.GetPlugin:output_type -> ai_studio_management.GetPluginResponse
+	6,   // 276: ai_studio_management.AIStudioManagementService.UpdatePluginConfig:output_type -> ai_studio_management.UpdatePluginConfigResponse
+	9,   // 277: ai_studio_management.AIStudioManagementService.ListLLMs:output_type -> ai_studio_management.ListLLMsResponse
+	11,  // 278: ai_studio_management.AIStudioManagementService.GetLLM:output_type -> ai_studio_management.GetLLMResponse
+	13,  // 279: ai_studio_management.AIStudioManagementService.GetLLMPlugins:output_type -> ai_studio_management.GetLLMPluginsResponse
+	16,  // 280: ai_studio_management.AIStudioManagementService.CreateLLM:output_type -> ai_studio_management.CreateLLMResponse
+	18,  // 281: ai_studio_management.AIStudioManagementService.UpdateLLM:output_type -> ai_studio_management.UpdateLLMResponse
+	20,  // 282: ai_studio_management.AIStudioManagementService.DeleteLLM:output_type -> ai_studio_management.DeleteLLMResponse
+	22,  // 283: ai_studio_management.AIStudioManagementService.UpdateLLMPlugins:output_type -> ai_studio_management.UpdateLLMPluginsResponse
+	24,  // 284: ai_studio_management.AIStudioManagementService.GetAnalyticsSummary:output_type -> ai_studio_management.GetAnalyticsSummaryResponse
+	26,  // 285: ai_studio_management.AIStudioManagementService.GetUsageStatistics:output_type -> ai_studio_management.GetUsageStatisticsResponse
+	28,  // 286: ai_studio_management.AIStudioManagementService.GetCostAnalysis:output_type -> ai_studio_management.GetCostAnalysisResponse
+	125, // 287: ai_studio_management.AIStudioManagementService.GetChatRecordsPerDay:output_type -> ai_studio_management.GetChatRecordsPerDayResponse
+	127, // 288: ai_studio_management.AIStudioManagementService.GetModelUsage:output_type -> ai_studio_management.GetModelUsageResponse
+	129, // 289: ai_studio_management.AIStudioManagementService.GetVendorUsage:output_type -> ai_studio_management.GetVendorUsageResponse
+	131, // 290: ai_studio_management.AIStudioManagementService.GetTokenUsagePerApp:output_type -> ai_studio_management.GetTokenUsagePerAppResponse
+	133, // 291: ai_studio_management.AIStudioManagementService.GetToolUsageStatistics:output_type -> ai_studio_management.GetToolUsageStatisticsResponse
+	34,  // 292: ai_studio_management.AIStudioManagementService.ListApps:output_type -> ai_studio_management.ListAppsResponse
+	36,  // 293: ai_studio_management.AIStudioManagementService.GetApp:output_type -> ai_studio_management.GetAppResponse
+	39,  // 294: ai_studio_management.AIStudioManagementService.CreateApp:output_type -> ai_studio_management.CreateAppResponse
+	41,  // 295: ai_studio_management.AIStudioManagementService.UpdateApp:output_type -> ai_studio_management.UpdateAppResponse
+	43,  // 296: ai_studio_management.AIStudioManagementService.DeleteApp:output_type -> ai_studio_management.DeleteAppResponse
+	45,  // 297: ai_studio_management.AIStudioManagementService.PatchAppMetadata:output_type -> ai_studio_management.PatchAppMetadataResponse
+	47,  // 298: ai_studio_management.AIStudioManagementService.ListTools:output_type -> ai_studio_management.ListToolsResponse
+	49,  // 299: ai_studio_management.AIStudioManagementService.GetTool:output_type -> ai_studio_management.GetToolResponse
+	51,  // 300: ai_studio_management.AIStudioManagementService.GetToolOperations:output_type -> ai_studio_management.GetToolOperationsResponse
+	53,  // 301: ai_studio_management.AIStudioManagementService.CallToolOperation:output_type -> ai_studio_management.CallToolOperationResponse
+	59,  // 302: ai_studio_management.AIStudioManagementService.CreateTool:output_type -> ai_studio_management.CreateToolResponse
+	61,  // 303: ai_studio_management.AIStudioManagementService.UpdateTool:output_type -> ai_studio_management.UpdateToolResponse
+	63,  // 304: ai_studio_management.AIStudioManagementService.DeleteTool:output_type -> ai_studio_management.DeleteToolResponse
+	65,  // 305: ai_studio_management.AIStudioManagementService.ListDatasources:output_type -> ai_studio_management.ListDatasourcesResponse
+	67,  // 306: ai_studio_management.AIStudioManagementService.GetDatasource:output_type -> ai_studio_management.GetDatasourceResponse
+	69,  // 307: ai_studio_management.AIStudioManagementService.CreateDatasource:output_type -> ai_studio_management.CreateDatasourceResponse
+	71,  // 308: ai_studio_management.AIStudioManagementService.UpdateDatasource:output_type -> ai_studio_management.UpdateDatasourceResponse
+	73,  // 309: ai_studio_management.AIStudioManagementService.DeleteDatasource:output_type -> ai_studio_management.DeleteDatasourceResponse
+	75,  // 310: ai_studio_management.AIStudioManagementService.CloneDatasource:output_type -> ai_studio_management.CloneDatasourceResponse
+	77,  // 311: ai_studio_management.AIStudioManagementService.SearchDatasources:output_type -> ai_studio_management.SearchDatasourcesResponse
+	79,  // 312: ai_studio_management.AIStudioManagementService.ProcessDatasourceEmbeddings:output_type -> ai_studio_management.ProcessEmbeddingsResponse
+	81,  // 313: ai_studio_management.AIStudioManagementService.GenerateEmbedding:output_type -> ai_studio_management.GenerateEmbeddingResponse
+	85,  // 314: ai_studio_management.AIStudioManagementService.StoreDocuments:output_type -> ai_studio_management.StoreDocumentsResponse
+	88,  // 315: ai_studio_management.AIStudioManagementService.ProcessAndStoreDocuments:output_type -> ai_studio_management.ProcessAndStoreResponse
+	179, // 316: ai_studio_management.AIStudioManagementService.QueryDatasourceByVector:output_type -> ai_studio_management.QueryDatasourceResponse
+	90,  // 317: ai_studio_management.AIStudioManagementService.DeleteDocumentsByMetadata:output_type -> ai_studio_management.DeleteDocumentsByMetadataResponse
+	92,  // 318: ai_studio_management.AIStudioManagementService.QueryByMetadataOnly:output_type -> ai_studio_management.QueryByMetadataOnlyResponse
+	94,  // 319: ai_studio_management.AIStudioManagementService.ListNamespaces:output_type -> ai_studio_management.ListNamespacesResponse
+	97,  // 320: ai_studio_management.AIStudioManagementService.DeleteNamespace:output_type -> ai_studio_management.DeleteNamespaceResponse
+	101, // 321: ai_studio_management.AIStudioManagementService.ListDataCatalogues:output_type -> ai_studio_management.ListDataCataloguesResponse
+	103, // 322: ai_studio_management.AIStudioManagementService.GetDataCatalogue:output_type -> ai_studio_management.GetDataCatalogueResponse
+	105, // 323: ai_studio_management.AIStudioManagementService.CreateDataCatalogue:output_type -> ai_studio_management.CreateDataCatalogueResponse
+	107, // 324: ai_studio_management.AIStudioManagementService.UpdateDataCatalogue:output_type -> ai_studio_management.UpdateDataCatalogueResponse
+	109, // 325: ai_studio_management.AIStudioManagementService.DeleteDataCatalogue:output_type -> ai_studio_management.DeleteDataCatalogueResponse
+	112, // 326: ai_studio_management.AIStudioManagementService.ListTags:output_type -> ai_studio_management.ListTagsResponse
+	114, // 327: ai_studio_management.AIStudioManagementService.GetTag:output_type -> ai_studio_management.GetTagResponse
+	116, // 328: ai_studio_management.AIStudioManagementService.CreateTag:output_type -> ai_studio_management.CreateTagResponse
+	118, // 329: ai_studio_management.AIStudioManagementService.UpdateTag:output_type -> ai_studio_management.UpdateTagResponse
+	120, // 330: ai_studio_management.AIStudioManagementService.DeleteTag:output_type -> ai_studio_management.DeleteTagResponse
+	122, // 331: ai_studio_management.AIStudioManagementService.SearchTags:output_type -> ai_studio_management.SearchTagsResponse
+	140, // 332: ai_studio_management.AIStudioManagementService.ListModelPrices:output_type -> ai_studio_management.ListModelPricesResponse
+	142, // 333: ai_studio_management.AIStudioManagementService.GetModelPrice:output_type -> ai_studio_management.GetModelPriceResponse
+	144, // 334: ai_studio_management.AIStudioManagementService.CreateModelPrice:output_type -> ai_studio_management.CreateModelPriceResponse
+	146, // 335: ai_studio_management.AIStudioManagementService.UpdateModelPrice:output_type -> ai_studio_management.UpdateModelPriceResponse
+	148, // 336: ai_studio_management.AIStudioManagementService.DeleteModelPrice:output_type -> ai_studio_management.DeleteModelPriceResponse
+	150, // 337: ai_studio_management.AIStudioManagementService.GetModelPricesByVendor:output_type -> ai_studio_management.GetModelPricesByVendorResponse
+	153, // 338: ai_studio_management.AIStudioManagementService.ListFilters:output_type -> ai_studio_management.ListFiltersResponse
+	155, // 339: ai_studio_management.AIStudioManagementService.GetFilter:output_type -> ai_studio_management.GetFilterResponse
+	157, // 340: ai_studio_management.AIStudioManagementService.CreateFilter:output_type -> ai_studio_management.CreateFilterResponse
+	159, // 341: ai_studio_management.AIStudioManagementService.UpdateFilter:output_type -> ai_studio_management.UpdateFilterResponse
+	161, // 342: ai_studio_management.AIStudioManagementService.DeleteFilter:output_type -> ai_studio_management.DeleteFilterResponse
+	164, // 343: ai_studio_management.AIStudioManagementService.GetAvailableLLMDrivers:output_type -> ai_studio_management.GetAvailableLLMDriversResponse
+	166, // 344: ai_studio_management.AIStudioManagementService.GetAvailableEmbedders:output_type -> ai_studio_management.GetAvailableEmbeddersResponse
+	168, // 345: ai_studio_management.AIStudioManagementService.GetAvailableVectorStores:output_type -> ai_studio_management.GetAvailableVectorStoresResponse
+	171, // 346: ai_studio_management.AIStudioManagementService.WritePluginKV:output_type -> ai_studio_management.WritePluginKVResponse
+	173, // 347: ai_studio_management.AIStudioManagementService.ReadPluginKV:output_type -> ai_studio_management.ReadPluginKVResponse
+	175, // 348: ai_studio_management.AIStudioManagementService.DeletePluginKV:output_type -> ai_studio_management.DeletePluginKVResponse
+	177, // 349: ai_studio_management.AIStudioManagementService.ExecuteTool:output_type -> ai_studio_management.ExecuteToolResponse
+	179, // 350: ai_studio_management.AIStudioManagementService.QueryDatasource:output_type -> ai_studio_management.QueryDatasourceResponse
+	182, // 351: ai_studio_management.AIStudioManagementService.CallLLM:output_type -> ai_studio_management.CallLLMResponse
+	190, // 352: ai_studio_management.AIStudioManagementService.CreateSchedule:output_type -> ai_studio_management.CreateScheduleResponse
+	192, // 353: ai_studio_management.AIStudioManagementService.GetSchedule:output_type -> ai_studio_management.GetScheduleResponse
+	194, // 354: ai_studio_management.AIStudioManagementService.ListSchedules:output_type -> ai_studio_management.ListSchedulesResponse
+	196, // 355: ai_studio_management.AIStudioManagementService.UpdateSchedule:output_type -> ai_studio_management.UpdateScheduleResponse
+	198, // 356: ai_studio_management.AIStudioManagementService.DeleteSchedule:output_type -> ai_studio_management.DeleteScheduleResponse
+	201, // 357: ai_studio_management.AIStudioManagementService.GetLicenseInfo:output_type -> ai_studio_management.GetLicenseInfoResponse
+	274, // [274:358] is the sub-list for method output_type
+	190, // [190:274] is the sub-list for method input_type
+	190, // [190:190] is the sub-list for extension type_name
+	190, // [190:190] is the sub-list for extension extendee
+	0,   // [0:190] is the sub-list for field type_name
 }
 
 func init() { file_proto_ai_studio_management_ai_studio_management_proto_init() }
@@ -14882,20 +15047,20 @@ func file_proto_ai_studio_management_ai_studio_management_proto_init() {
 	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[37].OneofWrappers = []any{}
 	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[38].OneofWrappers = []any{}
 	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[40].OneofWrappers = []any{}
-	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[44].OneofWrappers = []any{}
-	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[53].OneofWrappers = []any{}
-	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[62].OneofWrappers = []any{}
-	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[122].OneofWrappers = []any{}
+	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[46].OneofWrappers = []any{}
+	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[55].OneofWrappers = []any{}
+	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[64].OneofWrappers = []any{}
 	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[124].OneofWrappers = []any{}
 	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[126].OneofWrappers = []any{}
-	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[193].OneofWrappers = []any{}
+	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[128].OneofWrappers = []any{}
+	file_proto_ai_studio_management_ai_studio_management_proto_msgTypes[195].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_ai_studio_management_ai_studio_management_proto_rawDesc), len(file_proto_ai_studio_management_ai_studio_management_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   208,
+			NumMessages:   210,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/ai_studio_management/ai_studio_management.proto
+++ b/proto/ai_studio_management/ai_studio_management.proto
@@ -41,6 +41,7 @@ service AIStudioManagementService {
     rpc CreateApp(CreateAppRequest) returns (CreateAppResponse);
     rpc UpdateApp(UpdateAppRequest) returns (UpdateAppResponse);
     rpc DeleteApp(DeleteAppRequest) returns (DeleteAppResponse);
+    rpc PatchAppMetadata(PatchAppMetadataRequest) returns (PatchAppMetadataResponse);
 
     // Tool Management Operations (High Priority)
     rpc ListTools(ListToolsRequest) returns (ListToolsResponse);
@@ -403,6 +404,9 @@ message ListAppsRequest {
     // Pagination
     int32 page = 4;
     int32 limit = 5;
+
+    // Owner filtering
+    optional uint32 user_id = 6;
 }
 
 message ListAppsResponse {
@@ -480,6 +484,21 @@ message DeleteAppRequest {
 message DeleteAppResponse {
     bool success = 1;
     string message = 2;
+}
+
+// PatchAppMetadata atomically updates a single metadata key on an app
+message PatchAppMetadataRequest {
+    PluginContext context = 1;
+    uint32 app_id = 2;
+    string key = 3;       // Metadata key to set or delete
+    string value = 4;     // JSON-encoded value (ignored if delete=true)
+    bool delete = 5;      // If true, removes the key instead of setting it
+}
+
+message PatchAppMetadataResponse {
+    bool success = 1;
+    string message = 2;
+    string metadata = 3;  // Full metadata JSON after the operation
 }
 
 // Tool Management Messages

--- a/proto/ai_studio_management/ai_studio_management_grpc.pb.go
+++ b/proto/ai_studio_management/ai_studio_management_grpc.pb.go
@@ -42,6 +42,7 @@ const (
 	AIStudioManagementService_CreateApp_FullMethodName                   = "/ai_studio_management.AIStudioManagementService/CreateApp"
 	AIStudioManagementService_UpdateApp_FullMethodName                   = "/ai_studio_management.AIStudioManagementService/UpdateApp"
 	AIStudioManagementService_DeleteApp_FullMethodName                   = "/ai_studio_management.AIStudioManagementService/DeleteApp"
+	AIStudioManagementService_PatchAppMetadata_FullMethodName            = "/ai_studio_management.AIStudioManagementService/PatchAppMetadata"
 	AIStudioManagementService_ListTools_FullMethodName                   = "/ai_studio_management.AIStudioManagementService/ListTools"
 	AIStudioManagementService_GetTool_FullMethodName                     = "/ai_studio_management.AIStudioManagementService/GetTool"
 	AIStudioManagementService_GetToolOperations_FullMethodName           = "/ai_studio_management.AIStudioManagementService/GetToolOperations"
@@ -139,6 +140,7 @@ type AIStudioManagementServiceClient interface {
 	CreateApp(ctx context.Context, in *CreateAppRequest, opts ...grpc.CallOption) (*CreateAppResponse, error)
 	UpdateApp(ctx context.Context, in *UpdateAppRequest, opts ...grpc.CallOption) (*UpdateAppResponse, error)
 	DeleteApp(ctx context.Context, in *DeleteAppRequest, opts ...grpc.CallOption) (*DeleteAppResponse, error)
+	PatchAppMetadata(ctx context.Context, in *PatchAppMetadataRequest, opts ...grpc.CallOption) (*PatchAppMetadataResponse, error)
 	// Tool Management Operations (High Priority)
 	ListTools(ctx context.Context, in *ListToolsRequest, opts ...grpc.CallOption) (*ListToolsResponse, error)
 	GetTool(ctx context.Context, in *GetToolRequest, opts ...grpc.CallOption) (*GetToolResponse, error)
@@ -447,6 +449,16 @@ func (c *aIStudioManagementServiceClient) DeleteApp(ctx context.Context, in *Del
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteAppResponse)
 	err := c.cc.Invoke(ctx, AIStudioManagementService_DeleteApp_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *aIStudioManagementServiceClient) PatchAppMetadata(ctx context.Context, in *PatchAppMetadataRequest, opts ...grpc.CallOption) (*PatchAppMetadataResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PatchAppMetadataResponse)
+	err := c.cc.Invoke(ctx, AIStudioManagementService_PatchAppMetadata_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1097,6 +1109,7 @@ type AIStudioManagementServiceServer interface {
 	CreateApp(context.Context, *CreateAppRequest) (*CreateAppResponse, error)
 	UpdateApp(context.Context, *UpdateAppRequest) (*UpdateAppResponse, error)
 	DeleteApp(context.Context, *DeleteAppRequest) (*DeleteAppResponse, error)
+	PatchAppMetadata(context.Context, *PatchAppMetadataRequest) (*PatchAppMetadataResponse, error)
 	// Tool Management Operations (High Priority)
 	ListTools(context.Context, *ListToolsRequest) (*ListToolsResponse, error)
 	GetTool(context.Context, *GetToolRequest) (*GetToolResponse, error)
@@ -1249,6 +1262,9 @@ func (UnimplementedAIStudioManagementServiceServer) UpdateApp(context.Context, *
 }
 func (UnimplementedAIStudioManagementServiceServer) DeleteApp(context.Context, *DeleteAppRequest) (*DeleteAppResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteApp not implemented")
+}
+func (UnimplementedAIStudioManagementServiceServer) PatchAppMetadata(context.Context, *PatchAppMetadataRequest) (*PatchAppMetadataResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PatchAppMetadata not implemented")
 }
 func (UnimplementedAIStudioManagementServiceServer) ListTools(context.Context, *ListToolsRequest) (*ListToolsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListTools not implemented")
@@ -1862,6 +1878,24 @@ func _AIStudioManagementService_DeleteApp_Handler(srv interface{}, ctx context.C
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(AIStudioManagementServiceServer).DeleteApp(ctx, req.(*DeleteAppRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AIStudioManagementService_PatchAppMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PatchAppMetadataRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AIStudioManagementServiceServer).PatchAppMetadata(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AIStudioManagementService_PatchAppMetadata_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AIStudioManagementServiceServer).PatchAppMetadata(ctx, req.(*PatchAppMetadataRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3037,6 +3071,10 @@ var AIStudioManagementService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteApp",
 			Handler:    _AIStudioManagementService_DeleteApp_Handler,
+		},
+		{
+			MethodName: "PatchAppMetadata",
+			Handler:    _AIStudioManagementService_PatchAppMetadata_Handler,
 		},
 		{
 			MethodName: "ListTools",

--- a/services/app.go
+++ b/services/app.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/TykTechnologies/midsommar/v2/config"
 	"github.com/TykTechnologies/midsommar/v2/models"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var ERRPrivacyScoreMismatch = errors.New("Datasources have higher privacy requirements than the selected LLMs")
@@ -263,6 +265,53 @@ func (s *Service) UpdateApp(id uint, name, description string, userID uint, data
 	}
 
 	return app, nil
+}
+
+// PatchAppMetadata atomically updates a single metadata key on an app.
+// If deleteKey is true, the key is removed. Otherwise, the value (JSON string) is set.
+// Uses a database transaction for safe concurrent access. PostgreSQL uses FOR UPDATE
+// row locking; SQLite serializes transactions implicitly.
+func (s *Service) PatchAppMetadata(appID uint, key, value string, deleteKey bool) (map[string]interface{}, error) {
+	var resultMetadata map[string]interface{}
+
+	err := s.DB.Transaction(func(tx *gorm.DB) error {
+		var app models.App
+		query := tx
+		// Use FOR UPDATE row locking on PostgreSQL; skip on SQLite (not supported)
+		if s.DB.Dialector.Name() == "postgres" {
+			query = query.Clauses(clause.Locking{Strength: "UPDATE"})
+		}
+		if err := query.First(&app, appID).Error; err != nil {
+			return err
+		}
+
+		if app.Metadata == nil {
+			app.Metadata = make(map[string]interface{})
+		}
+
+		if deleteKey {
+			delete(app.Metadata, key)
+		} else {
+			// Parse the JSON value to store typed data
+			var parsed interface{}
+			if err := json.Unmarshal([]byte(value), &parsed); err != nil {
+				// If not valid JSON, store as plain string
+				app.Metadata[key] = value
+			} else {
+				app.Metadata[key] = parsed
+			}
+		}
+
+		// Use Save to properly trigger GORM's JSON serializer for the metadata field
+		if err := tx.Save(&app).Error; err != nil {
+			return err
+		}
+
+		resultMetadata = app.Metadata
+		return nil
+	})
+
+	return resultMetadata, err
 }
 
 // Helper function to convert string IDs to uint IDs
@@ -702,9 +751,13 @@ func (s *Service) SearchApps(searchTerm string, pageSize, pageNumber int, all bo
 }
 
 // ListAppsWithFilters returns a paginated list of apps with namespace and active status filtering
-func (s *Service) ListAppsWithFilters(pageSize, pageNumber int, all bool, sort, namespace string, isActive *bool) (models.Apps, int64, int, error) {
+func (s *Service) ListAppsWithFilters(pageSize, pageNumber int, all bool, sort, namespace string, isActive *bool, userID ...uint) (models.Apps, int64, int, error) {
 	var apps models.Apps
-	totalCount, totalPages, err := apps.ListWithFilters(s.DB, pageSize, pageNumber, all, sort, namespace, isActive)
+	var userIDPtr *uint
+	if len(userID) > 0 && userID[0] > 0 {
+		userIDPtr = &userID[0]
+	}
+	totalCount, totalPages, err := apps.ListWithFilters(s.DB, pageSize, pageNumber, all, sort, namespace, isActive, userIDPtr)
 	return apps, totalCount, totalPages, err
 }
 

--- a/services/app_test.go
+++ b/services/app_test.go
@@ -908,3 +908,161 @@ func TestValidatePrivacyScores(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestPatchAppMetadata(t *testing.T) {
+	service, _ := setupAppTest(t)
+
+	user := createTestAppUser(t, service, "patch-meta@test.com", "Patch Meta User")
+	llm := createTestAppLLM(t, service, "patch-meta-llm", 5)
+
+	// Create app with initial metadata
+	initialMeta := map[string]interface{}{
+		"tier":     "free",
+		"org_name": "Acme Corp",
+	}
+	app, err := service.CreateAppWithNamespace("Meta App", "Description", user.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "", initialMeta)
+	assert.NoError(t, err)
+	assert.NotNil(t, app)
+
+	t.Run("Set a new metadata key with string value", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "region", `"us-east-1"`, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "us-east-1", result["region"])
+		// Existing keys should be preserved
+		assert.Equal(t, "free", result["tier"])
+		assert.Equal(t, "Acme Corp", result["org_name"])
+	})
+
+	t.Run("Update existing metadata key", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "tier", `"premium"`, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "premium", result["tier"])
+		// Other keys should be preserved
+		assert.Equal(t, "us-east-1", result["region"])
+	})
+
+	t.Run("Set metadata with numeric value", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "max_requests", `1000`, false)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(1000), result["max_requests"])
+	})
+
+	t.Run("Set metadata with boolean value", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "cache_enabled", `true`, false)
+		assert.NoError(t, err)
+		assert.Equal(t, true, result["cache_enabled"])
+	})
+
+	t.Run("Set metadata with nested object", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "settings", `{"timeout": 30, "retries": 3}`, false)
+		assert.NoError(t, err)
+		settings, ok := result["settings"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, float64(30), settings["timeout"])
+		assert.Equal(t, float64(3), settings["retries"])
+	})
+
+	t.Run("Set metadata with plain string (non-JSON)", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "note", "just a plain string", false)
+		assert.NoError(t, err)
+		assert.Equal(t, "just a plain string", result["note"])
+	})
+
+	t.Run("Delete a metadata key", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "note", "", true)
+		assert.NoError(t, err)
+		_, exists := result["note"]
+		assert.False(t, exists)
+		// Other keys preserved
+		assert.Equal(t, "premium", result["tier"])
+	})
+
+	t.Run("Delete non-existent key is a no-op", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(app.ID, "nonexistent", "", true)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("Patch on non-existent app returns error", func(t *testing.T) {
+		result, err := service.PatchAppMetadata(99999, "key", `"value"`, false)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("Patch on app with nil metadata initializes it", func(t *testing.T) {
+		// Create app without metadata
+		app2, err := service.CreateAppWithNamespace("No Meta App", "Description", user.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "", nil)
+		assert.NoError(t, err)
+
+		result, err := service.PatchAppMetadata(app2.ID, "first_key", `"first_value"`, false)
+		assert.NoError(t, err)
+		assert.Equal(t, "first_value", result["first_key"])
+	})
+}
+
+func TestListAppsWithFiltersUserID(t *testing.T) {
+	service, _ := setupAppTest(t)
+
+	user1 := createTestAppUser(t, service, "owner1@test.com", "Owner One")
+	user2 := createTestAppUser(t, service, "owner2@test.com", "Owner Two")
+	llm := createTestAppLLM(t, service, "filter-user-llm", 5)
+
+	// Create apps for user1
+	service.CreateAppWithNamespace("User1 App A", "Description", user1.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "production", nil)
+	service.CreateAppWithNamespace("User1 App B", "Description", user1.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "production", nil)
+	service.CreateAppWithNamespace("User1 App C", "Description", user1.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "development", nil)
+
+	// Create apps for user2
+	service.CreateAppWithNamespace("User2 App A", "Description", user2.ID, []uint{}, []uint{llm.ID}, []uint{}, nil, nil, "production", nil)
+
+	t.Run("Filter by user_id returns only that user's apps", func(t *testing.T) {
+		apps, totalCount, _, err := service.ListAppsWithFilters(10, 1, false, "name", "", nil, user1.ID)
+		assert.NoError(t, err)
+		assert.Len(t, apps, 3)
+		assert.Equal(t, int64(3), totalCount)
+		for _, app := range apps {
+			assert.Equal(t, user1.ID, app.UserID)
+		}
+	})
+
+	t.Run("Filter by user_id for second user", func(t *testing.T) {
+		apps, totalCount, _, err := service.ListAppsWithFilters(10, 1, false, "name", "", nil, user2.ID)
+		assert.NoError(t, err)
+		assert.Len(t, apps, 1)
+		assert.Equal(t, int64(1), totalCount)
+		assert.Equal(t, user2.ID, apps[0].UserID)
+	})
+
+	t.Run("Filter by user_id and namespace combined", func(t *testing.T) {
+		apps, totalCount, _, err := service.ListAppsWithFilters(10, 1, false, "name", "production", nil, user1.ID)
+		assert.NoError(t, err)
+		assert.Len(t, apps, 2)
+		assert.Equal(t, int64(2), totalCount)
+		for _, app := range apps {
+			assert.Equal(t, user1.ID, app.UserID)
+			assert.Equal(t, "production", app.Namespace)
+		}
+	})
+
+	t.Run("No user_id filter returns all apps", func(t *testing.T) {
+		apps, totalCount, _, err := service.ListAppsWithFilters(10, 1, false, "name", "", nil)
+		assert.NoError(t, err)
+		assert.Len(t, apps, 4)
+		assert.Equal(t, int64(4), totalCount)
+	})
+
+	t.Run("Non-existent user_id returns empty", func(t *testing.T) {
+		apps, totalCount, _, err := service.ListAppsWithFilters(10, 1, false, "name", "", nil, 99999)
+		assert.NoError(t, err)
+		assert.Len(t, apps, 0)
+		assert.Equal(t, int64(0), totalCount)
+	})
+
+	t.Run("Filter by is_active and user_id", func(t *testing.T) {
+		isActive := true
+		apps, _, _, err := service.ListAppsWithFilters(10, 1, false, "name", "", &isActive, user1.ID)
+		assert.NoError(t, err)
+		// All apps are active by default
+		assert.Len(t, apps, 3)
+	})
+}

--- a/services/grpc/ai_studio_management_server.go
+++ b/services/grpc/ai_studio_management_server.go
@@ -218,8 +218,14 @@ func (s *AIStudioManagementServer) ListApps(ctx context.Context, req *pb.ListApp
 		isActive = &value
 	}
 
+	// Handle user_id parameter
+	var userIDArgs []uint
+	if req.UserId != nil && req.GetUserId() > 0 {
+		userIDArgs = append(userIDArgs, uint(req.GetUserId()))
+	}
+
 	// Call enhanced service method with filtering
-	apps, totalCount, _, err := s.service.ListAppsWithFilters(limit, page, false, "-created_at", namespace, isActive)
+	apps, totalCount, _, err := s.service.ListAppsWithFilters(limit, page, false, "-created_at", namespace, isActive, userIDArgs...)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to list apps via gRPC")
 		return nil, status.Errorf(codes.Internal, "failed to list apps: %v", err)
@@ -406,6 +412,43 @@ func (s *AIStudioManagementServer) DeleteApp(ctx context.Context, req *pb.Delete
 	return &pb.DeleteAppResponse{
 		Success: true,
 		Message: "App deleted successfully",
+	}, nil
+}
+
+// PatchAppMetadata atomically updates a single metadata key on an app
+func (s *AIStudioManagementServer) PatchAppMetadata(ctx context.Context, req *pb.PatchAppMetadataRequest) (*pb.PatchAppMetadataResponse, error) {
+	appID := req.GetAppId()
+	if appID == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "app_id is required")
+	}
+	if req.GetKey() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "key is required")
+	}
+
+	resultMetadata, err := s.service.PatchAppMetadata(uint(appID), req.GetKey(), req.GetValue(), req.GetDelete())
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, status.Errorf(codes.NotFound, "app not found: %d", appID)
+		}
+		log.Error().Err(err).Uint32("app_id", appID).Str("key", req.GetKey()).Msg("Failed to patch app metadata via gRPC")
+		return nil, status.Errorf(codes.Internal, "failed to patch app metadata: %v", err)
+	}
+
+	metadataJSON := "{}"
+	if metadataBytes, err := json.Marshal(resultMetadata); err == nil {
+		metadataJSON = string(metadataBytes)
+	}
+
+	log.Debug().
+		Uint32("app_id", appID).
+		Str("key", req.GetKey()).
+		Bool("delete", req.GetDelete()).
+		Msg("Patched app metadata via gRPC")
+
+	return &pb.PatchAppMetadataResponse{
+		Success:  true,
+		Message:  "Metadata updated",
+		Metadata: metadataJSON,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

This PR adds four improvements to the Plugin SDK based on pain points discovered during plugin development:

1. **PatchAppMetadata** — Atomic, single-key metadata updates that avoid the fragile read-modify-write pattern of `UpdateAppWithMetadata`
2. **ListApps with Filtering** — Exposes existing server-side filtering (namespace, is_active) to the SDK and adds new owner-based filtering (user_id)
3. **Configurable Streaming Timeout** — The gateway's 5-minute hardcoded streaming endpoint timeout is now configurable via `PLUGIN_ENDPOINT_STREAM_TIMEOUT` env var
4. **HTTP Client Helper** — `plugin_sdk.DefaultHTTPClient()` utility with sensible defaults for plugins making outbound HTTP calls

Two additional investigated items required **no code changes**: WritePluginKV TTL is already fully supported end-to-end, and the App.Metadata type inconsistency between gateway (`map<string,string>`) and Studio (JSON string) is deferred to avoid breaking published signed plugins.

## Changes

### PatchAppMetadata (New RPC)

- **Proto**: New `PatchAppMetadata` RPC with `PatchAppMetadataRequest`/`PatchAppMetadataResponse` messages
- **Service**: `PatchAppMetadata(appID, key, value, deleteKey)` using DB transactions with `FOR UPDATE` row locking on PostgreSQL (SQLite serializes implicitly)
- **gRPC Server**: Handler with app_id/key validation
- **SDK**: `ai_studio_sdk.PatchAppMetadata()` convenience function + `StudioServices.PatchAppMetadata()` interface method

### ListApps with Filtering

- **Proto**: Added `optional uint32 user_id = 6` to `ListAppsRequest` (backward compatible)
- **Model/Service**: Extended `ListWithFilters` to accept optional `userID` parameter (variadic, backward compatible)
- **gRPC Server**: Passes `user_id` from request through to service layer
- **SDK**: New `ListAppsOptions` struct and `ListAppsWithFilters()` function exposing all three filters (is_active, namespace, user_id). Existing `ListApps()` remains unchanged.

### Configurable Streaming Timeout

- **Config**: `PLUGIN_ENDPOINT_STREAM_TIMEOUT` env var (default `5m`) in `GatewayConfig`
- **Router**: `PluginEndpointStreamTimeout` field on `RouterConfig`, used in `handlePluginEndpointStream` with fallback to 5m
- **Server**: Wired through in both `RouterConfig` construction sites

### HTTP Client Helper

- **New file**: `pkg/plugin_sdk/http.go` with `DefaultHTTPClient()` — returns `*http.Client` with 30s timeout, connection pooling (100 idle / 10 per host), 10s TLS handshake timeout

### Documentation

- `plugins-service-api.md` — Added `ListAppsWithFilters`, `PatchAppMetadata`, `WritePluginKVWithTTL` sections; updated scope table
- `plugins-sdk.md` — Updated Studio Services example with new methods
- `plugins-best-practices.md` — Updated connection pooling section to reference `DefaultHTTPClient()`
- `plugins-custom-endpoints.md` — Added Configuration section with streaming timeout env var

## Test plan

- [x] `TestPatchAppMetadata` — 10 subtests: set string/numeric/boolean/nested/plain values, update existing key, delete key, delete non-existent (no-op), error on non-existent app, initialize nil metadata
- [x] `TestListAppsWithFiltersUserID` — 6 subtests: filter by user, second user, combined user+namespace, no filter, non-existent user, combined is_active+user
- [x] `TestDefaultHTTPClient` — Verifies timeout, transport config, new instance per call
- [x] Existing `TestListAppsWithFilters` continues to pass (backward compatible variadic change)
- [x] Full build passes for both main module and microgateway
- [ ] Integration test: start dev environment, install a plugin that uses `PatchAppMetadata` and `ListAppsWithFilters`
