### PR TITLE
fix: prevent secret value overwrite with placeholder on update

### DIFF
--- a/api/secrets_handlers.go
+++ b/api/secrets_handlers.go
@@ -164,10 +164,17 @@ func (a *API) updateSecret(c *gin.Context) {
 		return
 	}
 
-	secret.Value = input.Data.Attributes.Value
 	secret.VarName = input.Data.Attributes.VarName
 
-	if err := secrets.UpdateSecret(a.config.DB, secret); err != nil {
+	// Only update the value if the user actually provided a new secret value.
+	// When editing, the frontend loads the placeholder reference (e.g. $SECRET/NAME)
+	// and may send it back unchanged — we must not overwrite the real encrypted value.
+	valueChanged := !secrets.IsSecretReference(input.Data.Attributes.Value) && input.Data.Attributes.Value != ""
+	if valueChanged {
+		secret.Value = input.Data.Attributes.Value
+	}
+
+	if err := secrets.UpdateSecret(a.config.DB, secret, valueChanged); err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Errors: []struct {
 				Title  string `json:"title"`

--- a/api/secrets_update_test.go
+++ b/api/secrets_update_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateSecret_DoesNotOverwriteWithPlaceholder(t *testing.T) {
+	// Set the secret key for encryption
+	originalKey := os.Getenv("TYK_AI_SECRET_KEY")
+	os.Setenv("TYK_AI_SECRET_KEY", "test-secret-key-for-unit-test")
+	defer os.Setenv("TYK_AI_SECRET_KEY", originalKey)
+
+	api, db := setupTestAPI(t)
+
+	// Migrate the Secret table
+	db.AutoMigrate(&secrets.Secret{})
+
+	// Create a secret with a real value
+	secret := &secrets.Secret{
+		VarName: "MY_API_KEY",
+		Value:   "super-secret-value-123",
+	}
+	err := secrets.CreateSecret(db, secret)
+	require.NoError(t, err)
+
+	secretID := secret.ID
+
+	// Verify the secret was stored encrypted
+	storedSecret, err := secrets.GetSecretByID(db, secretID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret-value-123", storedSecret.Value)
+
+	// Now simulate what the frontend does: PATCH with the placeholder reference
+	// (this is what happens when the user edits only the var_name)
+	updatePayload := SecretInput{}
+	updatePayload.Data.Attributes.VarName = "MY_API_KEY_RENAMED"
+	updatePayload.Data.Attributes.Value = "$SECRET/MY_API_KEY" // placeholder from the frontend
+
+	body, _ := json.Marshal(updatePayload)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/v1/secrets/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	api.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify the secret value was NOT overwritten with the placeholder
+	updatedSecret, err := secrets.GetSecretByID(db, secretID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "MY_API_KEY_RENAMED", updatedSecret.VarName)
+	assert.Equal(t, "super-secret-value-123", updatedSecret.Value, "Secret value should be preserved when placeholder is sent")
+}
+
+func TestUpdateSecret_UpdatesValueWhenChanged(t *testing.T) {
+	originalKey := os.Getenv("TYK_AI_SECRET_KEY")
+	os.Setenv("TYK_AI_SECRET_KEY", "test-secret-key-for-unit-test")
+	defer os.Setenv("TYK_AI_SECRET_KEY", originalKey)
+
+	api, db := setupTestAPI(t)
+	db.AutoMigrate(&secrets.Secret{})
+
+	// Create a secret
+	secret := &secrets.Secret{
+		VarName: "MY_API_KEY",
+		Value:   "old-secret-value",
+	}
+	err := secrets.CreateSecret(db, secret)
+	require.NoError(t, err)
+
+	secretID := secret.ID
+
+	// PATCH with a new real value (not a placeholder)
+	updatePayload := SecretInput{}
+	updatePayload.Data.Attributes.VarName = "MY_API_KEY"
+	updatePayload.Data.Attributes.Value = "new-secret-value"
+
+	body, _ := json.Marshal(updatePayload)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/v1/secrets/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	api.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify the secret value WAS updated
+	updatedSecret, err := secrets.GetSecretByID(db, secretID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "new-secret-value", updatedSecret.Value, "Secret value should be updated when a real value is sent")
+}
+
+func TestUpdateSecret_EmptyValueDoesNotOverwrite(t *testing.T) {
+	originalKey := os.Getenv("TYK_AI_SECRET_KEY")
+	os.Setenv("TYK_AI_SECRET_KEY", "test-secret-key-for-unit-test")
+	defer os.Setenv("TYK_AI_SECRET_KEY", originalKey)
+
+	api, db := setupTestAPI(t)
+	db.AutoMigrate(&secrets.Secret{})
+
+	// Create a secret
+	secret := &secrets.Secret{
+		VarName: "MY_API_KEY",
+		Value:   "real-secret",
+	}
+	err := secrets.CreateSecret(db, secret)
+	require.NoError(t, err)
+
+	secretID := secret.ID
+
+	// PATCH with an empty value (frontend omitted the value field)
+	updatePayload := SecretInput{}
+	updatePayload.Data.Attributes.VarName = "MY_API_KEY"
+	updatePayload.Data.Attributes.Value = ""
+
+	body, _ := json.Marshal(updatePayload)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PATCH", "/api/v1/secrets/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	api.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify the secret value was NOT overwritten
+	updatedSecret, err := secrets.GetSecretByID(db, secretID, false)
+	require.NoError(t, err)
+	assert.Equal(t, "real-secret", updatedSecret.Value, "Secret value should be preserved when empty value is sent")
+}

--- a/secrets/models.go
+++ b/secrets/models.go
@@ -194,12 +194,16 @@ func CreateSecret(db *gorm.DB, settings *Secret) error {
 }
 
 // UpdateSecret updates an existing Secret record in the database.
-func UpdateSecret(db *gorm.DB, settings *Secret) error {
-	key := os.Getenv(midsommarSecret)
-	var err error
-	settings.Value, err = encrypt(key, settings.Value)
-	if err != nil {
-		return err
+// When encryptValue is true, the Value field is encrypted before saving.
+// Pass false when the Value already contains the stored (encrypted) value and should not be re-encrypted.
+func UpdateSecret(db *gorm.DB, settings *Secret, encryptValue bool) error {
+	if encryptValue {
+		key := os.Getenv(midsommarSecret)
+		var err error
+		settings.Value, err = encrypt(key, settings.Value)
+		if err != nil {
+			return err
+		}
 	}
 
 	return db.Save(settings).Error

--- a/ui/admin-frontend/src/admin/components/secrets/SecretForm.js
+++ b/ui/admin-frontend/src/admin/components/secrets/SecretForm.js
@@ -26,6 +26,7 @@ const SecretForm = () => {
     var_name: "",
     value: "",
   });
+  const [valueModified, setValueModified] = useState(false);
   const [showSecret, setShowSecret] = useState(false);
   const [errors, setErrors] = useState({});
   const [snackbar, setSnackbar] = useState({
@@ -65,7 +66,7 @@ const SecretForm = () => {
     if (!formData.var_name.trim()) {
       newErrors.var_name = "Variable name is required";
     }
-    if (!formData.value.trim()) {
+    if (!id && !formData.value.trim()) {
       newErrors.value = "Secret value is required";
     }
 
@@ -80,6 +81,9 @@ const SecretForm = () => {
   };
 
   const handleChange = (field) => (event) => {
+    if (field === "value") {
+      setValueModified(true);
+    }
     setFormData({
       ...formData,
       [field]: event.target.value,
@@ -90,13 +94,20 @@ const SecretForm = () => {
     e.preventDefault();
     if (!validateForm()) return;
 
+    const attributes = {
+      var_name: formData.var_name,
+    };
+
+    // Only include value if creating a new secret or if the user actually changed it.
+    // This prevents overwriting the real encrypted value with the placeholder reference.
+    if (!id || valueModified) {
+      attributes.value = formData.value;
+    }
+
     const secretData = {
       data: {
         type: "secrets",
-        attributes: {
-          var_name: formData.var_name,
-          value: formData.value,
-        },
+        attributes,
       },
     };
 
@@ -206,7 +217,7 @@ const SecretForm = () => {
               <PrimaryButton
                 variant="contained"
                 type="submit"
-                disabled={!formData.var_name || !formData.value}
+                disabled={!formData.var_name || (!id && !formData.value)}
               >
                 {id ? "Update secret" : "Add secret"}
               </PrimaryButton>

--- a/ui/admin-frontend/src/admin/components/secrets/SecretForm.test.js
+++ b/ui/admin-frontend/src/admin/components/secrets/SecretForm.test.js
@@ -1,0 +1,219 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+import { createTheme } from "@mui/material";
+import SecretForm from "./SecretForm";
+
+// Mock apiClient
+jest.mock("../../utils/apiClient", () => {
+  const mockClient = {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+  };
+  return {
+    __esModule: true,
+    default: mockClient,
+  };
+});
+
+// Mock useNavigate — default to create mode
+const mockNavigate = jest.fn();
+let mockId;
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: mockId }),
+}));
+
+describe("SecretForm Component", () => {
+  const theme = createTheme({
+    palette: {
+      text: {
+        primary: "#ffffff",
+        defaultSubdued: "rgba(255, 255, 255, 0.6)",
+      },
+      background: {
+        buttonPrimaryDefault: "#007bff",
+        buttonPrimaryDefaultHover: "#0069d9",
+      },
+      custom: { white: "#ffffff" },
+      primary: { main: "#7b68ee" },
+      error: { main: "#dc3545" },
+      border: { neutralDefault: "#e0e0e0" },
+    },
+    typography: {
+      bodyLargeMedium: { fontSize: "1rem", fontWeight: 500 },
+      headingXLarge: { fontSize: "2rem", fontWeight: "bold" },
+    },
+  });
+
+  const Wrapper = ({ children }) => (
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <Routes>
+          <Route path="*" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>
+  );
+
+  let apiClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockId = undefined;
+    apiClient = require("../../utils/apiClient").default;
+    apiClient.get.mockReset();
+    apiClient.post.mockReset();
+    apiClient.patch.mockReset();
+    apiClient.post.mockResolvedValue({ data: { data: { id: "1" } } });
+    apiClient.patch.mockResolvedValue({ data: { data: { id: "1" } } });
+  });
+
+  test("create mode sends value in request", async () => {
+    mockId = undefined;
+
+    render(<SecretForm />, { wrapper: Wrapper });
+
+    fireEvent.change(screen.getByLabelText(/Variable Name/i), {
+      target: { value: "MY_KEY" },
+    });
+    fireEvent.change(screen.getByLabelText(/Secret Value/i), {
+      target: { value: "my-secret-123" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add secret/i }));
+
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith("/secrets", {
+        data: {
+          type: "secrets",
+          attributes: {
+            var_name: "MY_KEY",
+            value: "my-secret-123",
+          },
+        },
+      });
+    });
+  });
+
+  test("edit mode does NOT send value when user does not modify it", async () => {
+    mockId = "42";
+
+    apiClient.get.mockResolvedValue({
+      data: {
+        data: {
+          attributes: {
+            var_name: "EXISTING_KEY",
+            value: "$SECRET/EXISTING_KEY",
+          },
+        },
+      },
+    });
+
+    render(<SecretForm />, { wrapper: Wrapper });
+
+    // Wait for the secret data to load
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/secrets/42");
+    });
+
+    // Only change the var_name, leave value untouched
+    fireEvent.change(screen.getByLabelText(/Variable Name/i), {
+      target: { value: "RENAMED_KEY" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Update secret/i }));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith("/secrets/42", {
+        data: {
+          type: "secrets",
+          attributes: {
+            var_name: "RENAMED_KEY",
+            // value should NOT be included
+          },
+        },
+      });
+    });
+
+    // Verify value was NOT sent
+    const patchCall = apiClient.patch.mock.calls[0][1];
+    expect(patchCall.data.attributes).not.toHaveProperty("value");
+  });
+
+  test("edit mode sends value when user modifies it", async () => {
+    mockId = "42";
+
+    apiClient.get.mockResolvedValue({
+      data: {
+        data: {
+          attributes: {
+            var_name: "EXISTING_KEY",
+            value: "$SECRET/EXISTING_KEY",
+          },
+        },
+      },
+    });
+
+    render(<SecretForm />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(apiClient.get).toHaveBeenCalledWith("/secrets/42");
+    });
+
+    // Change the value field
+    fireEvent.change(screen.getByLabelText(/Secret Value/i), {
+      target: { value: "brand-new-secret" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Update secret/i }));
+
+    await waitFor(() => {
+      expect(apiClient.patch).toHaveBeenCalledWith("/secrets/42", {
+        data: {
+          type: "secrets",
+          attributes: {
+            var_name: "EXISTING_KEY",
+            value: "brand-new-secret",
+          },
+        },
+      });
+    });
+  });
+
+  test("edit mode submit button is not disabled when value is unchanged", async () => {
+    mockId = "42";
+
+    apiClient.get.mockResolvedValue({
+      data: {
+        data: {
+          attributes: {
+            var_name: "EXISTING_KEY",
+            value: "$SECRET/EXISTING_KEY",
+          },
+        },
+      },
+    });
+
+    render(<SecretForm />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Variable Name/i)).toHaveValue(
+        "EXISTING_KEY"
+      );
+    });
+
+    const submitButton = screen.getByRole("button", {
+      name: /Update secret/i,
+    });
+    expect(submitButton).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #283 — When editing a secret without changing its value, the frontend sent back the placeholder reference (`$SECRET/NAME`), which the backend faithfully encrypted and saved, destroying the real secret.

- **Backend**: `updateSecret` handler now detects secret references and empty values, skipping the value update and avoiding double-encryption
- **Frontend**: `SecretForm` tracks whether the value field was actually modified; omits it from the PATCH payload when unchanged
- **`UpdateSecret` signature**: Added `encryptValue bool` parameter to avoid re-encrypting already-encrypted values when only metadata changes

## Test plan

- [x] Backend: 3 new tests in `api/secrets_update_test.go` — placeholder preserved, real value updated, empty value preserved
- [x] Frontend: 4 new tests in `SecretForm.test.js` — create includes value, edit omits unchanged value, edit sends modified value, submit button enabled in edit mode
- [x] Existing `TestSecretsHandlersWithoutKey` tests still pass
- [x] Verified no other callers of `UpdateSecret` exist
- [x] Traced all secret retrieval paths (proxy, microgateway, chat, scripts) — none affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)