### PR TITLE
feat: add Export to PDF button for chat conversations

### DIFF
--- a/ui/admin-frontend/src/portal/components/ChatView.js
+++ b/ui/admin-frontend/src/portal/components/ChatView.js
@@ -15,7 +15,10 @@ import { TitleBox } from '../../admin/styles/sharedStyles';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import AddIcon from '@mui/icons-material/Add';
+import PrintIcon from '@mui/icons-material/Print';
 import pubClient from '../../admin/utils/pubClient';
+import usePrintChat from './chat/hooks/usePrintChat';
+import './chat/printChat.css';
 
 import { useChatSSE } from './chat/hooks/useChatSSE';
 import MessageContent from './chat/MessageContent';
@@ -62,6 +65,12 @@ const ChatView = () => {
     messages.some(message => message.type === 'user'),
     [messages]
   );
+
+  const { handlePrint, canPrint } = usePrintChat({
+    chatName,
+    messages,
+    messagesContainerRef: messageContainerRef,
+  });
 
   // Process error messages to extract meaningful information
   const processErrorMessage = (error) => {
@@ -715,16 +724,25 @@ const ChatView = () => {
 
   return (
     <>
-      <TitleBox top="64px">
+      <TitleBox top="64px" data-print-role="toolbar">
         <Typography variant="headingXLarge">{chatName}</Typography>
-        <Button
-          variant="outlined"
-          startIcon={<AddIcon />}
-          onClick={handleNewChat}
-          sx={{ ml: 2 }}
-        >
-          New Chat
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button
+            variant="outlined"
+            startIcon={<PrintIcon />}
+            onClick={handlePrint}
+            disabled={!canPrint}
+          >
+            Export
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={handleNewChat}
+          >
+            New Chat
+          </Button>
+        </Box>
       </TitleBox>
       <Box
         sx={{
@@ -732,9 +750,10 @@ const ChatView = () => {
           display: 'flex',
           flexDirection: 'column',
         }}
+        data-print-role="chat-outer"
       >
         <Grid container sx={{ flexGrow: 1, overflow: 'hidden', mb: 4 }}>
-          <Grid item xs={9} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Grid item xs={9} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }} data-print-role="messages-grid">
             {/* Messages container */}
             <Box
               sx={{
@@ -745,6 +764,7 @@ const ChatView = () => {
                 width: '100%',
               }}
               ref={messageContainerRef}
+              data-print-role="messages"
             >
               <Box sx={{
                 maxWidth: '740px',
@@ -753,7 +773,7 @@ const ChatView = () => {
                 display: 'flex',
                 flexDirection: 'column',
                 flexGrow: 1,
-              }}>
+              }} data-print-role="messages-inner">
                 {!hasUserMessages ? (
                   <Box sx={{
                     width: '100%',
@@ -802,7 +822,7 @@ const ChatView = () => {
                 ) : (
                   <>
                     {messages.length > 1 && (
-                      <Box sx={{ mt: 2, textAlign: 'right' }}>
+                      <Box sx={{ mt: 2, textAlign: 'right' }} data-print-role="system-toggle">
                         <Typography
                           variant="caption"
                           component="div"
@@ -926,7 +946,7 @@ const ChatView = () => {
                 width: '100%',
                 padding: 2,
                 paddingTop: 0,
-              }}>
+              }} data-print-role="input">
                 <Box sx={{
                   maxWidth: '740px',
                   width: '100%',
@@ -950,7 +970,7 @@ const ChatView = () => {
             )}
           </Grid>
 
-          <Grid item xs={3} sx={{ height: '100%', overflowY: 'auto' }}>
+          <Grid item xs={3} sx={{ height: '100%', overflowY: 'auto' }} data-print-role="sidebar">
             <ChatSidebar
               currentlyUsing={currentlyUsing}
               databases={databases}

--- a/ui/admin-frontend/src/portal/components/chat/hooks/usePrintChat.js
+++ b/ui/admin-frontend/src/portal/components/chat/hooks/usePrintChat.js
@@ -1,0 +1,45 @@
+import { useMemo, useCallback } from 'react';
+import { format } from 'date-fns';
+
+const usePrintChat = ({ chatName, messages, messagesContainerRef }) => {
+  const canPrint = useMemo(() => {
+    return messages.some(m => m.type === 'user' || m.role === 'user');
+  }, [messages]);
+
+  const handlePrint = useCallback(() => {
+    if (!canPrint) return;
+
+    // Create and inject print header
+    const header = document.createElement('div');
+    header.setAttribute('data-print-role', 'print-header');
+    header.style.display = 'none'; // Hidden on screen, shown via print CSS
+    header.innerHTML = `
+      <h1>${chatName || 'Chat Conversation'}</h1>
+      <p>Exported on ${format(new Date(), 'MMMM d, yyyy \'at\' h:mm a')}</p>
+    `;
+
+    // Insert header at the top of the messages container
+    const container = messagesContainerRef?.current;
+    if (container) {
+      container.insertBefore(header, container.firstChild);
+    } else {
+      document.body.insertBefore(header, document.body.firstChild);
+    }
+
+    const cleanup = () => {
+      header.remove();
+    };
+
+    window.addEventListener('afterprint', cleanup, { once: true });
+
+    // Fallback cleanup in case afterprint doesn't fire
+    const fallbackTimeout = setTimeout(cleanup, 5000);
+    window.addEventListener('afterprint', () => clearTimeout(fallbackTimeout), { once: true });
+
+    window.print();
+  }, [canPrint, chatName, messagesContainerRef]);
+
+  return { handlePrint, canPrint };
+};
+
+export default usePrintChat;

--- a/ui/admin-frontend/src/portal/components/chat/hooks/usePrintChat.test.js
+++ b/ui/admin-frontend/src/portal/components/chat/hooks/usePrintChat.test.js
@@ -1,0 +1,185 @@
+import { renderHook, act } from '@testing-library/react';
+import usePrintChat from './usePrintChat';
+
+describe('usePrintChat', () => {
+  let printSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    printSpy = jest.spyOn(window, 'print').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    printSpy.mockRestore();
+    // Clean up any injected print headers
+    document.querySelectorAll('[data-print-role="print-header"]').forEach(el => el.remove());
+  });
+
+  describe('canPrint', () => {
+    test('returns false when messages array is empty', () => {
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages: [], messagesContainerRef: { current: null } })
+      );
+      expect(result.current.canPrint).toBe(false);
+    });
+
+    test('returns false when there are only AI messages', () => {
+      const messages = [
+        { id: '1', type: 'ai', content: 'Hello' },
+        { id: '2', type: 'system', content: 'System msg' },
+      ];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+      expect(result.current.canPrint).toBe(false);
+    });
+
+    test('returns true when there is a user message (type field)', () => {
+      const messages = [
+        { id: '1', type: 'user', content: 'Hi' },
+        { id: '2', type: 'ai', content: 'Hello' },
+      ];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+      expect(result.current.canPrint).toBe(true);
+    });
+
+    test('returns true when there is a user message (role field, AgentChat)', () => {
+      const messages = [
+        { id: '1', role: 'user', content: 'Hi' },
+        { id: '2', role: 'agent', content: 'Hello' },
+      ];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+      expect(result.current.canPrint).toBe(true);
+    });
+
+    test('updates when messages change', () => {
+      let messages = [];
+      const { result, rerender } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+      expect(result.current.canPrint).toBe(false);
+
+      messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      rerender();
+      expect(result.current.canPrint).toBe(true);
+    });
+  });
+
+  describe('handlePrint', () => {
+    test('does not call window.print when canPrint is false', () => {
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages: [], messagesContainerRef: { current: null } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      expect(printSpy).not.toHaveBeenCalled();
+    });
+
+    test('calls window.print when canPrint is true', () => {
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      expect(printSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('injects print header into the messages container', () => {
+      const container = document.createElement('div');
+      const existingChild = document.createElement('p');
+      container.appendChild(existingChild);
+
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'My Chat', messages, messagesContainerRef: { current: container } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      const header = container.querySelector('[data-print-role="print-header"]');
+      expect(header).not.toBeNull();
+      expect(header.querySelector('h1').textContent).toBe('My Chat');
+      expect(header.querySelector('p').textContent).toContain('Exported on');
+      // Header should be the first child
+      expect(container.firstChild).toBe(header);
+    });
+
+    test('uses fallback chat name when chatName is not provided', () => {
+      const container = document.createElement('div');
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: '', messages, messagesContainerRef: { current: container } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      const header = container.querySelector('[data-print-role="print-header"]');
+      expect(header.querySelector('h1').textContent).toBe('Chat Conversation');
+    });
+
+    test('injects header into document.body when no container ref', () => {
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: null } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      const header = document.body.querySelector('[data-print-role="print-header"]');
+      expect(header).not.toBeNull();
+    });
+
+    test('cleans up header on afterprint event', () => {
+      const container = document.createElement('div');
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: container } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      expect(container.querySelector('[data-print-role="print-header"]')).not.toBeNull();
+
+      // Simulate afterprint event
+      act(() => {
+        window.dispatchEvent(new Event('afterprint'));
+      });
+
+      expect(container.querySelector('[data-print-role="print-header"]')).toBeNull();
+    });
+
+    test('header is hidden on screen via inline style', () => {
+      const container = document.createElement('div');
+      const messages = [{ id: '1', type: 'user', content: 'Hi' }];
+      const { result } = renderHook(() =>
+        usePrintChat({ chatName: 'Test', messages, messagesContainerRef: { current: container } })
+      );
+
+      act(() => {
+        result.current.handlePrint();
+      });
+
+      const header = container.querySelector('[data-print-role="print-header"]');
+      expect(header.style.display).toBe('none');
+    });
+  });
+});

--- a/ui/admin-frontend/src/portal/components/chat/printChat.css
+++ b/ui/admin-frontend/src/portal/components/chat/printChat.css
@@ -1,0 +1,146 @@
+@media print {
+  /* Hide MUI AppBar (fixed position, renders outside parent flow) */
+  .MuiAppBar-root {
+    display: none !important;
+  }
+
+  /* Hide MUI Drawer (fixed position, renders outside parent flow) */
+  .MuiDrawer-root {
+    display: none !important;
+  }
+
+  /* Hide the Toolbar spacer in the main content area */
+  [data-print-role="main"] > .MuiToolbar-root {
+    display: none !important;
+  }
+
+  /* Hide entire toolbar (print header replaces it) */
+  [data-print-role="toolbar"] {
+    display: none !important;
+  }
+
+  /* Hide chat input */
+  [data-print-role="input"] {
+    display: none !important;
+  }
+
+  /* Hide sidebar */
+  [data-print-role="sidebar"] {
+    display: none !important;
+  }
+
+  /* Hide system message toggle */
+  [data-print-role="system-toggle"] {
+    display: none !important;
+  }
+
+  /* Hide welcome screen */
+  [data-print-role="welcome"] {
+    display: none !important;
+  }
+
+  /* Show print header */
+  [data-print-role="print-header"] {
+    display: block !important;
+    padding: 16px 0;
+    margin-bottom: 16px;
+    border-bottom: 2px solid #333;
+  }
+
+  [data-print-role="print-header"] h1 {
+    margin: 0 0 4px 0;
+    font-size: 20px;
+    font-weight: 600;
+  }
+
+  [data-print-role="print-header"] p {
+    margin: 0;
+    font-size: 12px;
+    color: #666;
+  }
+
+  /* Make main content full width, remove margin/padding from drawer offset */
+  [data-print-role="main"],
+  main,
+  [class*="MuiBox-root"] > main {
+    margin: 0 !important;
+    margin-top: 0 !important;
+    margin-left: 0 !important;
+    padding: 8px !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    flex-grow: 1 !important;
+  }
+
+  /* Messages container: full width, no scroll */
+  [data-print-role="messages"] {
+    overflow: visible !important;
+    height: auto !important;
+    max-height: none !important;
+  }
+
+  /* Remove max-width on message content */
+  [data-print-role="messages-inner"] {
+    max-width: 100% !important;
+  }
+
+  /* Messages grid: full width */
+  [data-print-role="messages-grid"] {
+    max-width: 100% !important;
+    flex-basis: 100% !important;
+    overflow: visible !important;
+    height: auto !important;
+  }
+
+  /* Outer container: no fixed height */
+  [data-print-role="chat-outer"] {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  /* Prevent page breaks inside messages */
+  [data-print-role="messages"] > div > div {
+    break-inside: avoid;
+  }
+
+  /* Code blocks: ensure they wrap and don't overflow the page */
+  pre {
+    white-space: pre-wrap !important;
+    word-wrap: break-word !important;
+  }
+
+  /* Hide code copy buttons */
+  pre button,
+  .copy-button {
+    display: none !important;
+  }
+
+  /* Ensure links are visible with URL */
+  a[href]:after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  /* Internal links: don't show URL */
+  a[href^="#"]:after,
+  a[href^="javascript"]:after {
+    content: "";
+  }
+
+  /* Page setup */
+  @page {
+    margin: 1.5cm;
+    size: A4;
+  }
+
+  /* Remove backgrounds and shadows for cleaner print */
+  * {
+    box-shadow: none !important;
+  }
+
+  body {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/ui/admin-frontend/src/portal/layouts/PortalLayout.js
+++ b/ui/admin-frontend/src/portal/layouts/PortalLayout.js
@@ -9,7 +9,7 @@ const PortalLayout = () => {
     <Box sx={{ display: "flex" }}>
       <PortalAppBar />
       <PortalDrawer />
-      <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
+      <Box component="main" sx={{ flexGrow: 1, p: 3 }} data-print-role="main">
         <Toolbar /> {/* This creates space below the AppBar */}
         <Outlet />
       </Box>

--- a/ui/admin-frontend/src/portal/pages/AgentChat.js
+++ b/ui/admin-frontend/src/portal/pages/AgentChat.js
@@ -12,10 +12,13 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import AddIcon from '@mui/icons-material/Add';
+import PrintIcon from '@mui/icons-material/Print';
 import { TitleBox } from '../../admin/styles/sharedStyles';
 import agentService from '../services/agentService';
 import ChatInput from '../components/chat/ChatInput';
 import AgentMessage from '../components/agents/AgentMessage';
+import usePrintChat from '../components/chat/hooks/usePrintChat';
+import '../components/chat/printChat.css';
 
 const AgentChat = () => {
   const { agentId } = useParams();
@@ -42,6 +45,12 @@ const AgentChat = () => {
     messages.some(message => message.role === 'user'),
     [messages]
   );
+
+  const { handlePrint, canPrint } = usePrintChat({
+    chatName: agent?.name,
+    messages,
+    messagesContainerRef: messagesEndRef,
+  });
 
   useEffect(() => {
     loadAgent();
@@ -261,7 +270,7 @@ const AgentChat = () => {
   return (
     <>
       {/* Header */}
-      <TitleBox top="64px">
+      <TitleBox top="64px" data-print-role="toolbar">
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: 1 }}>
           <IconButton onClick={handleBack} size="small">
             <ArrowBackIcon />
@@ -277,19 +286,29 @@ const AgentChat = () => {
               </Typography>
             )}
           </Box>
-          <Button
-            variant="outlined"
-            startIcon={<AddIcon />}
-            onClick={handleNewChat}
-          >
-            New Chat
-          </Button>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              variant="outlined"
+              startIcon={<PrintIcon />}
+              onClick={handlePrint}
+              disabled={!canPrint}
+            >
+              Export
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<AddIcon />}
+              onClick={handleNewChat}
+            >
+              New Chat
+            </Button>
+          </Box>
         </Box>
       </TitleBox>
 
-      <Box sx={{ height: '85vh', display: 'flex', flexDirection: 'column' }}>
+      <Box sx={{ height: '85vh', display: 'flex', flexDirection: 'column' }} data-print-role="chat-outer">
         <Grid container sx={{ flexGrow: 1, overflow: 'hidden', mb: 4 }}>
-          <Grid item xs={12} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+          <Grid item xs={12} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }} data-print-role="messages-grid">
             {/* Messages container */}
             <Box
               sx={{
@@ -300,6 +319,7 @@ const AgentChat = () => {
                 width: '100%',
               }}
               ref={messagesEndRef}
+              data-print-role="messages"
             >
               <Box sx={{
                 maxWidth: '740px',
@@ -308,7 +328,7 @@ const AgentChat = () => {
                 display: 'flex',
                 flexDirection: 'column',
                 flexGrow: 1,
-              }}>
+              }} data-print-role="messages-inner">
                 {!hasUserMessages ? (
                   <Box sx={{
                     width: '100%',
@@ -367,7 +387,7 @@ const AgentChat = () => {
                 ) : (
                   <>
                     {/* System message toggle - reserve space even when not shown to prevent layout shift */}
-                    <Box sx={{ mt: 2, textAlign: 'right', minHeight: '24px' }}>
+                    <Box sx={{ mt: 2, textAlign: 'right', minHeight: '24px' }} data-print-role="system-toggle">
                       {messages.length > 1 && (
                         <Typography
                           variant="caption"
@@ -416,7 +436,7 @@ const AgentChat = () => {
                 width: '100%',
                 padding: 2,
                 paddingTop: 0,
-              }}>
+              }} data-print-role="input">
                 <Box sx={{
                   maxWidth: '740px',
                   width: '100%',


### PR DESCRIPTION
## Summary

- Adds an "Export" button to both ChatView and AgentChat toolbars that opens the browser's native print dialog, allowing users to print or save conversations as PDF
- Uses `@media print` CSS to hide app chrome (nav, drawer, sidebar, input) and show only the conversation with a title/date header
- Zero new dependencies — leverages the browser's built-in print/PDF capabilities
- Includes 12 unit tests for the `usePrintChat` hook

Closes #343

## Test plan

- [ ] Open a chat with several messages (including code blocks and markdown)
- [ ] Click "Export" — verify browser print dialog opens
- [ ] Verify print preview shows only the conversation (no sidebar, nav, input)
- [ ] Verify code blocks retain syntax highlighting
- [ ] Verify "Save as PDF" produces a clean document
- [ ] Verify the Export button is disabled when there are no user messages
- [ ] Test in AgentChat view as well
- [ ] Run `npx react-scripts test --watchAll=false --testPathPattern=usePrintChat` — all 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)