### PR TITLE
fix: resolve data race in TokenAuthProvider.ValidateToken

### DIFF
--- a/microgateway/internal/auth/token_auth.go
+++ b/microgateway/internal/auth/token_auth.go
@@ -65,9 +65,9 @@ func (p *TokenAuthProvider) ValidateToken(token string) (*AuthResult, error) {
 	}
 
 	// Update last used timestamp asynchronously
-	go func() {
-		p.db.Model(&apiToken).Update("last_used_at", time.Now())
-	}()
+	go func(tokenValue string) {
+		p.db.Model(&database.APIToken{}).Where("token = ?", tokenValue).Update("last_used_at", time.Now())
+	}(token)
 
 	// Parse scopes
 	var scopes []string


### PR DESCRIPTION
## Summary

- Fix data race in `microgateway/internal/auth/token_auth.go` where the goroutine updating `last_used_at` captured `apiToken` by reference, racing with the parent goroutine reading `apiToken` fields
- The goroutine now uses the `token` string value to identify the record via a `Where` clause instead of sharing the `apiToken` struct pointer

## Test plan

- [ ] Run `go test -race ./microgateway/internal/auth/...` to verify no data race is detected
- [ ] Verify token validation still updates `last_used_at` in the database

---
🤖 Generated with Tyk AI Assistant