### PR TITLE
fix: CSRF origin validation in Docker dev environment

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -211,10 +211,16 @@ func NewAPI(service *services.Service, disableCORS bool, authService *auth.AuthS
 	// no CSRF for tests
 	if !config.TestMode {
 		// Add CSRF middleware
-		csrfMiddleware := csrf.Protect(
-			csrfKey,
+		csrfOpts := []csrf.Option{
 			csrf.Secure(false), // Allow HTTP in development
 			csrf.Path("/"),
+		}
+		if os.Getenv("DEVMODE") == "true" || os.Getenv("DEVMODE") == "1" {
+			csrfOpts = append(csrfOpts, csrf.TrustedOrigins([]string{"localhost:3000"}))
+		}
+		csrfMiddleware := csrf.Protect(
+			csrfKey,
+			csrfOpts...,
 		)
 
 		api.router.Use(func(c *gin.Context) {
@@ -234,6 +240,11 @@ func NewAPI(service *services.Service, disableCORS bool, authService *auth.AuthS
 				c.Request = r
 				c.Next()
 			})).ServeHTTP(c.Writer, c.Request)
+
+			// If CSRF middleware rejected the request, abort the gin chain
+			if c.Writer.Status() == http.StatusForbidden {
+				c.Abort()
+			}
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Adds `localhost:3000` as a trusted CSRF origin when `DEVMODE` is enabled, fixing login failures in the Docker dev environment where the frontend proxy origin doesn't match the backend container host
- Fixes the gin middleware to properly abort the handler chain when CSRF validation fails, preventing handlers from executing after rejection

## Test plan
- [ ] Run `make dev-full-ent` and verify login works at http://localhost:3000
- [ ] Verify CSRF protection still works in production (without DEVMODE)
- [ ] Verify API calls with `Authorization` header still bypass CSRF

🤖 Generated with [Claude Code](https://claude.com/claude-code)