### PR TITLE
fix: use API-provided total_tokens in GoogleAI GetTokenCounts

### DIFF
--- a/vendors/googleai/googleai.go
+++ b/vendors/googleai/googleai.go
@@ -26,8 +26,11 @@ func New() models.LLMVendorProvider {
 func (v *GoogleAI) GetTokenCounts(choice *llms.ContentChoice) (int, int, int) {
 	promptTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "input_tokens")
 	responseTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "output_tokens")
-	cacheTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "cached_content_tokens")
-	totalTokens := promptTokens + responseTokens + cacheTokens
+
+	totalTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "total_tokens")
+	if totalTokens <= 0 {
+		totalTokens = promptTokens + responseTokens
+	}
 
 	return totalTokens, promptTokens, responseTokens
 }


### PR DESCRIPTION
## Summary
- Prioritize the `total_tokens` value from the `GenerationInfo` map in `GetTokenCounts` for the Google AI vendor
- Fall back to summing `input_tokens` + `output_tokens` only when `total_tokens` is not available or is zero
- This fixes inaccurate token analytics when the API's total includes tokens not captured by the simple sum (e.g. thinking tokens)

## Test plan
- [ ] Verify that when `total_tokens` is present and > 0 in `GenerationInfo`, it is used as the total
- [ ] Verify that when `total_tokens` is absent or zero, the fallback sum of `input_tokens` + `output_tokens` is used
- [ ] Verify the build passes

---
🤖 Generated with Tyk AI Assistant