### PR TITLE
Fix analytics parsing failure for compressed LLM responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/TykTechnologies/opentelemetry v0.0.21 // indirect
 	github.com/TykTechnologies/storage v1.2.2 // indirect
 	github.com/TykTechnologies/tyk v1.9.2-0.20240815043856-ec7db94fbe3d // indirect
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beevik/etree v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/TykTechnologies/tyk-pump v1.10.0/go.mod h1:dN4jBt2NlveiWalfTBgmyhkdRF
 github.com/airbrake/gobrake v3.6.1+incompatible/go.mod h1:wM4gu3Cn0W0K7GUuVWnlXZU11AGBXMILnrdOU8Kn00o=
 github.com/amikos-tech/chroma-go v0.2.5 h1:CxM8A9FlwtgQmlL0ZgmpfO6Hm7obYvO7WIg2aoo1PK8=
 github.com/amikos-tech/chroma-go v0.2.5/go.mod h1:j6Lw1dAWnGwUeRNCuciyquNZrQm37yJiEQmGbQFKDqs=
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=

--- a/proxy/buffered_response_capture.go
+++ b/proxy/buffered_response_capture.go
@@ -2,9 +2,7 @@ package proxy
 
 import (
 	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -15,8 +13,8 @@ type bufferedResponseCapture struct {
 	statusCode      int
 	buffer          *bytes.Buffer
 	header          http.Header
-	written         bool
-	gzipDecompressed bool // Track if we've already decompressed gzip
+	written      bool
+	decompressed bool // Track if we've already decompressed the response body
 }
 
 func newBufferedResponseCapture(w http.ResponseWriter) *bufferedResponseCapture {
@@ -24,8 +22,8 @@ func newBufferedResponseCapture(w http.ResponseWriter) *bufferedResponseCapture 
 		ResponseWriter:   w,
 		buffer:           &bytes.Buffer{},
 		header:           make(http.Header),
-		written:          false,
-		gzipDecompressed: false,
+		written:      false,
+		decompressed: false,
 	}
 }
 
@@ -46,15 +44,11 @@ func (rc *bufferedResponseCapture) Write(b []byte) (int, error) {
 }
 
 func (rc *bufferedResponseCapture) CapturedBody() []byte {
-	// Decompress gzip content if present for analytics
-	if !rc.gzipDecompressed && rc.header.Get("Content-Encoding") == "gzip" && rc.buffer.Len() > 0 {
-		reader, err := gzip.NewReader(bytes.NewReader(rc.buffer.Bytes()))
+	encoding := rc.header.Get("Content-Encoding")
+	if !rc.decompressed && encoding != "" && encoding != "identity" && rc.buffer.Len() > 0 {
+		decompressed, err := decompressBody(encoding, rc.buffer.Bytes())
 		if err == nil {
-			decompressed, err := io.ReadAll(reader)
-			reader.Close()
-			if err == nil {
-				return decompressed
-			}
+			return decompressed
 		}
 	}
 	return rc.buffer.Bytes()
@@ -106,18 +100,15 @@ func (rc *bufferedResponseCapture) WriteToClient() {
 		return // Already written
 	}
 
-	// Decompress gzip content if present and not already decompressed
-	if !rc.gzipDecompressed && rc.header.Get("Content-Encoding") == "gzip" && rc.buffer.Len() > 0 {
-		reader, err := gzip.NewReader(bytes.NewReader(rc.buffer.Bytes()))
+	// Decompress content if present and not already decompressed
+	encoding := rc.header.Get("Content-Encoding")
+	if !rc.decompressed && encoding != "" && encoding != "identity" && rc.buffer.Len() > 0 {
+		decompressed, err := decompressBody(encoding, rc.buffer.Bytes())
 		if err == nil {
-			decompressed, err := io.ReadAll(reader)
-			reader.Close()
-			if err == nil {
-				rc.buffer = bytes.NewBuffer(decompressed)
-				// Remove Content-Encoding header since we've decompressed the data
-				rc.header.Del("Content-Encoding")
-				rc.gzipDecompressed = true
-			}
+			rc.buffer = bytes.NewBuffer(decompressed)
+			// Remove Content-Encoding header since we've decompressed the data
+			rc.header.Del("Content-Encoding")
+			rc.decompressed = true
 		}
 	}
 

--- a/proxy/decompress.go
+++ b/proxy/decompress.go
@@ -1,0 +1,37 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"io"
+
+	"github.com/andybalholm/brotli"
+)
+
+// decompressBody decompresses a response body based on the Content-Encoding header value.
+// Returns the original data unchanged if the encoding is empty, "identity", or unrecognized.
+func decompressBody(encoding string, data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return data, nil
+	}
+
+	switch encoding {
+	case "gzip":
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+		return io.ReadAll(reader)
+	case "br":
+		reader := brotli.NewReader(bytes.NewReader(data))
+		return io.ReadAll(reader)
+	case "deflate":
+		reader := flate.NewReader(bytes.NewReader(data))
+		defer reader.Close()
+		return io.ReadAll(reader)
+	default:
+		return data, nil
+	}
+}

--- a/proxy/decompress_test.go
+++ b/proxy/decompress_test.go
@@ -1,0 +1,99 @@
+package proxy
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+)
+
+func TestDecompressBody(t *testing.T) {
+	original := []byte(`{"model":"gpt-4","choices":[{"message":{"content":"Hello"}}]}`)
+
+	t.Run("gzip", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		w.Write(original)
+		w.Close()
+
+		result, err := decompressBody("gzip", buf.Bytes())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("brotli", func(t *testing.T) {
+		var buf bytes.Buffer
+		w := brotli.NewWriter(&buf)
+		w.Write(original)
+		w.Close()
+
+		result, err := decompressBody("br", buf.Bytes())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("deflate", func(t *testing.T) {
+		var buf bytes.Buffer
+		w, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+		w.Write(original)
+		w.Close()
+
+		result, err := decompressBody("deflate", buf.Bytes())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("identity passthrough", func(t *testing.T) {
+		result, err := decompressBody("identity", original)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("empty encoding passthrough", func(t *testing.T) {
+		result, err := decompressBody("", original)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+
+	t.Run("empty data", func(t *testing.T) {
+		result, err := decompressBody("gzip", []byte{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected empty result, got %d bytes", len(result))
+		}
+	})
+
+	t.Run("unknown encoding passthrough", func(t *testing.T) {
+		result, err := decompressBody("zstd", original)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !bytes.Equal(result, original) {
+			t.Fatalf("got %q, want %q", result, original)
+		}
+	})
+}

--- a/proxy/response_capture.go
+++ b/proxy/response_capture.go
@@ -2,8 +2,6 @@ package proxy
 
 import (
 	"bytes"
-	"compress/gzip"
-	"io"
 	"net/http"
 )
 
@@ -36,13 +34,9 @@ func (rc *responseCapture) WriteHeader(statusCode int) {
 
 func (rc *responseCapture) Write(b []byte) (int, error) {
 	rc.buffer.Write(b)
-	if rc.Header().Get("Content-Encoding") == "gzip" {
-		reader, err := gzip.NewReader(bytes.NewReader(rc.buffer.Bytes()))
-		if err != nil {
-			return 0, err
-		}
-		defer reader.Close()
-		decompressed, err := io.ReadAll(reader)
+	encoding := rc.Header().Get("Content-Encoding")
+	if encoding != "" && encoding != "identity" {
+		decompressed, err := decompressBody(encoding, rc.buffer.Bytes())
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
## Summary
- Add Brotli (`br`) and `deflate` decompression support to the proxy's response capture layer, fixing the `failed to unmarshal llm rest response: invalid character '\u008b'` error
- Extract decompression logic into a shared `decompressBody` helper in `proxy/decompress.go` that handles `gzip`, `br`, and `deflate` encodings
- Update both `responseCapture` (streaming path) and `bufferedResponseCapture` (hooks/filters path) to use the shared helper consistently

## Test plan
- [x] Unit tests for `decompressBody` covering gzip, brotli, deflate, identity passthrough, empty data, and unknown encoding
- [ ] Manual test: configure an LLM provider that returns `Content-Encoding: br` and verify analytics records are created correctly
- [ ] Manual test: verify existing gzip-compressed responses still work
- [ ] Manual test: verify uncompressed responses are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)