### PR TITLE
Replace dependency-review-action with dep-guard reusable workflow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,6 +2,12 @@ name: CI Tests
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
   push:
     branches:
       - main
@@ -14,17 +20,12 @@ env:
 
 jobs:
   # ==========================================================================
-  # Dependency Review (PR only)
+  # Dependency Guard
   # ==========================================================================
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+  dep-guard:
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@42304edda365365e0a887cf018d8edc34b960b82  # main
+    permissions:
+      contents: read
 
   # ==========================================================================
   # Go Linting (disabled for now)
@@ -60,6 +61,7 @@ jobs:
   # Frontend Tests (Jest)
   # ==========================================================================
   frontend-tests:
+    needs: [dep-guard]
     name: Frontend Tests
     runs-on: warp-ubuntu-latest-arm64-2x
     steps:
@@ -91,6 +93,7 @@ jobs:
   # Go Unit Tests (Studio + Microgateway) - Matrix for CE/ENT
   # ==========================================================================
   go-unit-tests:
+    needs: [dep-guard]
     name: Go Unit Tests (${{ matrix.edition }})
     runs-on: warp-ubuntu-latest-arm64-4x
     strategy:
@@ -181,6 +184,7 @@ jobs:
   # Documentation Build
   # ==========================================================================
   docs-build:
+    needs: [dep-guard]
     name: Documentation Build
     runs-on: warp-ubuntu-latest-arm64-2x
     steps:


### PR DESCRIPTION
## Summary
- Replace direct `actions/dependency-review-action` usage with `TykTechnologies/github-actions/.github/workflows/dependency-guard.yml` reusable workflow
- Add explicit PR type triggers (`opened`, `reopened`, `synchronize`, `ready_for_review`, `labeled`) for bypass label support
- Gate `frontend-tests`, `go-unit-tests`, and `docs-build` jobs behind `dep-guard` with `needs: [dep-guard]`

## Context
The previous hardening PR incorrectly pinned the dependency-review-action directly instead of using the org's reusable dep-guard workflow, which provides consistent policy enforcement and bypass label support across all repos.

## Test plan
- [ ] Verify dep-guard job runs on PR open
- [ ] Verify build jobs wait for dep-guard to pass
- [ ] Verify bypass label works via `labeled` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)