### PR TITLE
fix: build docs site in prod workflow

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -70,6 +70,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu gcc libsqlite3-dev
 
+      - name: Build docs site
+        run: |
+          cd docs/site && npm install && NODE_ENV=production npm run docs:build
+
       - name: Remove enterprise module references for CE
         run: |
           sed -i '/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d' go.mod
@@ -181,6 +185,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu gcc libsqlite3-dev
+
+      - name: Build docs site
+        run: |
+          cd docs/site && npm install && NODE_ENV=production npm run docs:build
 
       - name: Build ENT Binaries
         run: |


### PR DESCRIPTION
## Summary
- Add docs site build step (`npm install && npm run docs:build`) before Go compilation in both CE and ENT binary build jobs
- `docs/docs.go` embeds `site/dist` which requires building the vitepress site first

Fixes https://github.com/TykTechnologies/ai-studio/actions/runs/22438716291

## Test plan
- [ ] Prod workflow should pass on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)