### PR TITLE
fix: fix release workflow for renamed enterprise repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         if: matrix.edition == 'ent'
         uses: actions/checkout@v4
         with:
-          repository: TykTechnologies/midsommar-enterprise
+          repository: TykTechnologies/ai-studio-enterprise
           path: midsommar/enterprise
           token: ${{ secrets.ORG_GH_TOKEN }}
 
@@ -169,6 +169,12 @@ jobs:
           echo "Verifying static files..."
           find build -type f
           cd ../..
+
+      -
+        name: Remove enterprise module references for CE builds
+        if: matrix.edition == 'ce'
+        run: |
+          sed -i '/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d' go.mod
 
       -
         name: Build


### PR DESCRIPTION
## Summary
- Update enterprise submodule checkout from `TykTechnologies/midsommar-enterprise` to `TykTechnologies/ai-studio-enterprise` (repo was renamed, causing 404 on ent builds)
- Strip enterprise module `require`/`replace` lines from `go.mod` for CE builds so Go doesn't fail on the missing `./enterprise` directory

Fixes https://github.com/TykTechnologies/ai-studio/actions/runs/22434403107

## Test plan
- [ ] Trigger a release build and verify all 4 matrix jobs pass (studio-ce, studio-ent, microgateway-ce, microgateway-ent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)