### PR TITLE
ci: free disk space for studio release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,14 @@ jobs:
       -
         name: Free disk space
         if: matrix.component == 'studio'
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache
-          sudo apt-get clean
-          df -h /
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
       -
         name: Checkout of midsommar
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Studio release builds (CE + ENT) fail with "No space left on device" when compiling go-sqlite3 CGO for 4 architectures (amd64, arm64, s390x, fips)
- Adds a "Free disk space" step that removes pre-installed .NET SDK (~1.7GB), Android SDK (~8GB), GHC, Boost, and hostedtoolcache before building
- Only runs for `studio` component (microgateway builds don't need it since they're lighter)

## Failure details from run 22447662940
- **studio-ce**: `write $WORK/b975/_pkg_.a: no space left on device`
- **studio-ent**: `sqlite3-binding.c: fatal error: error writing to /tmp/cckEeoj8.s: No space left on device`
- **microgateway-ce**: PackageCloud repo `tyk/tyk-microgateway` not found (separate infra issue)
- **microgateway-ent**: PackageCloud 504 Gateway Timeout (transient)

## Note
The microgateway PackageCloud failures are not workflow issues — `tyk/tyk-microgateway` repo needs to be created on PackageCloud, and the ent timeout was transient.

## Test plan
- [ ] Verify studio-ce and studio-ent release builds have enough disk space
- [ ] Check `df -h /` output in logs shows sufficient free space after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)