### PR TITLE
fix: redact tool AuthKey in API responses to prevent credential leakage

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -244,6 +244,7 @@ func (a *API) getCommonToolCatalogueTools(c *gin.Context) {
 				PrivacyScore   int                 `json:"privacy_score"`
 				Operations     []string            `json:"operations"`
 				AuthKey        string              `json:"auth_key"`
+				HasAuthKey     bool                `json:"has_auth_key"`
 				AuthSchemaName string              `json:"auth_schema_name"`
 				Active         bool                `json:"active"`
 				Namespace      string              `json:"namespace"`
@@ -971,6 +972,7 @@ func (a *API) getUserAccessibleTools(c *gin.Context) {
 				PrivacyScore   int                 `json:"privacy_score"`
 				Operations     []string            `json:"operations"`
 				AuthKey        string              `json:"auth_key"`
+				HasAuthKey     bool                `json:"has_auth_key"`
 				AuthSchemaName string              `json:"auth_schema_name"`
 				Active         bool                `json:"active"`
 				Namespace      string              `json:"namespace"`

--- a/api/models.go
+++ b/api/models.go
@@ -549,6 +549,7 @@ type ToolResponse struct {
 		PrivacyScore   int                 `json:"privacy_score"`
 		Operations     []string            `json:"operations"`
 		AuthKey        string              `json:"auth_key"`
+		HasAuthKey     bool                `json:"has_auth_key"`
 		AuthSchemaName string              `json:"auth_schema_name"`
 		Active         bool                `json:"active"`
 		Namespace      string              `json:"namespace"`

--- a/api/tool_catalogue_handlers.go
+++ b/api/tool_catalogue_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/TykTechnologies/midsommar/v2/helpers"
 	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/services"
 	"github.com/TykTechnologies/midsommar/v2/universalclient"
 	"github.com/gin-gonic/gin"
 	"github.com/pb33f/libopenapi"
@@ -358,6 +359,7 @@ func toSecureToolResponse(tool *models.Tool) ToolResponse {
 			PrivacyScore   int                 `json:"privacy_score"`
 			Operations     []string            `json:"operations"`
 			AuthKey        string              `json:"auth_key"`
+			HasAuthKey     bool                `json:"has_auth_key"`
 			AuthSchemaName string              `json:"auth_schema_name"`
 			Active         bool                `json:"active"`
 			Namespace      string              `json:"namespace"`
@@ -371,7 +373,8 @@ func toSecureToolResponse(tool *models.Tool) ToolResponse {
 			OASSpec:        "", // Hide OAS spec for security
 			PrivacyScore:   tool.PrivacyScore,
 			Operations:     ops,
-			AuthKey:        "", // Hide auth key for security
+			AuthKey:        services.REDACTED_VALUE,
+			HasAuthKey:     tool.AuthKey != "",
 			AuthSchemaName: tool.AuthSchemaName,
 			Active:         tool.Active,
 		},
@@ -391,6 +394,7 @@ func toToolResponse(tool *models.Tool) ToolResponse {
 			PrivacyScore   int                 `json:"privacy_score"`
 			Operations     []string            `json:"operations"`
 			AuthKey        string              `json:"auth_key"`
+			HasAuthKey     bool                `json:"has_auth_key"`
 			AuthSchemaName string              `json:"auth_schema_name"`
 			Active         bool                `json:"active"`
 			Namespace      string              `json:"namespace"`
@@ -404,7 +408,8 @@ func toToolResponse(tool *models.Tool) ToolResponse {
 			OASSpec:        tool.OASSpec,
 			PrivacyScore:   tool.PrivacyScore,
 			Operations:     ops,
-			AuthKey:        tool.AuthKey,
+			AuthKey:        services.REDACTED_VALUE,
+			HasAuthKey:     tool.AuthKey != "",
 			AuthSchemaName: tool.AuthSchemaName,
 			Active:         tool.Active,
 		},

--- a/api/tool_handlers.go
+++ b/api/tool_handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/services"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
@@ -220,7 +221,9 @@ func (a *API) updateTool(c *gin.Context) {
 	tool.OASSpec = input.Data.Attributes.OASSpec
 	tool.PrivacyScore = input.Data.Attributes.PrivacyScore
 	tool.AuthSchemaName = input.Data.Attributes.AuthSchemaName
-	tool.AuthKey = input.Data.Attributes.AuthKey
+	if input.Data.Attributes.AuthKey != services.REDACTED_VALUE {
+		tool.AuthKey = input.Data.Attributes.AuthKey
+	}
 
 	// Namespace change requires admin authorization
 	if input.Data.Attributes.Namespace != tool.Namespace {
@@ -1040,6 +1043,7 @@ func serializeTool(tool *models.Tool, db *gorm.DB) ToolResponse {
 			PrivacyScore   int                 `json:"privacy_score"`
 			Operations     []string            `json:"operations"`
 			AuthKey        string              `json:"auth_key"`
+			HasAuthKey     bool                `json:"has_auth_key"`
 			AuthSchemaName string              `json:"auth_schema_name"`
 			Active         bool                `json:"active"`
 			Namespace      string              `json:"namespace"`
@@ -1053,7 +1057,8 @@ func serializeTool(tool *models.Tool, db *gorm.DB) ToolResponse {
 			OASSpec:        tool.OASSpec,
 			PrivacyScore:   tool.PrivacyScore,
 			Operations:     tool.GetOperations(),
-			AuthKey:        tool.AuthKey,
+			AuthKey:        services.REDACTED_VALUE,
+			HasAuthKey:     tool.AuthKey != "",
 			AuthSchemaName: tool.AuthSchemaName,
 			Active:         tool.Active,
 			Namespace:      tool.Namespace,
@@ -1100,6 +1105,7 @@ func serializeToolSlim(tool *models.Tool, db *gorm.DB) ToolResponse {
 			PrivacyScore   int                 `json:"privacy_score"`
 			Operations     []string            `json:"operations"`
 			AuthKey        string              `json:"auth_key"`
+			HasAuthKey     bool                `json:"has_auth_key"`
 			AuthSchemaName string              `json:"auth_schema_name"`
 			Active         bool                `json:"active"`
 			Namespace      string              `json:"namespace"`
@@ -1113,7 +1119,8 @@ func serializeToolSlim(tool *models.Tool, db *gorm.DB) ToolResponse {
 			OASSpec:        "", // Omit large OAS spec
 			PrivacyScore:   tool.PrivacyScore,
 			Operations:     tool.GetOperations(),
-			AuthKey:        "", // Omit sensitive auth key
+			AuthKey:        services.REDACTED_VALUE,
+			HasAuthKey:     tool.AuthKey != "",
 			AuthSchemaName: tool.AuthSchemaName,
 			Active:         tool.Active,
 			Namespace:      tool.Namespace,

--- a/api/tool_handlers_test.go
+++ b/api/tool_handlers_test.go
@@ -145,6 +145,94 @@ func TestToolEndpoints(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
+func TestToolAuthKeyRedaction(t *testing.T) {
+	api, _ := setupTestAPI(t)
+
+	makeInput := func(name, authKey string) ToolInput {
+		return ToolInput{
+			Data: struct {
+				Type       string `json:"type"`
+				Attributes struct {
+					Name           string   `json:"name"`
+					Description    string   `json:"description"`
+					ToolType       string   `json:"tool_type"`
+					OASSpec        string   `json:"oas_spec"`
+					PrivacyScore   int      `json:"privacy_score"`
+					AuthKey        string   `json:"auth_key"`
+					AuthSchemaName string   `json:"auth_schema_name"`
+					Operations     []string `json:"operations"`
+					Namespace      string   `json:"namespace"`
+				} `json:"attributes"`
+			}{
+				Type: "tools",
+				Attributes: struct {
+					Name           string   `json:"name"`
+					Description    string   `json:"description"`
+					ToolType       string   `json:"tool_type"`
+					OASSpec        string   `json:"oas_spec"`
+					PrivacyScore   int      `json:"privacy_score"`
+					AuthKey        string   `json:"auth_key"`
+					AuthSchemaName string   `json:"auth_schema_name"`
+					Operations     []string `json:"operations"`
+					Namespace      string   `json:"namespace"`
+				}{
+					Name:     name,
+					AuthKey:  authKey,
+					ToolType: models.ToolTypeREST,
+					OASSpec:  `{"openapi": "3.0.0"}`,
+				},
+			},
+		}
+	}
+
+	// Create a tool with an auth key
+	w := performRequest(api.router, "POST", "/api/v1/tools", makeInput("SecureTool", "super-secret-key"))
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var createResp map[string]ToolResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &createResp))
+	toolID := createResp["data"].ID
+
+	// GET single tool: auth_key must be redacted, has_auth_key must be true
+	w = performRequest(api.router, "GET", fmt.Sprintf("/api/v1/tools/%s", toolID), nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var getResp map[string]ToolResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &getResp))
+	assert.Equal(t, "[redacted]", getResp["data"].Attributes.AuthKey, "auth_key must be redacted on GET")
+	assert.True(t, getResp["data"].Attributes.HasAuthKey, "has_auth_key must be true when a key is set")
+
+	// GET list: same masking applies
+	w = performRequest(api.router, "GET", "/api/v1/tools", nil)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var listResp map[string][]ToolResponse
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &listResp))
+	assert.Equal(t, "[redacted]", listResp["data"][0].Attributes.AuthKey, "auth_key must be redacted in list")
+	assert.True(t, listResp["data"][0].Attributes.HasAuthKey, "has_auth_key must be true in list")
+
+	// PATCH with [redacted] must NOT overwrite the stored key
+	w = performRequest(api.router, "PATCH", fmt.Sprintf("/api/v1/tools/%s", toolID), makeInput("SecureTool", "[redacted]"))
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Re-fetch and confirm key is still set
+	w = performRequest(api.router, "GET", fmt.Sprintf("/api/v1/tools/%s", toolID), nil)
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &getResp))
+	assert.True(t, getResp["data"].Attributes.HasAuthKey, "key must still be set after PATCH with [redacted]")
+
+	// PATCH with a new key value must update it (has_auth_key stays true)
+	w = performRequest(api.router, "PATCH", fmt.Sprintf("/api/v1/tools/%s", toolID), makeInput("SecureTool", "new-secret-key"))
+	assert.Equal(t, http.StatusOK, w.Code)
+	w = performRequest(api.router, "GET", fmt.Sprintf("/api/v1/tools/%s", toolID), nil)
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &getResp))
+	assert.Equal(t, "[redacted]", getResp["data"].Attributes.AuthKey, "new key must also be redacted")
+	assert.True(t, getResp["data"].Attributes.HasAuthKey, "has_auth_key must remain true after key update")
+
+	// PATCH with empty string must clear the key
+	w = performRequest(api.router, "PATCH", fmt.Sprintf("/api/v1/tools/%s", toolID), makeInput("SecureTool", ""))
+	assert.Equal(t, http.StatusOK, w.Code)
+	w = performRequest(api.router, "GET", fmt.Sprintf("/api/v1/tools/%s", toolID), nil)
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &getResp))
+	assert.False(t, getResp["data"].Attributes.HasAuthKey, "has_auth_key must be false after clearing key")
+}
+
 func TestToolEndpointsErrors(t *testing.T) {
 	api, _ := setupTestAPI(t)
 


### PR DESCRIPTION
## Summary

- Tool API keys (`auth_key`) were returned in plaintext on all `GET /tools` and `GET /tools/:id` responses, making them visible in browser devtools/network tab
- Applies the same `[redacted]` + `has_auth_key bool` masking pattern already used by LLM and Datasource handlers
- `PATCH` requests that send back `[redacted]` (as the frontend will after this fix) are now ignored, preserving the stored key — matching how LLM key updates work
- Affected serializers: `serializeTool`, `serializeToolSlim`, `toToolResponse`, `toSecureToolResponse`, and two inline response builders in `common.go`

## Test plan

- [ ] `TestToolAuthKeyRedaction` covers the key scenarios: redaction on GET single + list, `[redacted]` no-op on PATCH, real key update, and key clear with `""`
- [ ] Run `go test ./api/... -run TestTool` — all tool tests pass
- [ ] Manually verify: create a tool with an auth key, confirm `auth_key: "[redacted]"` and `has_auth_key: true` appear in the network response

🤖 Generated with [Claude Code](https://claude.com/claude-code)