### PR TITLE
feat: add ListModelPrices/GetModelPricesByVendor to ai_studio_sdk

### DIFF
--- a/pkg/ai_studio_sdk/service_api.go
+++ b/pkg/ai_studio_sdk/service_api.go
@@ -936,6 +936,34 @@ func DeleteModelPrice(ctx context.Context, modelPriceID uint32) error {
 	return nil
 }
 
+// ListModelPrices lists model prices with optional vendor filter and pagination
+func ListModelPrices(ctx context.Context, vendor string, page, limit int32) (*mgmtpb.ListModelPricesResponse, error) {
+	client, err := getServiceClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("service client unavailable: %w", err)
+	}
+
+	return client.ListModelPrices(ctx, &mgmtpb.ListModelPricesRequest{
+		Context: createPluginContext(AvailableScopes.PricingRead),
+		Vendor:  vendor,
+		Page:    page,
+		Limit:   limit,
+	})
+}
+
+// GetModelPricesByVendor retrieves all model prices for a specific vendor
+func GetModelPricesByVendor(ctx context.Context, vendor string) (*mgmtpb.GetModelPricesByVendorResponse, error) {
+	client, err := getServiceClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("service client unavailable: %w", err)
+	}
+
+	return client.GetModelPricesByVendor(ctx, &mgmtpb.GetModelPricesByVendorRequest{
+		Context: createPluginContext(AvailableScopes.PricingRead),
+		Vendor:  vendor,
+	})
+}
+
 // === Datasource CRUD Operations ===
 
 // ListDatasources retrieves all datasources with optional filtering and pagination


### PR DESCRIPTION
## Summary
- Adds `ListModelPrices()` and `GetModelPricesByVendor()` wrapper functions to `pkg/ai_studio_sdk/service_api.go`
- These gRPC methods already existed in the proto definition but had no SDK wrappers
- Bumps community submodule ref to include the new `llm-price-sync` plugin (TykTechnologies/ai-studio-community-plugins#3)

## Test plan
- [ ] `go build ./pkg/ai_studio_sdk/...` compiles cleanly
- [ ] `go test ./...` passes
- [ ] Community plugin can call `ListModelPrices` and `GetModelPricesByVendor` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)