### PR TITLE
fix: Docker builds failing on enterprise module references

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -219,6 +219,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.ORG_GH_TOKEN }}
 
       - name: Download Frontend Build
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,21 @@ RUN cd ui/admin-frontend && npm ci && PUBLIC_URL="/" REACT_APP_API_URL="" CI=fal
 # Build documentation site
 RUN cd docs/site && npm ci && npm run docs:build
 
+# Build arguments for version information and edition
+ARG EDITION=ce
+
+# Remove enterprise module references for CE builds
+RUN if [ "$EDITION" = "ce" ]; then \
+        sed -i '/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d' go.mod; \
+        sed -i '/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d' microgateway/go.mod; \
+    fi
+
 # Download dependencies
 RUN go mod download
 
-# Build arguments for version information and edition
 ARG VERSION=dev
 ARG BUILD_HASH=unknown
 ARG BUILD_TIME=unknown
-ARG EDITION=ce
 
 # Build the binary
 RUN if [ "$EDITION" = "ent" ]; then \


### PR DESCRIPTION
## Summary
- **CE image build**: Dockerfile runs `go mod download` which fails because `go.mod` has `replace ./enterprise` but no enterprise directory exists. Fixed by moving `ARG EDITION` before `go mod download` and stripping enterprise references with sed when `EDITION=ce`.
- **ENT image build**: `build-ent-image` job checks out the repo without submodules, so enterprise directory is empty. Fixed by adding `submodules: true` with `ORG_GH_TOKEN`.

Fixes both failures from https://github.com/TykTechnologies/ai-studio/actions/runs/22448872644

## Test plan
- [ ] CE Docker image builds successfully (no enterprise module error)
- [ ] ENT Docker image builds successfully (enterprise submodule present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)