### PR TITLE
fix: Gemini streaming analytics broken for SSE responses

### DIFF
--- a/proxy/proxy_token_analytics_test.go
+++ b/proxy/proxy_token_analytics_test.go
@@ -290,6 +290,64 @@ func TestTokenAnalytics_StreamingResponse(t *testing.T) {
 	}
 }
 
+// TestTokenAnalytics_StreamingSSEResponse verifies analytics work with SSE format (alt=sse),
+// which is the standard format used by Google's streamGenerateContent endpoint.
+func TestTokenAnalytics_StreamingSSEResponse(t *testing.T) {
+	db, cancel := setupTest(t)
+	defer tearDownTest(db, cancel)
+
+	mockUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// SSE format as returned by Google with alt=sse
+		sseResponse := `data: {"candidates":[{"content":{"parts":[{"text":"The morning sun cast long shadows."}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":36,"totalTokenCount":220,"thoughtsTokenCount":176},"modelVersion":"gemini-2.5-pro"}
+
+data: {"candidates":[{"content":{"parts":[{"text":" A gentle start."}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":43,"totalTokenCount":227,"thoughtsTokenCount":176},"modelVersion":"gemini-2.5-pro"}
+
+`
+		w.Write([]byte(sseResponse))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer mockUpstream.Close()
+
+	proxy, _, _, secret := setupIntegrationProxy(t, db, mockUpstream.URL)
+
+	price := &models.ModelPrice{
+		Model:     gorm.Model{ID: 1},
+		ModelName: "gemini-2.5-pro",
+		Vendor:    string(models.GOOGLEAI),
+		CPT:       0.0000025,
+		CPIT:      0.0000003,
+		Currency:  "USD",
+	}
+	require.NoError(t, db.Create(price).Error)
+
+	srv := startProxyServer(t, proxy)
+	defer srv.Close()
+
+	reqBody := `{"model":"gemini-2.5-pro", "contents": [{"role":"user","parts":[{"text":"Hello!"}]}]}`
+	resp := sendProxyRequest(t, srv.URL, "gemini-api", secret, reqBody, "", true)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	waitForAnalytics(t, db, 1)
+	waitUntilIdle(t, db)
+
+	var record models.LLMChatRecord
+	require.NoError(t, db.First(&record).Error)
+
+	// Model name should come from modelVersion in the SSE response, not from URL
+	assert.Equal(t, "gemini-2.5-pro", record.Name)
+	assert.Equal(t, 8, record.PromptTokens)
+	// Response tokens = candidatesTokenCount + thoughtsTokenCount = 43 + 176
+	assert.Equal(t, 219, record.ResponseTokens)
+	assert.Equal(t, 1, record.Choices)
+}
+
 func setupIntegrationProxy(t *testing.T, db *gorm.DB, mockURL string) (*Proxy, *models.LLM, *models.App, string) {
 	t.Helper()
 

--- a/responses/response_model_googleai.go
+++ b/responses/response_model_googleai.go
@@ -26,7 +26,8 @@ type GoogleAIChatResponse struct {
 		CachedContentTokenCount int `json:"cachedContentTokenCount"`
 		ThoughtsTokenCount      int `json:"thoughtsTokenCount"`
 	} `json:"usageMetadata"`
-	Model string `json:"model"`
+	Model        string `json:"model"`
+	ModelVersion string `json:"modelVersion"`
 }
 
 type GoogleAIStreamChunk struct {
@@ -50,6 +51,7 @@ type GoogleAIStreamChunk struct {
 		TotalTokenCount      int `json:"totalTokenCount"`
 		ThoughtsTokenCount   int `json:"thoughtsTokenCount"`
 	} `json:"usageMetadata"`
+	ModelVersion string `json:"modelVersion"`
 }
 
 // type GoogleAIChatResponse struct {

--- a/vendors/googleai/googleai.go
+++ b/vendors/googleai/googleai.go
@@ -66,20 +66,20 @@ func (v *GoogleAI) GetEmbedder(d *models.Datasource) (*embeddings.EmbedderImpl, 
 }
 
 func (v *GoogleAI) AnalyzeResponse(llm *models.LLM, app *models.App, statusCode int, body []byte, r *http.Request) (*models.LLM, *models.App, models.ITokenResponse, error) {
-	modelName, err := extractModelIDFromGoogleURL(r.URL.Path)
-	if err != nil {
+	response := &responses.GoogleAIChatResponse{}
+	if err := json.Unmarshal(body, response); err != nil {
 		return nil, nil, nil, err
 	}
 
+	// Prefer modelVersion from the response body (most accurate)
+	modelName := response.ModelVersion
+	if modelName == "" {
+		modelName, _ = extractModelIDFromGoogleURL(r.URL.Path)
+	}
 	if modelName == "" {
 		modelName = "googleai-gemini-no-id"
 	}
 
-	response := &responses.GoogleAIChatResponse{}
-	err = json.Unmarshal(body, response)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	response.SetModel(modelName)
 	return llm, app, response, nil
 }
@@ -87,14 +87,20 @@ func (v *GoogleAI) AnalyzeResponse(llm *models.LLM, app *models.App, statusCode 
 func (v *GoogleAI) AnalyzeStreamingResponse(llm *models.LLM, app *models.App, statusCode int, resps []byte, r *http.Request, chunks [][]byte) (*models.LLM, *models.App, models.ITokenResponse, error) {
 	var streamChunks []responses.GoogleAIStreamChunk
 
-	err := json.Unmarshal(resps, &streamChunks)
-	if err != nil {
-		var singleChunk responses.GoogleAIStreamChunk
-
-		if singleErr := json.Unmarshal(resps, &singleChunk); singleErr == nil {
-			streamChunks = append(streamChunks, singleChunk)
-		} else {
-			return nil, nil, nil, fmt.Errorf("failed to unmarshal googleai streaming response: %w", err)
+	// Try SSE format first (when alt=sse is used, which is the standard for streaming)
+	if isSSEFormat(resps) {
+		streamChunks = parseSSEGoogleAIChunks(resps)
+	} else {
+		// Try JSON array format (non-SSE streaming)
+		err := json.Unmarshal(resps, &streamChunks)
+		if err != nil {
+			// Fallback: try single JSON object
+			var singleChunk responses.GoogleAIStreamChunk
+			if singleErr := json.Unmarshal(resps, &singleChunk); singleErr == nil {
+				streamChunks = append(streamChunks, singleChunk)
+			} else {
+				return nil, nil, nil, fmt.Errorf("failed to unmarshal googleai streaming response: %w", err)
+			}
 		}
 	}
 
@@ -104,7 +110,11 @@ func (v *GoogleAI) AnalyzeStreamingResponse(llm *models.LLM, app *models.App, st
 
 	finalChunk := streamChunks[len(streamChunks)-1]
 
-	modelName, _ := extractModelIDFromGoogleURL(r.URL.Path)
+	// Prefer modelVersion from the response itself (most accurate)
+	modelName := finalChunk.ModelVersion
+	if modelName == "" {
+		modelName, _ = extractModelIDFromGoogleURL(r.URL.Path)
+	}
 	if modelName == "" {
 		modelName = "googleai-gemini-no-id"
 	}
@@ -118,6 +128,44 @@ func (v *GoogleAI) AnalyzeStreamingResponse(llm *models.LLM, app *models.App, st
 		finalChunk.UsageMetadata.ThoughtsTokenCount
 
 	return llm, app, aggregate, nil
+}
+
+// isSSEFormat checks if the response data is in SSE (Server-Sent Events) format.
+func isSSEFormat(data []byte) bool {
+	// Check first non-empty line for "data:" prefix
+	for _, line := range strings.SplitN(string(data), "\n", 5) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		return strings.HasPrefix(line, "data:")
+	}
+	return false
+}
+
+// parseSSEGoogleAIChunks parses SSE-formatted streaming response into GoogleAIStreamChunks.
+// Google's streamGenerateContent with alt=sse returns:
+//
+//	data: {"candidates":[...],"usageMetadata":{...},"modelVersion":"gemini-2.5-pro"}
+//	data: {"candidates":[...],"usageMetadata":{...},"modelVersion":"gemini-2.5-pro"}
+func parseSSEGoogleAIChunks(data []byte) []responses.GoogleAIStreamChunk {
+	var chunks []responses.GoogleAIStreamChunk
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		jsonData := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if jsonData == "" || jsonData == "[DONE]" {
+			continue
+		}
+		var chunk responses.GoogleAIStreamChunk
+		if err := json.Unmarshal([]byte(jsonData), &chunk); err != nil {
+			continue
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks
 }
 
 // ProxySetAuthHeader injects the required Google AI authentication credentials into the

--- a/vendors/googleai/googleai_test.go
+++ b/vendors/googleai/googleai_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TykTechnologies/midsommar/v2/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGoogleAI_AnalyzeStreamingResponse_ErrorCases(t *testing.T) {
@@ -71,6 +72,155 @@ func TestGoogleAI_AnalyzeStreamingResponse_ErrorCases(t *testing.T) {
 			if tt.expectedError != "" {
 				assert.Contains(t, err.Error(), tt.expectedError)
 			}
+		})
+	}
+}
+
+func TestGoogleAI_AnalyzeStreamingResponse_SSEFormat(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse", nil)
+
+	// SSE format as returned by Google's streamGenerateContent with alt=sse
+	sseResponse := []byte(`data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15,"thoughtsTokenCount":0},"modelVersion":"gemini-2.5-pro"}
+
+data: {"candidates":[{"content":{"parts":[{"text":" world!"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":12,"totalTokenCount":22,"thoughtsTokenCount":0},"modelVersion":"gemini-2.5-pro"}
+
+`)
+
+	llm, app, response, err := v.AnalyzeStreamingResponse(
+		mockLLM, mockApp, http.StatusOK, sseResponse, mockRequest, [][]byte{},
+	)
+
+	require.NoError(t, err)
+	assert.NotNil(t, llm)
+	assert.NotNil(t, app)
+	assert.NotNil(t, response)
+	assert.Equal(t, 10, response.GetPromptTokens())
+	assert.Equal(t, 12, response.GetResponseTokens())
+	assert.Equal(t, "gemini-2.5-pro", response.GetModel())
+}
+
+func TestGoogleAI_AnalyzeStreamingResponse_SSEWithThinkingTokens(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse", nil)
+
+	sseResponse := []byte(`data: {"candidates":[{"content":{"parts":[{"text":"thinking..."}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":36,"totalTokenCount":220,"thoughtsTokenCount":176},"modelVersion":"gemini-2.5-pro"}
+
+data: {"candidates":[{"content":{"parts":[{"text":" done."}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":43,"totalTokenCount":227,"thoughtsTokenCount":176},"modelVersion":"gemini-2.5-pro"}
+
+`)
+
+	_, _, response, err := v.AnalyzeStreamingResponse(
+		mockLLM, mockApp, http.StatusOK, sseResponse, mockRequest, [][]byte{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 8, response.GetPromptTokens())
+	// Response tokens should include thinking tokens
+	assert.Equal(t, 43+176, response.GetResponseTokens())
+	assert.Equal(t, "gemini-2.5-pro", response.GetModel())
+}
+
+func TestGoogleAI_AnalyzeStreamingResponse_JSONArrayFormat(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-2.5-flash:streamGenerateContent", nil)
+
+	// JSON array format (without alt=sse)
+	jsonResponse := []byte(`[
+		{"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"},"index":0}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.5-flash"},
+		{"candidates":[{"content":{"parts":[{"text":" world"}],"role":"model"},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":7,"totalTokenCount":12},"modelVersion":"gemini-2.5-flash"}
+	]`)
+
+	_, _, response, err := v.AnalyzeStreamingResponse(
+		mockLLM, mockApp, http.StatusOK, jsonResponse, mockRequest, [][]byte{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 5, response.GetPromptTokens())
+	assert.Equal(t, 7, response.GetResponseTokens())
+	assert.Equal(t, "gemini-2.5-flash", response.GetModel())
+}
+
+func TestGoogleAI_AnalyzeStreamingResponse_ModelVersionPrecedence(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	// URL says gemini-flash but response says gemini-2.5-pro
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-flash:streamGenerateContent", nil)
+
+	jsonResponse := []byte(`[{"candidates":[{"content":{"parts":[{"text":"test"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2},"modelVersion":"gemini-2.5-pro"}]`)
+
+	_, _, response, err := v.AnalyzeStreamingResponse(
+		mockLLM, mockApp, http.StatusOK, jsonResponse, mockRequest, [][]byte{},
+	)
+
+	require.NoError(t, err)
+	// modelVersion from response should take precedence over URL
+	assert.Equal(t, "gemini-2.5-pro", response.GetModel())
+}
+
+func TestGoogleAI_AnalyzeStreamingResponse_FallbackToURL(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-2.5-flash:streamGenerateContent", nil)
+
+	// No modelVersion in response
+	jsonResponse := []byte(`[{"candidates":[{"content":{"parts":[{"text":"test"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2}}]`)
+
+	_, _, response, err := v.AnalyzeStreamingResponse(
+		mockLLM, mockApp, http.StatusOK, jsonResponse, mockRequest, [][]byte{},
+	)
+
+	require.NoError(t, err)
+	// Should fall back to URL extraction
+	assert.Equal(t, "gemini-2.5-flash", response.GetModel())
+}
+
+func TestGoogleAI_AnalyzeResponse_ModelVersionPrecedence(t *testing.T) {
+	v := &GoogleAI{}
+	mockLLM := &models.LLM{ID: 1}
+	mockApp := &models.App{ID: 1}
+	// URL says gemini-flash but response says gemini-2.5-pro
+	mockRequest := httptest.NewRequest("POST", "/v1beta/models/gemini-flash:generateContent", nil)
+
+	responseBody := []byte(`{
+		"candidates":[{"content":{"parts":[{"text":"test"}],"role":"model"},"finishReason":"STOP"}],
+		"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10,"totalTokenCount":15},
+		"modelVersion":"gemini-2.5-pro"
+	}`)
+
+	_, _, response, err := v.AnalyzeResponse(
+		mockLLM, mockApp, http.StatusOK, responseBody, mockRequest,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "gemini-2.5-pro", response.GetModel())
+	assert.Equal(t, 5, response.GetPromptTokens())
+	assert.Equal(t, 10, response.GetResponseTokens())
+}
+
+func TestIsSSEFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected bool
+	}{
+		{"SSE with data prefix", []byte("data: {\"test\":true}\n"), true},
+		{"SSE with leading newline", []byte("\ndata: {\"test\":true}\n"), true},
+		{"JSON array", []byte(`[{"test":true}]`), false},
+		{"JSON object", []byte(`{"test":true}`), false},
+		{"empty", []byte(""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSSEFormat(tt.data))
 		})
 	}
 }

--- a/vendors/vertex/vertex.go
+++ b/vendors/vertex/vertex.go
@@ -61,20 +61,20 @@ func (v *Vertex) GetEmbedder(d *models.Datasource) (*embeddings.EmbedderImpl, er
 }
 
 func (v *Vertex) AnalyzeResponse(llm *models.LLM, app *models.App, statusCode int, body []byte, r *http.Request) (*models.LLM, *models.App, models.ITokenResponse, error) {
-	modelName, err := extractModelIDFromVertexURL(r.URL.Path)
-	if err != nil {
+	response := &responses.GoogleAIChatResponse{}
+	if err := json.Unmarshal(body, response); err != nil {
 		return nil, nil, nil, err
 	}
 
+	// Prefer modelVersion from the response body (most accurate)
+	modelName := response.ModelVersion
+	if modelName == "" {
+		modelName, _ = extractModelIDFromVertexURL(r.URL.Path)
+	}
 	if modelName == "" {
 		modelName = "googleai-gemini-no-id"
 	}
 
-	response := &responses.GoogleAIChatResponse{}
-	err = json.Unmarshal(body, response)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	response.SetModel(modelName)
 	return llm, app, response, nil
 }


### PR DESCRIPTION
## Summary
- Gemini SSE streaming analytics were completely broken — GoogleAI.AnalyzeStreamingResponse() called json.Unmarshal directly on SSE-formatted response bytes (data: {...}\n), which always fails. No analytics were recorded for streaming Gemini calls using alt=sse (the standard format).
- Model names were tracked incorrectly — extracted solely from URL path via regex, ignoring the modelVersion field present in every Gemini API response. When URL extraction failed or matched the wrong model, analytics recorded wrong model names like gemini-flash instead of gemini-2.5-pro.

## Root Causes
- SSE parsing gap: OpenAI's handler already splits on \n and strips data: prefix. GoogleAI's handler did not — it assumed JSON array format, which only works without alt=sse. The cache plugin (community/plugins/llm-cache/sse.go) also handles SSE correctly for caching, but the analytics path was missed.
- Missing modelVersion field: The GoogleAIStreamChunk and GoogleAIChatResponse structs didn't include modelVersion, so the accurate model name from Google's response was silently discarded.

### Changes

- Add SSE format detection and parsing to GoogleAI streaming analytics
- Add ModelVersion field to both response structs
- Prefer modelVersion from response over URL regex extraction (GoogleAI + Vertex)
- Add 8 unit tests + 1 integration test

Test plan
- [x ] All existing GoogleAI vendor tests pass (regression)
- [x]  New SSE format unit tests pass
- [x]  New model version precedence tests pass
- [x]  New proxy integration test for SSE streaming passes
- [ ]  Manual test with utils/proxy-tests/googleai/GenerateStream.sh