### PR TITLE
fix: show full Google AI proxy URL with model path in example endpoint

### DIFF
--- a/ui/admin-frontend/src/portal/components/AppDetailView.js
+++ b/ui/admin-frontend/src/portal/components/AppDetailView.js
@@ -659,12 +659,16 @@ const AppDetailView = () => {
                       flexGrow: 1,
                     }}
                   >
-                    {generateEndpointUrl("/llm/call/", llm.attributes.name)}
+                    {llm.attributes.vendor === "google_ai"
+                      ? joinUrlParts(generateEndpointUrl("/llm/call/", llm.attributes.name), "v1/models/YOUR_MODEL:generateContent")
+                      : generateEndpointUrl("/llm/call/", llm.attributes.name)}
                   </Typography>
                   <IconButton
                     onClick={() =>
                       copyToClipboard(
-                        generateEndpointUrl("/llm/call/", llm.attributes.name),
+                        llm.attributes.vendor === "google_ai"
+                          ? joinUrlParts(generateEndpointUrl("/llm/call/", llm.attributes.name), "v1/models/YOUR_MODEL:generateContent")
+                          : generateEndpointUrl("/llm/call/", llm.attributes.name),
                       )
                     }
                     size="small"


### PR DESCRIPTION
## Summary

- When an LLM's vendor is `google_ai`, the example proxy URL in the "Recommended Endpoint" section now displays `http://localhost:9090/llm/call/{slug}/v1/models/YOUR_MODEL:generateContent` instead of just `http://localhost:9090/llm/call/{slug}`
- For all other vendors, the existing URL format is unchanged
- Both the displayed URL and the copy-to-clipboard action are updated consistently

## Test plan

- [ ] Navigate to an app detail view with a Google AI LLM assigned
- [ ] Verify the Recommended Endpoint shows the full URL with `/v1/models/YOUR_MODEL:generateContent` suffix
- [ ] Verify clicking the copy button copies the full Google AI URL
- [ ] Navigate to an app detail view with a non-Google AI LLM (e.g., OpenAI)
- [ ] Verify the Recommended Endpoint shows the original URL format without any suffix

🤖 Generated with Tyk AI Assistant