### PR TITLE
Include thinking tokens in Google AI response token count

### DIFF
--- a/vendors/googleai/googleai.go
+++ b/vendors/googleai/googleai.go
@@ -25,7 +25,13 @@ func New() models.LLMVendorProvider {
 
 func (v *GoogleAI) GetTokenCounts(choice *llms.ContentChoice) (int, int, int) {
 	promptTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "input_tokens")
-	responseTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "output_tokens")
+	thinkingTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "ThinkingTokens")
+	outputTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "output_tokens")
+
+	// INFO: We have to include thoughts tokens as they're priced like response tokens
+	// More details: https://ai.google.dev/gemini-api/docs/thinking#go_5
+	responseTokens := outputTokens + thinkingTokens
+
 	cacheTokens := helpers.KeyValueInt32OrZero(choice.GenerationInfo, "cached_content_tokens")
 	totalTokens := promptTokens + responseTokens + cacheTokens
 


### PR DESCRIPTION
## Summary
- Updated `GetTokenCounts` in `vendors/googleai/googleai.go` to include `thinkingTokens` (from `GenerationInfo["ThinkingTokens"]`) in the `responseTokens` calculation
- Thinking tokens from Gemini models are priced like response tokens and must be accounted for in token usage tracking
- Reference: https://ai.google.dev/gemini-api/docs/thinking#go_5

## Test plan
- [ ] Verify token counts are correctly calculated when thinking tokens are present
- [ ] Verify backwards compatibility when thinking tokens are zero/absent

🤖 Generated with Tyk AI Assistant