### PR TITLE
fix: resolve secret interpolation for chat resume and datasource embedding keys

### DIFF
--- a/api/chat_session_handler.go
+++ b/api/chat_session_handler.go
@@ -307,10 +307,18 @@ func handleSSEOutgoingMessages(w http.ResponseWriter, cs *chat_session.ChatSessi
 
 func (a *API) loadExistingSession(sessionID string, userID uint) (*chat_session.ChatSession, error) {
 	history := chat_session.NewGormChatMessageHistory(a.service.DB, sessionID, 0, userID, "")
-	chat, err := history.GetAssociatedChat(context.Background())
+	chatFromHistory, err := history.GetAssociatedChat(context.Background())
 	if err != nil {
 		return nil, err
 	}
+
+	// Reload via service layer to resolve secret references ($SECRET/NAME)
+	// GetAssociatedChat uses the model layer directly which bypasses secret interpolation
+	chat, err := a.service.GetChatByID(chatFromHistory.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	chatSession, err := chat_session.NewChatSession(
 		chat,
 		chat_session.ChatStream,

--- a/api/secret_interpolation_test.go
+++ b/api/secret_interpolation_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	apitest "github.com/TykTechnologies/midsommar/v2/api/testing"
+	"github.com/TykTechnologies/midsommar/v2/chat_session"
+	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadExistingSessionResolvesSecrets verifies that when a chat session is
+// resumed via loadExistingSession, the LLM API key is resolved from a
+// $SECRET/NAME reference. Before the fix, loadExistingSession used the model
+// layer directly (chat.Get) which bypassed secret interpolation.
+func TestLoadExistingSessionResolvesSecrets(t *testing.T) {
+	os.Setenv("TYK_AI_SECRET_KEY", "test-encryption-key-for-secrets")
+	defer os.Unsetenv("TYK_AI_SECRET_KEY")
+
+	db := apitest.SetupTestDB(t)
+	service := apitest.SetupTestService(db)
+	secrets.SetDBRef(db)
+
+	config := apitest.SetupTestAuthConfig(db, service)
+	authService := apitest.SetupTestAuthService(db, service)
+	a := NewAPI(service, true, authService, config, nil, emptyFile, nil)
+
+	// Create a secret
+	secret := &secrets.Secret{
+		VarName: "TEST_LLM_KEY",
+		Value:   "sk-actual-secret-key-12345",
+	}
+	err := secrets.CreateSecret(db, secret)
+	require.NoError(t, err)
+
+	// Create an LLM with a secret reference
+	llm := &models.LLM{
+		Name:   "Test LLM",
+		Vendor: models.MOCK_VENDOR,
+		APIKey: "$SECRET/TEST_LLM_KEY",
+	}
+	err = llm.Create(db)
+	require.NoError(t, err)
+
+	llmSettings := &models.LLMSettings{
+		ModelName: "test-model",
+	}
+	err = llmSettings.Create(db)
+	require.NoError(t, err)
+
+	chat := &models.Chat{
+		Name:          "Test Chat",
+		LLMID:         llm.ID,
+		LLMSettingsID: llmSettings.ID,
+	}
+	err = chat.Create(db)
+	require.NoError(t, err)
+
+	user := &models.User{
+		Email:         "testuser@example.com",
+		Name:          "Test User",
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	err = user.Create(db)
+	require.NoError(t, err)
+
+	// First, verify the bug: loading via model layer does NOT resolve secrets
+	rawChat := &models.Chat{}
+	err = rawChat.Get(db, chat.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "$SECRET/TEST_LLM_KEY", rawChat.LLM.APIKey,
+		"Model layer should return raw secret reference (this is the bug path)")
+
+	// Verify the fix: service layer DOES resolve secrets
+	resolvedChat, err := service.GetChatByID(chat.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "sk-actual-secret-key-12345", resolvedChat.LLM.APIKey,
+		"Service layer should resolve secret reference to actual value")
+
+	// Now test loadExistingSession end-to-end:
+	// Create a session record so we can resume it
+	history := chat_session.NewGormChatMessageHistory(db, "test-session-id", chat.ID, user.ID, "")
+	_, err = history.GetAssociatedChat(context.Background())
+	require.NoError(t, err)
+
+	// Resume via loadExistingSession (which now uses service.GetChatByID)
+	resumedSession, err := a.loadExistingSession("test-session-id", user.ID)
+	require.NoError(t, err)
+	require.NotNil(t, resumedSession)
+}

--- a/chat_session/chat_session.go
+++ b/chat_session/chat_session.go
@@ -16,6 +16,7 @@ import (
 	dataSession "github.com/TykTechnologies/midsommar/v2/data_session"
 	"github.com/TykTechnologies/midsommar/v2/helpers"
 	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/secrets"
 	"github.com/TykTechnologies/midsommar/v2/scripting"
 	"github.com/TykTechnologies/midsommar/v2/services"
 	"github.com/TykTechnologies/midsommar/v2/switches"
@@ -157,6 +158,10 @@ func (cs *ChatSession) AddDatasource(id uint) error {
 	if !entitlements.HasDataSourceAccess(ds.ID) {
 		return fmt.Errorf("user does not have access to datasource %s", ds.Name)
 	}
+
+	// Resolve secret references for embedding and DB connection API keys
+	ds.EmbedAPIKey = secrets.GetValue(ds.EmbedAPIKey, false)
+	ds.DBConnAPIKey = secrets.GetValue(ds.DBConnAPIKey, false)
 
 	cs.datasources[id] = &ds
 

--- a/chat_session/secret_interpolation_test.go
+++ b/chat_session/secret_interpolation_test.go
@@ -1,0 +1,122 @@
+package chat_session
+
+import (
+	"os"
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/secrets"
+	"github.com/TykTechnologies/midsommar/v2/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddDatasourceResolvesSecrets verifies that when a datasource is added to
+// a chat session, the EmbedAPIKey and DBConnAPIKey fields are resolved from
+// $SECRET/NAME references to their actual decrypted values.
+func TestAddDatasourceResolvesSecrets(t *testing.T) {
+	os.Setenv("TYK_AI_SECRET_KEY", "test-encryption-key-for-secrets")
+	defer os.Unsetenv("TYK_AI_SECRET_KEY")
+
+	db := setupTestDB(t)
+	secrets.SetDBRef(db)
+	service := services.NewService(db)
+
+	// Create secrets for embed and DB connection keys
+	embedSecret := &secrets.Secret{
+		VarName: "TEST_EMBED_KEY",
+		Value:   "sk-embed-actual-key-12345",
+	}
+	err := secrets.CreateSecret(db, embedSecret)
+	require.NoError(t, err)
+
+	dbConnSecret := &secrets.Secret{
+		VarName: "TEST_DBCONN_KEY",
+		Value:   "dbconn-actual-key-67890",
+	}
+	err = secrets.CreateSecret(db, dbConnSecret)
+	require.NoError(t, err)
+
+	// Create a datasource with secret references
+	ds := &models.Datasource{
+		Name:        "Test Datasource",
+		EmbedAPIKey: "$SECRET/TEST_EMBED_KEY",
+		DBConnAPIKey: "$SECRET/TEST_DBCONN_KEY",
+	}
+	err = db.Create(ds).Error
+	require.NoError(t, err)
+
+	// Create an admin user (bypasses entitlements check)
+	adminUser := &models.User{
+		Email:         "admin@test.com",
+		Name:          "Admin User",
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	err = adminUser.Create(db)
+	require.NoError(t, err)
+	adminUID := adminUser.ID
+
+	// Create a chat session
+	chat := &models.Chat{
+		LLM:         &models.LLM{Name: "Dummy LLM", Vendor: models.MOCK_VENDOR},
+		LLMSettings: &models.LLMSettings{ModelName: "dummy"},
+	}
+	cs, err := NewChatSession(chat, ChatMessage, db, service, nil, &adminUID, &sid)
+	require.NoError(t, err)
+
+	// Add the datasource — this should resolve secrets
+	err = cs.AddDatasource(ds.ID)
+	require.NoError(t, err)
+
+	// Verify the datasource was added with resolved secrets
+	addedDS, ok := cs.datasources[ds.ID]
+	require.True(t, ok, "Datasource should be in the session")
+
+	assert.Equal(t, "sk-embed-actual-key-12345", addedDS.EmbedAPIKey,
+		"EmbedAPIKey should be resolved from secret reference to actual value")
+	assert.Equal(t, "dbconn-actual-key-67890", addedDS.DBConnAPIKey,
+		"DBConnAPIKey should be resolved from secret reference to actual value")
+}
+
+// TestAddDatasourcePlainKeysUnchanged verifies that plain (non-secret-reference)
+// API keys are passed through unchanged.
+func TestAddDatasourcePlainKeysUnchanged(t *testing.T) {
+	db := setupTestDB(t)
+	secrets.SetDBRef(db)
+	service := services.NewService(db)
+
+	ds := &models.Datasource{
+		Name:         "Plain Key Datasource",
+		EmbedAPIKey:  "sk-plain-embed-key",
+		DBConnAPIKey: "plain-dbconn-key",
+	}
+	err := db.Create(ds).Error
+	require.NoError(t, err)
+
+	adminUser := &models.User{
+		Email:         "admin@test.com",
+		Name:          "Admin User",
+		IsAdmin:       true,
+		EmailVerified: true,
+	}
+	err = adminUser.Create(db)
+	require.NoError(t, err)
+	adminUID := adminUser.ID
+
+	chat := &models.Chat{
+		LLM:         &models.LLM{Name: "Dummy LLM", Vendor: models.MOCK_VENDOR},
+		LLMSettings: &models.LLMSettings{ModelName: "dummy"},
+	}
+	cs, err := NewChatSession(chat, ChatMessage, db, service, nil, &adminUID, &sid)
+	require.NoError(t, err)
+
+	err = cs.AddDatasource(ds.ID)
+	require.NoError(t, err)
+
+	addedDS := cs.datasources[ds.ID]
+	assert.Equal(t, "sk-plain-embed-key", addedDS.EmbedAPIKey,
+		"Plain EmbedAPIKey should be passed through unchanged")
+	assert.Equal(t, "plain-dbconn-key", addedDS.DBConnAPIKey,
+		"Plain DBConnAPIKey should be passed through unchanged")
+}


### PR DESCRIPTION
## Summary
- **Chat resume**: `loadExistingSession` was using `GetAssociatedChat()` (model layer) which bypassed secret resolution. Now reloads the chat via `service.GetChatByID()` to properly resolve `$SECRET/NAME` references in LLM API keys and endpoints.
- **Datasource embedding**: `AddDatasource` loaded datasources via the model layer without resolving `EmbedAPIKey` and `DBConnAPIKey`. Now calls `secrets.GetValue()` after loading from DB.

Fixes #358

## Test plan
- [x] Added `TestLoadExistingSessionResolvesSecrets` — verifies model layer returns raw `$SECRET/` ref while service layer resolves it, and that `loadExistingSession` works end-to-end
- [x] Added `TestAddDatasourceResolvesSecrets` — verifies embedding and DB connection API keys are resolved after adding a datasource to a chat session
- [x] Added `TestAddDatasourcePlainKeysUnchanged` — verifies plain (non-secret) keys pass through unchanged
- [x] Existing test suites pass (`chat_session`, `services`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)