### PR TITLE
feat: general-purpose compliance event reporting from filter scripts

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -221,6 +221,24 @@ func RecordChatLogEntry(ctx context.Context, log *models.LLMChatLogEntry) {
 	}
 }
 
+// RecordComplianceEvents records filter script compliance events asynchronously
+func RecordComplianceEvents(ctx context.Context, events []*models.ComplianceEvent) {
+	if len(events) == 0 {
+		return
+	}
+
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
+
+	if globalHandler != nil {
+		globalHandler.RecordComplianceEvents(ctx, events)
+	}
+
+	for _, event := range events {
+		metrics.RecordComplianceEvent(ctx, event.EventType, event.Severity, event.FilterName)
+	}
+}
+
 // RecordChatRecordsBatch records multiple chat records in a batch for improved performance
 func RecordChatRecordsBatch(ctx context.Context, records []*models.LLMChatRecord) {
 	handlerMu.RLock()

--- a/analytics/database_handler.go
+++ b/analytics/database_handler.go
@@ -23,8 +23,9 @@ type DatabaseHandler struct {
 	toolCallChan   chan *models.ToolCallRecord
 	proxyLogChan   chan *models.ProxyLog
 	// Batch processing channels for async non-blocking batch operations
-	chatRecordBatchChan chan []*models.LLMChatRecord
-	proxyLogBatchChan   chan []*models.ProxyLog
+	chatRecordBatchChan    chan []*models.LLMChatRecord
+	proxyLogBatchChan      chan []*models.ProxyLog
+	complianceEventChan    chan []*models.ComplianceEvent
 	recStarted          bool
 	recMutex            sync.RWMutex
 	ctx                 context.Context
@@ -113,6 +114,7 @@ func (h *DatabaseHandler) start() {
 	}
 	h.chatRecordBatchChan = make(chan []*models.LLMChatRecord, batchBufferSize)
 	h.proxyLogBatchChan = make(chan []*models.ProxyLog, batchBufferSize)
+	h.complianceEventChan = make(chan []*models.ComplianceEvent, batchBufferSize)
 
 	// Start background workers
 	go h.startWorker()
@@ -207,6 +209,13 @@ func (h *DatabaseHandler) startWorker() {
 					Time("timestamp", logs[0].TimeStamp).
 					Msg("Created proxy log batch")
 			}
+		case events := <-h.complianceEventChan:
+			err := h.createRecordWithRetry(func() error {
+				return h.db.CreateInBatches(events, 100).Error
+			})
+			if err != nil {
+				logger.Warnf("Error creating compliance events: %s", sanitizeError(err))
+			}
 		case <-h.ctx.Done():
 			logger.Info("shutting down database analytics handler")
 			h.recMutex.Lock()
@@ -218,6 +227,7 @@ func (h *DatabaseHandler) startWorker() {
 			close(h.proxyLogChan)
 			close(h.chatRecordBatchChan)
 			close(h.proxyLogBatchChan)
+			close(h.complianceEventChan)
 			return
 		}
 	}
@@ -409,6 +419,29 @@ func (h *DatabaseHandler) RecordProxyLogsBatch(_ context.Context, logs []*models
 	}
 }
 
+// RecordComplianceEvents records filter script compliance events asynchronously
+func (h *DatabaseHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+	if len(events) == 0 {
+		return
+	}
+
+	h.recMutex.RLock()
+	if !h.recStarted {
+		h.recMutex.RUnlock()
+		return
+	}
+	h.recMutex.RUnlock()
+
+	select {
+	case <-h.ctx.Done():
+		logger.Warnf("dropping compliance events due to cancellation: %s", h.ctx.Err())
+		return
+	case h.complianceEventChan <- events:
+	default:
+		logger.Warn("compliance event buffer full, dropping events")
+	}
+}
+
 // SetAsGlobalHandler sets this handler as the global analytics handler
 func (h *DatabaseHandler) SetAsGlobalHandler() {
 	SetHandler(h)
@@ -421,6 +454,7 @@ func initDB(db *gorm.DB) {
 		&models.LLMChatLogEntry{},
 		&models.ToolCallRecord{},
 		&models.ProxyLog{},
+		&models.ComplianceEvent{},
 	)
 
 	if err != nil {

--- a/analytics/interface.go
+++ b/analytics/interface.go
@@ -28,6 +28,9 @@ type AnalyticsHandler interface {
 	// Batch processing methods for improved performance
 	RecordChatRecordsBatch(ctx context.Context, records []*models.LLMChatRecord)
 	RecordProxyLogsBatch(ctx context.Context, logs []*models.ProxyLog)
+
+	// RecordComplianceEvents records filter script compliance events
+	RecordComplianceEvents(ctx context.Context, events []*models.ComplianceEvent)
 }
 
 var (

--- a/analytics/metrics_integration_test.go
+++ b/analytics/metrics_integration_test.go
@@ -337,7 +337,8 @@ func TestRecordChatRecord_WithActiveHandler(t *testing.T) {
 
 // mockHandler implements AnalyticsHandler for testing dual-path behavior
 type mockHandler struct {
-	onRecordChatRecord func(*models.LLMChatRecord)
+	onRecordChatRecord       func(*models.LLMChatRecord)
+	onRecordComplianceEvents func([]*models.ComplianceEvent)
 }
 
 func (m *mockHandler) RecordChatRecord(_ context.Context, record *models.LLMChatRecord) {
@@ -349,11 +350,103 @@ func (m *mockHandler) RecordChatLogEntry(_ context.Context, log *models.LLMChatL
 func (m *mockHandler) RecordProxyLog(_ context.Context, log *models.ProxyLog)                  {}
 func (m *mockHandler) RecordToolCall(_ context.Context, name string, t time.Time, execTime int, toolID uint) {}
 func (m *mockHandler) SetAsGlobalHandler()                                                     {}
-func (m *mockHandler) RecordChatRecordsBatch(_ context.Context, records []*models.LLMChatRecord) {}
-func (m *mockHandler) RecordProxyLogsBatch(_ context.Context, logs []*models.ProxyLog)         {}
+func (m *mockHandler) RecordChatRecordsBatch(_ context.Context, records []*models.LLMChatRecord)  {}
+func (m *mockHandler) RecordProxyLogsBatch(_ context.Context, logs []*models.ProxyLog)           {}
+func (m *mockHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+	if m.onRecordComplianceEvents != nil {
+		m.onRecordComplianceEvents(events)
+	}
+}
 
 // Verify mockHandler satisfies the interface at compile time.
 var _ AnalyticsHandler = (*mockHandler)(nil)
+
+func TestRecordComplianceEvents_WithActiveHandler(t *testing.T) {
+	metrics.Init()
+
+	var capturedEvents []*models.ComplianceEvent
+	mock := &mockHandler{
+		onRecordComplianceEvents: func(events []*models.ComplianceEvent) {
+			capturedEvents = events
+		},
+	}
+
+	handlerMu.Lock()
+	oldHandler := globalHandler
+	globalHandler = mock
+	handlerMu.Unlock()
+	defer func() {
+		handlerMu.Lock()
+		globalHandler = oldHandler
+		handlerMu.Unlock()
+	}()
+
+	events := []*models.ComplianceEvent{
+		{
+			AppID:       10,
+			UserID:      5,
+			LLMID:       3,
+			FilterName:  "pii-filter",
+			FilterScope: "proxy_request",
+			EventType:   "pii_redacted",
+			Severity:    "warning",
+			Description: "SSN redacted",
+			Vendor:      "openai",
+			ModelName:   "gpt-4",
+			TimeStamp:   time.Now(),
+		},
+		{
+			AppID:       10,
+			UserID:      5,
+			LLMID:       3,
+			FilterName:  "pii-filter",
+			FilterScope: "proxy_request",
+			EventType:   "email_detected",
+			Severity:    "info",
+			Description: "Email address found",
+			Vendor:      "openai",
+			ModelName:   "gpt-4",
+			TimeStamp:   time.Now(),
+		},
+	}
+
+	RecordComplianceEvents(context.Background(), events)
+
+	// Verify the handler received the events
+	if capturedEvents == nil {
+		t.Fatal("mock handler did not receive compliance events")
+	}
+	if len(capturedEvents) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(capturedEvents))
+	}
+	if capturedEvents[0].EventType != "pii_redacted" {
+		t.Errorf("expected event type pii_redacted, got %s", capturedEvents[0].EventType)
+	}
+	if capturedEvents[0].FilterName != "pii-filter" {
+		t.Errorf("expected filter name pii-filter, got %s", capturedEvents[0].FilterName)
+	}
+	if capturedEvents[1].EventType != "email_detected" {
+		t.Errorf("expected event type email_detected, got %s", capturedEvents[1].EventType)
+	}
+
+	// Verify metrics were emitted
+	body := scrapeMetrics(t)
+	if !strings.Contains(body, `aistudio_compliance_events_total`) {
+		t.Error("aistudio_compliance_events_total metric not emitted")
+	}
+	if !strings.Contains(body, `event_type="pii_redacted"`) {
+		t.Error("metric with event_type=pii_redacted not found")
+	}
+	if !strings.Contains(body, `filter_name="pii-filter"`) {
+		t.Error("metric with filter_name=pii-filter not found")
+	}
+}
+
+func TestRecordComplianceEvents_EmptySlice(t *testing.T) {
+	// Should be a no-op, not panic
+	RecordComplianceEvents(context.Background(), nil)
+	RecordComplianceEvents(context.Background(), []*models.ComplianceEvent{})
+}
 
 func TestMetricsWithoutInit(t *testing.T) {
 	// When metrics.Init() is not called, analytics functions should still work

--- a/api/api.go
+++ b/api/api.go
@@ -930,6 +930,7 @@ func (a *API) setupRoutes() {
 	v1.GET("/compliance/access-issues", a.getAccessIssues)
 	v1.GET("/compliance/policy-violations", a.getPolicyViolations)
 	v1.GET("/compliance/violations", a.getViolationRecords)
+	v1.GET("/compliance/events", a.getComplianceEvents)
 	v1.GET("/compliance/budget-alerts", a.getBudgetAlerts)
 	v1.GET("/compliance/errors", a.getComplianceErrors)
 	v1.GET("/compliance/app/:id/risk-profile", a.getAppRiskProfile)

--- a/api/compliance_handlers.go
+++ b/api/compliance_handlers.go
@@ -587,3 +587,88 @@ func (a *API) getViolationRecords(c *gin.Context) {
 
 	c.JSON(http.StatusOK, records)
 }
+
+// getComplianceEvents godoc
+// @Summary Get script-reported compliance events
+// @Description Get compliance events reported by filter scripts, with filtering and aggregation
+// @Tags Compliance
+// @Accept json
+// @Produce json
+// @Param start_date query string false "Start date (YYYY-MM-DD), defaults to 7 days ago"
+// @Param end_date query string false "End date (YYYY-MM-DD), defaults to today"
+// @Param app_id query int false "Filter by app ID"
+// @Param event_type query string false "Filter by event type"
+// @Param severity query string false "Filter by severity (info, warning, critical)"
+// @Param limit query int false "Maximum number of records, defaults to 100"
+// @Param offset query int false "Pagination offset, defaults to 0"
+// @Success 200 {object} compliance.ComplianceEventsData
+// @Failure 400 {object} models.ErrorResponse
+// @Failure 403 {object} models.ErrorResponse
+// @Failure 500 {object} models.ErrorResponse
+// @Router /compliance/events [get]
+func (a *API) getComplianceEvents(c *gin.Context) {
+	startDate, endDate, err := getComplianceDateRange(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.ErrorResponse{
+			Errors: []struct {
+				Title  string `json:"title"`
+				Detail string `json:"detail"`
+			}{{Title: "Bad Request", Detail: err.Error()}},
+		})
+		return
+	}
+
+	var appID *uint
+	if appIDStr := c.Query("app_id"); appIDStr != "" {
+		if parsed, err := strconv.ParseUint(appIDStr, 10, 32); err == nil {
+			id := uint(parsed)
+			appID = &id
+		}
+	}
+
+	var eventType *string
+	if et := c.Query("event_type"); et != "" {
+		eventType = &et
+	}
+
+	var severity *string
+	if sev := c.Query("severity"); sev != "" {
+		severity = &sev
+	}
+
+	limit := 100
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	offset := 0
+	if offsetStr := c.Query("offset"); offsetStr != "" {
+		if parsed, err := strconv.Atoi(offsetStr); err == nil && parsed >= 0 {
+			offset = parsed
+		}
+	}
+
+	data, err := complianceService.GetComplianceEvents(startDate, endDate, appID, eventType, severity, limit, offset)
+	if err != nil {
+		if err == compliance.ErrEnterpriseFeature {
+			c.JSON(http.StatusForbidden, models.ErrorResponse{
+				Errors: []struct {
+					Title  string `json:"title"`
+					Detail string `json:"detail"`
+				}{{Title: "Enterprise Feature", Detail: err.Error()}},
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Errors: []struct {
+				Title  string `json:"title"`
+				Detail string `json:"detail"`
+			}{{Title: "Internal Server Error", Detail: "Failed to get compliance events"}},
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, data)
+}

--- a/api/compliance_handlers.go
+++ b/api/compliance_handlers.go
@@ -633,7 +633,18 @@ func (a *API) getComplianceEvents(c *gin.Context) {
 
 	var severity *string
 	if sev := c.Query("severity"); sev != "" {
-		severity = &sev
+		switch sev {
+		case "info", "warning", "critical":
+			severity = &sev
+		default:
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Errors: []struct {
+					Title  string `json:"title"`
+					Detail string `json:"detail"`
+				}{{Title: "Bad Request", Detail: "severity must be one of: info, warning, critical"}},
+			})
+			return
+		}
 	}
 
 	limit := 100

--- a/api/compliance_handlers.go
+++ b/api/compliance_handlers.go
@@ -628,6 +628,15 @@ func (a *API) getComplianceEvents(c *gin.Context) {
 
 	var eventType *string
 	if et := c.Query("event_type"); et != "" {
+		if len(et) > 100 {
+			c.JSON(http.StatusBadRequest, models.ErrorResponse{
+				Errors: []struct {
+					Title  string `json:"title"`
+					Detail string `json:"detail"`
+				}{{Title: "Bad Request", Detail: "event_type must be 100 characters or fewer"}},
+			})
+			return
+		}
 		eventType = &et
 	}
 

--- a/api/compliance_handlers_test.go
+++ b/api/compliance_handlers_test.go
@@ -483,6 +483,21 @@ func TestComplianceEnterprise_GetComplianceEvents(t *testing.T) {
 		assert.Equal(t, "critical", response.Events[0].Severity)
 	})
 
+	t.Run("Rejects invalid severity", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?severity=INVALID", nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+
+		var errResp models.ErrorResponse
+		err := json.Unmarshal(w.Body.Bytes(), &errResp)
+		assert.NoError(t, err)
+		assert.Contains(t, errResp.Errors[0].Detail, "severity must be one of")
+	})
+
+	t.Run("Rejects SQL injection in severity", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?severity=info'+OR+1%3D1--", nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
 	t.Run("Filters by event_type", func(t *testing.T) {
 		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?event_type=pii_redacted", nil)
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/api/compliance_handlers_test.go
+++ b/api/compliance_handlers_test.go
@@ -23,7 +23,7 @@ func setupComplianceTestAPI(t *testing.T) (*API, *gin.Engine) {
 	db := apitest.SetupTestDB(t)
 
 	// Create additional tables needed for compliance tests
-	err := db.AutoMigrate(&models.ProxyLog{}, &models.LLMChatRecord{})
+	err := db.AutoMigrate(&models.ProxyLog{}, &models.LLMChatRecord{}, &models.ComplianceEvent{})
 	assert.NoError(t, err)
 
 	service := apitest.SetupTestService(db)
@@ -43,6 +43,7 @@ func setupComplianceTestAPI(t *testing.T) (*API, *gin.Engine) {
 	v1.GET("/compliance/access-issues", api.getAccessIssues)
 	v1.GET("/compliance/policy-violations", api.getPolicyViolations)
 	v1.GET("/compliance/violations", api.getViolationRecords)
+	v1.GET("/compliance/events", api.getComplianceEvents)
 	v1.GET("/compliance/budget-alerts", api.getBudgetAlerts)
 	v1.GET("/compliance/errors", api.getComplianceErrors)
 	v1.GET("/compliance/app/:id/risk-profile", api.getAppRiskProfile)
@@ -367,6 +368,7 @@ func TestComplianceEnterprise_DateRangeDefaults(t *testing.T) {
 		"/api/v1/compliance/access-issues",
 		"/api/v1/compliance/policy-violations",
 		"/api/v1/compliance/violations",
+		"/api/v1/compliance/events",
 		"/api/v1/compliance/budget-alerts",
 		"/api/v1/compliance/errors",
 	}
@@ -378,4 +380,156 @@ func TestComplianceEnterprise_DateRangeDefaults(t *testing.T) {
 			assert.Equal(t, http.StatusOK, w.Code, "Endpoint %s should return OK with default date range", endpoint)
 		})
 	}
+}
+
+func TestComplianceEnterprise_GetComplianceEvents(t *testing.T) {
+	api, r := setupComplianceTestAPI(t)
+
+	t.Run("Returns empty events with default date range", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.NotNil(t, response.Events)
+		assert.Equal(t, int64(0), response.TotalCount)
+		assert.NotNil(t, response.BySeverity)
+		assert.NotNil(t, response.ByType)
+		assert.NotNil(t, response.ByFilter)
+	})
+
+	t.Run("Returns events after inserting data", func(t *testing.T) {
+		now := time.Now()
+
+		// Insert test compliance events
+		events := []models.ComplianceEvent{
+			{
+				AppID:       1,
+				UserID:      10,
+				LLMID:       5,
+				FilterName:  "pii-filter",
+				FilterScope: "proxy_request",
+				EventType:   "pii_redacted",
+				Severity:    "warning",
+				Description: "SSN pattern redacted",
+				Metadata:    `{"pattern":"ssn","count":2}`,
+				Vendor:      "openai",
+				ModelName:   "gpt-4",
+				TimeStamp:   now,
+			},
+			{
+				AppID:       1,
+				UserID:      10,
+				LLMID:       5,
+				FilterName:  "tone-filter",
+				FilterScope: "chat_request",
+				EventType:   "content_rewritten",
+				Severity:    "info",
+				Description: "Tone adjusted to professional",
+				Vendor:      "anthropic",
+				ModelName:   "claude-3",
+				TimeStamp:   now,
+			},
+			{
+				AppID:       2,
+				UserID:      20,
+				LLMID:       8,
+				FilterName:  "pii-filter",
+				FilterScope: "proxy_request",
+				EventType:   "pii_redacted",
+				Severity:    "critical",
+				Description: "Credit card number blocked",
+				Vendor:      "openai",
+				ModelName:   "gpt-4",
+				TimeStamp:   now,
+			},
+		}
+
+		for _, e := range events {
+			err := api.service.DB.Create(&e).Error
+			assert.NoError(t, err)
+		}
+
+		// Test: get all events
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(3), response.TotalCount)
+		assert.Len(t, response.Events, 3)
+
+		// Verify aggregation
+		assert.Equal(t, 1, response.BySeverity["warning"])
+		assert.Equal(t, 1, response.BySeverity["info"])
+		assert.Equal(t, 1, response.BySeverity["critical"])
+		assert.Equal(t, 2, response.ByType["pii_redacted"])
+		assert.Equal(t, 1, response.ByType["content_rewritten"])
+		assert.Equal(t, 2, response.ByFilter["pii-filter"])
+		assert.Equal(t, 1, response.ByFilter["tone-filter"])
+	})
+
+	t.Run("Filters by severity", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?severity=critical", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), response.TotalCount)
+		assert.Len(t, response.Events, 1)
+		assert.Equal(t, "critical", response.Events[0].Severity)
+	})
+
+	t.Run("Filters by event_type", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?event_type=pii_redacted", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(2), response.TotalCount)
+		for _, e := range response.Events {
+			assert.Equal(t, "pii_redacted", e.EventType)
+		}
+	})
+
+	t.Run("Filters by app_id", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?app_id=2", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), response.TotalCount)
+		assert.Equal(t, uint(2), response.Events[0].AppID)
+	})
+
+	t.Run("Respects limit and offset", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?limit=1&offset=0", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Len(t, response.Events, 1)
+		assert.Equal(t, int64(3), response.TotalCount) // total is still 3
+	})
+
+	t.Run("Returns metadata as parsed JSON", func(t *testing.T) {
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?event_type=pii_redacted&app_id=1", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, len(response.Events), 1)
+
+		// The metadata should be a parsed map
+		meta := response.Events[0].Metadata
+		assert.NotNil(t, meta)
+		assert.Equal(t, "ssn", meta["pattern"])
+	})
 }

--- a/api/compliance_handlers_test.go
+++ b/api/compliance_handlers_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -495,6 +496,25 @@ func TestComplianceEnterprise_GetComplianceEvents(t *testing.T) {
 
 	t.Run("Rejects SQL injection in severity", func(t *testing.T) {
 		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?severity=info'+OR+1%3D1--", nil)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("SQL injection in event_type returns no results", func(t *testing.T) {
+		// event_type is free-form but uses parameterized queries (GORM Where("event_type = ?", val))
+		// so injection attempts are treated as literal string matches and return 0 results
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?event_type=pii_redacted'+OR+1%3D1--", nil)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response compliance.ComplianceEventsData
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), response.TotalCount, "SQL injection attempt should match no events")
+		assert.Empty(t, response.Events)
+	})
+
+	t.Run("Rejects oversized event_type", func(t *testing.T) {
+		longType := strings.Repeat("a", 101)
+		w := apitest.PerformRequest(r, "GET", "/api/v1/compliance/events?event_type="+longType, nil)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 

--- a/chat_session/chat_session.go
+++ b/chat_session/chat_session.go
@@ -381,6 +381,9 @@ func (cs *ChatSession) Start() error {
 						break
 					}
 
+					// Record any compliance events reported by the script
+					scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "chat_request", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
+
 					if output.Block {
 						blockMsg := output.Message
 						if blockMsg == "" {
@@ -690,6 +693,9 @@ func (cs *ChatSession) scanFiles(refs []string) (string, bool) {
 				if err != nil {
 					return fmt.Sprintf("filter error in %s: %v", refs[i], err), false
 				}
+
+				// Record any compliance events reported by the script
+				scripting.RecordComplianceEvents(context.Background(), output, cs.filters[i2].Name, "file_reference", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
 
 				if output.Block {
 					msg := output.Message
@@ -1478,6 +1484,9 @@ func (cs *ChatSession) handleToolCalls(choice *llms.ContentChoice, toolCall, too
 					cs.handleToolError(errMsg, t.ID, t.FunctionCall.Name, toolResult)
 					continue
 				}
+
+				// Record any compliance events reported by the script
+				scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "tool_response", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
 
 				// Check if tool response should be blocked (NEW capability)
 				if output.Block {

--- a/chat_session/chat_session.go
+++ b/chat_session/chat_session.go
@@ -52,6 +52,8 @@ type ChatSession struct {
 	input               chan *models.UserMessage
 	queue               MessageQueue // NEW: Replaces llmResponses, outputMessages, outputStream, errors
 	stop                chan struct{}
+	ctx                 context.Context    // Session-scoped context, cancelled on Stop()
+	ctxCancel           context.CancelFunc // Cancels ctx
 	preProcessors       []func(*models.UserMessage) error
 	caller              llms.Model
 	mode                ChatMode
@@ -99,12 +101,16 @@ func NewChatSession(chat *models.Chat, mode ChatMode, db *gorm.DB, svc *services
 		}
 	}
 
+	ctx, ctxCancel := context.WithCancel(context.Background())
+
 	cs := &ChatSession{
 		id:            id,
 		chatRef:       chat,
 		input:         make(chan *models.UserMessage, 100),
 		queue:         queue, // Use MessageQueue interface
 		stop:          make(chan struct{}),
+		ctx:           ctx,
+		ctxCancel:     ctxCancel,
 		preProcessors: []func(*models.UserMessage) error{},
 		mode:          mode,
 		db:            db,
@@ -291,6 +297,7 @@ func (cs *ChatSession) AddPreProcessor(fn func(*models.UserMessage) error) {
 }
 
 func (cs *ChatSession) Stop() {
+	cs.ctxCancel() // Cancel session-scoped context
 	cs.stop <- struct{}{}
 	close(cs.input)
 	cs.queue.Close() // Close the queue instead of individual channels
@@ -382,7 +389,7 @@ func (cs *ChatSession) Start() error {
 					}
 
 					// Record any compliance events reported by the script
-					scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "chat_request", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
+					scripting.RecordComplianceEvents(cs.ctx, output, filter.Name, "chat_request", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
 
 					if output.Block {
 						blockMsg := output.Message
@@ -695,7 +702,7 @@ func (cs *ChatSession) scanFiles(refs []string) (string, bool) {
 				}
 
 				// Record any compliance events reported by the script
-				scripting.RecordComplianceEvents(context.Background(), output, cs.filters[i2].Name, "file_reference", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
+				scripting.RecordComplianceEvents(cs.ctx, output, cs.filters[i2].Name, "file_reference", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
 
 				if output.Block {
 					msg := output.Message
@@ -889,6 +896,7 @@ func (cs *ChatSession) HandleLLMResponse(w *LLMResponseWrapper) error {
 	if content != "" {
 		// Execute response filters before adding to history and sending to user
 		blocked, blockMsg, filterErr := ExecuteResponseFilters(
+			cs.ctx,
 			cs.filters,
 			cs.service,
 			content,
@@ -1486,7 +1494,7 @@ func (cs *ChatSession) handleToolCalls(choice *llms.ContentChoice, toolCall, too
 				}
 
 				// Record any compliance events reported by the script
-				scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "tool_response", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
+				scripting.RecordComplianceEvents(cs.ctx, output, filter.Name, "tool_response", 0, cs.userID, cs.chatRef.LLM.ID, string(cs.chatRef.LLM.Vendor), cs.chatRef.LLMSettings.ModelName)
 
 				// Check if tool response should be blocked (NEW capability)
 				if output.Block {
@@ -1552,6 +1560,7 @@ func (cs *ChatSession) streamingFunc(ctx context.Context, chunk []byte) error {
 
 		if cs.chatRef != nil && cs.chatRef.LLM != nil && cs.chatRef.LLMSettings != nil {
 			blocked, blockMsg, filterErr = ExecuteResponseFilters(
+				cs.ctx,
 				cs.filters,
 				cs.service,
 				chunkText,

--- a/chat_session/response_filter_utils.go
+++ b/chat_session/response_filter_utils.go
@@ -1,6 +1,7 @@
 package chat_session
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -69,6 +70,9 @@ func ExecuteResponseFilters(
 			// On error, allow response through (fail open for safety)
 			return false, "", fmt.Errorf("filter '%s' error: %w", filter.Name, err)
 		}
+
+		// Record any compliance events reported by the script
+		scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "chat_response", 0, userID, 0, vendor, modelName)
 
 		// Check if filter blocks the response
 		if output.Block {

--- a/chat_session/response_filter_utils.go
+++ b/chat_session/response_filter_utils.go
@@ -14,6 +14,7 @@ import (
 // ExecuteResponseFilters executes response-side filters on chat LLM responses
 // Returns whether the response should be blocked and an optional block message
 func ExecuteResponseFilters(
+	ctx context.Context,
 	filters []*models.Filter,
 	service services.ServiceInterface,
 	responseText string,
@@ -72,7 +73,7 @@ func ExecuteResponseFilters(
 		}
 
 		// Record any compliance events reported by the script
-		scripting.RecordComplianceEvents(context.Background(), output, filter.Name, "chat_response", 0, userID, 0, vendor, modelName)
+		scripting.RecordComplianceEvents(ctx, output, filter.Name, "chat_response", 0, userID, 0, vendor, modelName)
 
 		// Check if filter blocks the response
 		if output.Block {

--- a/examples/file-based-demo/services/file_analytics_handler.go
+++ b/examples/file-based-demo/services/file_analytics_handler.go
@@ -199,6 +199,10 @@ func (h *FileAnalyticsHandler) RecordProxyLogsBatch(_ context.Context, logs []*m
 	h.saveProxyLogs()
 }
 
+// RecordComplianceEvents implements analytics.AnalyticsHandler (no-op for file handler)
+func (h *FileAnalyticsHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+}
+
 // SetAsGlobalHandler sets this handler as the global analytics handler
 func (h *FileAnalyticsHandler) SetAsGlobalHandler() {
 	analytics.SetHandler(h)

--- a/grpc/analytics_pulse_test.go
+++ b/grpc/analytics_pulse_test.go
@@ -21,7 +21,7 @@ func setupPulseTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 
-	err = db.AutoMigrate(&models.LLMChatRecord{}, &models.ProxyLog{}, &models.EdgeInstance{})
+	err = db.AutoMigrate(&models.LLMChatRecord{}, &models.ProxyLog{}, &models.EdgeInstance{}, &models.ComplianceEvent{})
 	require.NoError(t, err)
 
 	return db
@@ -29,6 +29,8 @@ func setupPulseTestDB(t *testing.T) *gorm.DB {
 
 func setupControlServer(t *testing.T, db *gorm.DB) *ControlServer {
 	ctx := context.Background()
+	// Reset and reinitialize to ensure this test's DB is used
+	analytics.ResetHandler()
 	analytics.InitDefault(ctx, db)
 
 	// Set required environment variable for testing
@@ -201,6 +203,269 @@ func TestSendAnalyticsPulse_EmptyPulse(t *testing.T) {
 	err = db.Model(&models.ProxyLog{}).Count(&proxyLogCount).Error
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), proxyLogCount)
+}
+
+func TestSendAnalyticsPulse_ComplianceEvents(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	now := time.Now()
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-compliance",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   3,
+		ComplianceEvents: []*pb.ComplianceEventProto{
+			{
+				AppId:       1,
+				UserId:      10,
+				LlmId:       5,
+				FilterName:  "pii-filter",
+				FilterScope: "proxy_request",
+				EventType:   "pii_redacted",
+				Severity:    "warning",
+				Description: "SSN pattern found and redacted",
+				Metadata:    `{"pattern":"ssn","count":2}`,
+				Vendor:      "openai",
+				ModelName:   "gpt-4",
+				Timestamp:   timestamppb.New(now),
+			},
+			{
+				AppId:       1,
+				UserId:      10,
+				LlmId:       5,
+				FilterName:  "tone-filter",
+				FilterScope: "proxy_request",
+				EventType:   "content_rewritten",
+				Severity:    "info",
+				Description: "Tone adjusted to professional",
+				Vendor:      "openai",
+				ModelName:   "gpt-4",
+				Timestamp:   timestamppb.New(now.Add(1 * time.Second)),
+			},
+			{
+				AppId:       2,
+				UserId:      20,
+				LlmId:       8,
+				FilterName:  "pii-filter",
+				FilterScope: "proxy_response",
+				EventType:   "pii_redacted",
+				Severity:    "critical",
+				Description: "Credit card number detected in response",
+				Metadata:    `{"pattern":"credit_card"}`,
+				Vendor:      "anthropic",
+				ModelName:   "claude-3",
+				Timestamp:   timestamppb.New(now.Add(2 * time.Second)),
+			},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(3), response.ProcessedRecords)
+
+	// Wait for async analytics processing
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify compliance events were stored in the database
+	var complianceCount int64
+	err = db.Model(&models.ComplianceEvent{}).Count(&complianceCount).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), complianceCount, "All 3 compliance events should be stored")
+
+	// Verify the data integrity of stored events
+	var events []models.ComplianceEvent
+	err = db.Order("time_stamp ASC").Find(&events).Error
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+
+	// First event
+	assert.Equal(t, uint(1), events[0].AppID)
+	assert.Equal(t, uint(10), events[0].UserID)
+	assert.Equal(t, uint(5), events[0].LLMID)
+	assert.Equal(t, "pii-filter", events[0].FilterName)
+	assert.Equal(t, "proxy_request", events[0].FilterScope)
+	assert.Equal(t, "pii_redacted", events[0].EventType)
+	assert.Equal(t, "warning", events[0].Severity)
+	assert.Equal(t, "SSN pattern found and redacted", events[0].Description)
+	assert.Equal(t, `{"pattern":"ssn","count":2}`, events[0].Metadata)
+	assert.Equal(t, "openai", events[0].Vendor)
+	assert.Equal(t, "gpt-4", events[0].ModelName)
+
+	// Third event - different app, different scope
+	assert.Equal(t, uint(2), events[2].AppID)
+	assert.Equal(t, "proxy_response", events[2].FilterScope)
+	assert.Equal(t, "critical", events[2].Severity)
+	assert.Equal(t, "anthropic", events[2].Vendor)
+}
+
+func TestSendAnalyticsPulse_ComplianceEventsOnly(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	// Pulse with ONLY compliance events (no analytics, no budget, no proxy)
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-compliance-only",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   1,
+		ComplianceEvents: []*pb.ComplianceEventProto{
+			{
+				AppId:     1,
+				EventType: "solo_event",
+				Severity:  "info",
+				Timestamp: timestamppb.Now(),
+			},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(1), response.ProcessedRecords)
+
+	time.Sleep(200 * time.Millisecond)
+
+	var count int64
+	db.Model(&models.ComplianceEvent{}).Count(&count)
+	assert.Equal(t, int64(1), count)
+
+	// No other records should be created
+	var chatCount, proxyCount int64
+	db.Model(&models.LLMChatRecord{}).Count(&chatCount)
+	db.Model(&models.ProxyLog{}).Count(&proxyCount)
+	assert.Equal(t, int64(0), chatCount)
+	assert.Equal(t, int64(0), proxyCount)
+}
+
+func TestSendAnalyticsPulse_ComplianceEventsWithZeroFields(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	// Events with minimal fields — should still store without error
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-minimal",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   1,
+		ComplianceEvents: []*pb.ComplianceEventProto{
+			{
+				// Only event_type and severity set, everything else zero/empty
+				EventType: "minimal",
+				Severity:  "info",
+				Timestamp: timestamppb.Now(),
+			},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+
+	time.Sleep(200 * time.Millisecond)
+
+	var events []models.ComplianceEvent
+	db.Find(&events)
+	require.Len(t, events, 1)
+	assert.Equal(t, "minimal", events[0].EventType)
+	assert.Equal(t, uint(0), events[0].AppID)
+	assert.Equal(t, uint(0), events[0].UserID)
+	assert.Equal(t, "", events[0].FilterName)
+	assert.Equal(t, "", events[0].Vendor)
+}
+
+func TestSendAnalyticsPulse_EmptyComplianceEvents(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	// Pulse with empty compliance_events list (not nil, but empty)
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:           "test-edge-empty-compliance",
+		EdgeNamespace:    "test",
+		SequenceNumber:   1,
+		TotalRecords:     0,
+		ComplianceEvents: []*pb.ComplianceEventProto{},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(0), response.ProcessedRecords)
+
+	var count int64
+	db.Model(&models.ComplianceEvent{}).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestSendAnalyticsPulse_MixedAnalyticsAndCompliance(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	now := time.Now()
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-mixed",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   3,
+		AnalyticsEvents: []*pb.AnalyticsEvent{
+			{
+				RequestId:      "req-001",
+				AppId:          1,
+				LlmId:          1,
+				ModelName:      "gpt-4",
+				Vendor:         "openai",
+				StatusCode:     200,
+				TotalTokens:    100,
+				RequestTokens:  80,
+				ResponseTokens: 20,
+				Cost:           0.002,
+				Timestamp:      timestamppb.New(now),
+			},
+		},
+		ComplianceEvents: []*pb.ComplianceEventProto{
+			{
+				AppId:       1,
+				UserId:      10,
+				LlmId:       1,
+				FilterName:  "pii-filter",
+				FilterScope: "proxy_request",
+				EventType:   "pii_redacted",
+				Severity:    "warning",
+				Description: "PII detected in request",
+				Vendor:      "openai",
+				ModelName:   "gpt-4",
+				Timestamp:   timestamppb.New(now),
+			},
+		},
+		BudgetEvents: []*pb.BudgetUsageEvent{
+			{
+				AppId:     1,
+				LlmId:     1,
+				Cost:      0.002,
+				Timestamp: timestamppb.New(now),
+			},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(3), response.ProcessedRecords) // 1 analytics + 1 compliance + 1 budget
+
+	// Wait for async processing
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify both types of records were stored
+	var chatRecordCount int64
+	db.Model(&models.LLMChatRecord{}).Count(&chatRecordCount)
+	assert.Equal(t, int64(1), chatRecordCount)
+
+	var complianceCount int64
+	db.Model(&models.ComplianceEvent{}).Count(&complianceCount)
+	assert.Equal(t, int64(1), complianceCount)
 }
 
 func BenchmarkSendAnalyticsPulse_BatchProcessing(b *testing.B) {

--- a/grpc/control_server.go
+++ b/grpc/control_server.go
@@ -793,6 +793,7 @@ func (s *ControlServer) SendAnalyticsPulse(ctx context.Context, req *pb.Analytic
 		Int("analytics_events", len(req.AnalyticsEvents)).
 		Int("budget_events", len(req.BudgetEvents)).
 		Int("proxy_summaries", len(req.ProxySummaries)).
+		Int("compliance_events", len(req.ComplianceEvents)).
 		Msg("AI Studio control server: received analytics pulse from edge")
 
 	processedRecords := uint64(0)
@@ -866,6 +867,34 @@ func (s *ControlServer) SendAnalyticsPulse(ctx context.Context, req *pb.Analytic
 			Str("edge_id", req.EdgeId).
 			Int("analytics_events", len(req.AnalyticsEvents)).
 			Msg("Analytics events processed via batch operations")
+	}
+
+	// Process compliance events from edge filter scripts
+	if len(req.ComplianceEvents) > 0 {
+		complianceEvents := make([]*models.ComplianceEvent, len(req.ComplianceEvents))
+		for i, ce := range req.ComplianceEvents {
+			complianceEvents[i] = &models.ComplianceEvent{
+				AppID:       uint(ce.AppId),
+				UserID:      uint(ce.UserId),
+				LLMID:       uint(ce.LlmId),
+				FilterName:  ce.FilterName,
+				FilterScope: ce.FilterScope,
+				EventType:   ce.EventType,
+				Severity:    ce.Severity,
+				Description: ce.Description,
+				Metadata:    ce.Metadata,
+				Vendor:      ce.Vendor,
+				ModelName:   ce.ModelName,
+				TimeStamp:   ce.Timestamp.AsTime(),
+			}
+		}
+		analytics.RecordComplianceEvents(ctx, complianceEvents)
+		processedRecords += uint64(len(req.ComplianceEvents))
+
+		log.Debug().
+			Str("edge_id", req.EdgeId).
+			Int("compliance_events", len(req.ComplianceEvents)).
+			Msg("Compliance events processed from edge pulse")
 	}
 
 	// Process budget events (for now just log - AI Studio budget integration would need budget service)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -24,7 +24,8 @@ var (
 	tokensTotal      otelmetric.Int64Counter
 	costTotal        otelmetric.Float64Counter
 	toolCallsTotal   otelmetric.Int64Counter
-	policyBlockTotal otelmetric.Int64Counter
+	policyBlockTotal      otelmetric.Int64Counter
+	complianceEventsTotal otelmetric.Int64Counter
 
 	// Histograms
 	requestDuration  otelmetric.Float64Histogram
@@ -85,6 +86,13 @@ func Init() http.Handler {
 	)
 	if err != nil {
 		panic("failed to create policyBlockTotal counter: " + err.Error())
+	}
+
+	complianceEventsTotal, err = meter.Int64Counter("aistudio_compliance_events_total",
+		otelmetric.WithDescription("Compliance events reported by filter scripts"),
+	)
+	if err != nil {
+		panic("failed to create complianceEventsTotal counter: " + err.Error())
 	}
 
 	// Register histograms
@@ -190,6 +198,20 @@ func RecordPolicyBlock(ctx context.Context, ruleName, blockType string) {
 		otelmetric.WithAttributes(
 			attribute.String("rule_name", ruleName),
 			attribute.String("block_type", blockType),
+		),
+	)
+}
+
+// RecordComplianceEvent increments the compliance events counter.
+func RecordComplianceEvent(ctx context.Context, eventType, severity, filterName string) {
+	if !initialized.Load() {
+		return
+	}
+	complianceEventsTotal.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("event_type", eventType),
+			attribute.String("severity", severity),
+			attribute.String("filter_name", filterName),
 		),
 	)
 }

--- a/microgateway/internal/plugins/analytics_pulse_compliance_test.go
+++ b/microgateway/internal/plugins/analytics_pulse_compliance_test.go
@@ -1,0 +1,305 @@
+package plugins
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyticsPulsePlugin_BufferComplianceEvents(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{
+			MaxBufferSize:          10000,
+			IncludeProxySummaries:  true,
+			CompressionEnabled:     false,
+			TimeoutSeconds:         5,
+		},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+	}
+
+	events := []ComplianceEventBuffer{
+		{
+			AppID:       1,
+			UserID:      10,
+			LLMID:       5,
+			FilterName:  "pii-filter",
+			FilterScope: "proxy_request",
+			EventType:   "pii_redacted",
+			Severity:    "warning",
+			Description: "SSN found",
+			Metadata:    `{"count":3}`,
+			Vendor:      "openai",
+			ModelName:   "gpt-4",
+			Timestamp:   time.Now(),
+		},
+		{
+			AppID:       2,
+			UserID:      20,
+			LLMID:       8,
+			FilterName:  "tone-filter",
+			FilterScope: "chat_request",
+			EventType:   "content_rewritten",
+			Severity:    "info",
+			Description: "Tone adjusted",
+			Vendor:      "anthropic",
+			ModelName:   "claude-3",
+			Timestamp:   time.Now(),
+		},
+	}
+
+	// Buffer events
+	plugin.BufferComplianceEvents(events)
+
+	// Verify buffer contents
+	plugin.bufferMutex.RLock()
+	assert.Len(t, plugin.complianceBuffer, 2)
+	assert.Equal(t, "pii_redacted", plugin.complianceBuffer[0].EventType)
+	assert.Equal(t, "content_rewritten", plugin.complianceBuffer[1].EventType)
+	plugin.bufferMutex.RUnlock()
+
+	// Buffer more events
+	plugin.BufferComplianceEvents([]ComplianceEventBuffer{
+		{
+			AppID:     3,
+			EventType: "silent_failure",
+			Severity:  "critical",
+		},
+	})
+
+	plugin.bufferMutex.RLock()
+	assert.Len(t, plugin.complianceBuffer, 3)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_WithComplianceEvents(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{
+			IncludeProxySummaries: true,
+			CompressionEnabled:   false,
+		},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	now := time.Now()
+	complianceData := []ComplianceEventBuffer{
+		{
+			AppID:       1,
+			UserID:      10,
+			LLMID:       5,
+			FilterName:  "pii-filter",
+			FilterScope: "proxy_request",
+			EventType:   "pii_redacted",
+			Severity:    "warning",
+			Description: "SSN pattern found",
+			Metadata:    `{"pattern":"ssn","count":2}`,
+			Vendor:      "openai",
+			ModelName:   "gpt-4",
+			Timestamp:   now,
+		},
+		{
+			AppID:       2,
+			UserID:      20,
+			LLMID:       8,
+			FilterName:  "tone-filter",
+			FilterScope: "proxy_response",
+			EventType:   "content_rewritten",
+			Severity:    "info",
+			Description: "Tone adjusted",
+			Vendor:      "anthropic",
+			ModelName:   "claude-3",
+			Timestamp:   now.Add(1 * time.Second),
+		},
+	}
+
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, 42)
+
+	require.NotNil(t, pulse)
+	assert.Equal(t, "test-edge", pulse.EdgeId)
+	assert.Equal(t, "test", pulse.EdgeNamespace)
+	assert.Equal(t, uint64(42), pulse.SequenceNumber)
+	assert.Equal(t, uint32(2), pulse.TotalRecords)
+
+	// Verify compliance events in proto message
+	require.Len(t, pulse.ComplianceEvents, 2)
+
+	ce1 := pulse.ComplianceEvents[0]
+	assert.Equal(t, uint32(1), ce1.AppId)
+	assert.Equal(t, uint32(10), ce1.UserId)
+	assert.Equal(t, uint32(5), ce1.LlmId)
+	assert.Equal(t, "pii-filter", ce1.FilterName)
+	assert.Equal(t, "proxy_request", ce1.FilterScope)
+	assert.Equal(t, "pii_redacted", ce1.EventType)
+	assert.Equal(t, "warning", ce1.Severity)
+	assert.Equal(t, "SSN pattern found", ce1.Description)
+	assert.Equal(t, `{"pattern":"ssn","count":2}`, ce1.Metadata)
+	assert.Equal(t, "openai", ce1.Vendor)
+	assert.Equal(t, "gpt-4", ce1.ModelName)
+	assert.NotNil(t, ce1.Timestamp)
+
+	ce2 := pulse.ComplianceEvents[1]
+	assert.Equal(t, uint32(2), ce2.AppId)
+	assert.Equal(t, "content_rewritten", ce2.EventType)
+	assert.Equal(t, "info", ce2.Severity)
+	assert.Equal(t, "anthropic", ce2.Vendor)
+
+	// Verify other collections are empty
+	assert.Empty(t, pulse.AnalyticsEvents)
+	assert.Empty(t, pulse.BudgetEvents)
+	assert.Empty(t, pulse.ProxySummaries)
+}
+
+func TestAnalyticsPulsePlugin_BufferComplianceEvents_EmptySlice(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{},
+	}
+
+	// Should not panic on empty slice
+	plugin.BufferComplianceEvents(nil)
+	plugin.BufferComplianceEvents([]ComplianceEventBuffer{})
+
+	plugin.bufferMutex.RLock()
+	assert.Len(t, plugin.complianceBuffer, 0)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BufferComplianceEvents_ConcurrentAccess(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{},
+	}
+
+	// Simulate concurrent buffering from multiple goroutines
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+			plugin.BufferComplianceEvents([]ComplianceEventBuffer{
+				{
+					AppID:     uint32(id),
+					EventType: "concurrent_test",
+					Severity:  "info",
+					Timestamp: time.Now(),
+				},
+			})
+		}(i)
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	plugin.bufferMutex.RLock()
+	assert.Len(t, plugin.complianceBuffer, 10)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_EmptyComplianceData(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{
+			IncludeProxySummaries: false,
+			CompressionEnabled:   false,
+		},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	// Empty compliance data should produce nil ComplianceEvents (not empty slice)
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, nil, 1)
+	require.NotNil(t, pulse)
+	assert.Nil(t, pulse.ComplianceEvents)
+	assert.Equal(t, uint32(0), pulse.TotalRecords)
+
+	// Empty slice should also produce nil
+	pulse = plugin.buildPulseMessage(nil, nil, nil, nil, []ComplianceEventBuffer{}, 2)
+	require.NotNil(t, pulse)
+	assert.Nil(t, pulse.ComplianceEvents)
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_ComplianceWithMissingFields(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{
+			IncludeProxySummaries: false,
+			CompressionEnabled:   false,
+		},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	// Events with minimal/missing fields should still serialize without error
+	complianceData := []ComplianceEventBuffer{
+		{
+			// Only required fields
+			EventType: "minimal_event",
+			Severity:  "info",
+			Timestamp: time.Now(),
+		},
+		{
+			// Zero-value IDs, empty strings
+			AppID:       0,
+			UserID:      0,
+			LLMID:       0,
+			FilterName:  "",
+			FilterScope: "",
+			EventType:   "empty_fields",
+			Severity:    "warning",
+			Description: "",
+			Metadata:    "",
+			Vendor:      "",
+			ModelName:   "",
+			Timestamp:   time.Time{}, // zero time
+		},
+	}
+
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, 1)
+	require.NotNil(t, pulse)
+	require.Len(t, pulse.ComplianceEvents, 2)
+
+	assert.Equal(t, "minimal_event", pulse.ComplianceEvents[0].EventType)
+	assert.Equal(t, uint32(0), pulse.ComplianceEvents[0].AppId) // zero value preserved
+
+	assert.Equal(t, "empty_fields", pulse.ComplianceEvents[1].EventType)
+	assert.Equal(t, "", pulse.ComplianceEvents[1].FilterName) // empty string preserved
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_MixedData(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config: &PulsePluginConfig{
+			IncludeProxySummaries: false,
+			CompressionEnabled:   false,
+		},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	complianceData := []ComplianceEventBuffer{
+		{
+			AppID:     1,
+			EventType: "pii_redacted",
+			Severity:  "warning",
+			Timestamp: time.Now(),
+		},
+	}
+
+	budgetData := []BudgetUsageBuffer{
+		{
+			AppID:     1,
+			Cost:      0.005,
+			Timestamp: time.Now(),
+		},
+	}
+
+	pulse := plugin.buildPulseMessage(nil, nil, budgetData, nil, complianceData, 1)
+
+	require.NotNil(t, pulse)
+	assert.Equal(t, uint32(2), pulse.TotalRecords) // 1 budget + 1 compliance
+	assert.Len(t, pulse.ComplianceEvents, 1)
+	assert.Len(t, pulse.BudgetEvents, 1)
+	assert.Empty(t, pulse.AnalyticsEvents)
+}

--- a/microgateway/internal/plugins/analytics_pulse_plugin.go
+++ b/microgateway/internal/plugins/analytics_pulse_plugin.go
@@ -28,6 +28,7 @@ type AnalyticsPulsePlugin struct {
 	analyticsMetadata  []AnalyticsMetadata // Store additional data not in database.AnalyticsEvent
 	budgetBuffer       []BudgetUsageBuffer
 	proxyBuffer        []ProxyLogBuffer
+	complianceBuffer   []ComplianceEventBuffer
 	bufferMutex        sync.RWMutex
 
 	// Pulse management
@@ -97,6 +98,22 @@ type ProxyLogBuffer struct {
 	UniqueModels       []string
 	TotalTokens        uint32
 	TotalCost          float64
+}
+
+// ComplianceEventBuffer holds a compliance event for batching in pulses
+type ComplianceEventBuffer struct {
+	AppID       uint32
+	UserID      uint32
+	LLMID       uint32
+	FilterName  string
+	FilterScope string
+	EventType   string
+	Severity    string
+	Description string
+	Metadata    string // JSON blob
+	Vendor      string
+	ModelName   string
+	Timestamp   time.Time
 }
 
 // NewAnalyticsPulsePlugin creates a new built-in analytics pulse plugin
@@ -364,6 +381,20 @@ func (p *AnalyticsPulsePlugin) HandleBudgetUsage(ctx context.Context, req *inter
 	}, nil
 }
 
+// BufferComplianceEvents adds compliance events to the buffer for pulse transmission.
+// Called by the microgateway analytics handler when filter scripts report compliance events.
+func (p *AnalyticsPulsePlugin) BufferComplianceEvents(events []ComplianceEventBuffer) {
+	p.bufferMutex.Lock()
+	defer p.bufferMutex.Unlock()
+
+	p.complianceBuffer = append(p.complianceBuffer, events...)
+
+	log.Debug().
+		Int("count", len(events)).
+		Int("buffer_size", len(p.complianceBuffer)).
+		Msg("Compliance events buffered for pulse")
+}
+
 // schedulePulse schedules the next pulse
 func (p *AnalyticsPulsePlugin) schedulePulse() {
 	if p.pulseTimer != nil {
@@ -395,7 +426,7 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 	p.bufferMutex.Lock()
 
 	// Check if there's any data to send
-	if len(p.analyticsBuffer) == 0 && len(p.budgetBuffer) == 0 && len(p.proxyBuffer) == 0 {
+	if len(p.analyticsBuffer) == 0 && len(p.budgetBuffer) == 0 && len(p.proxyBuffer) == 0 && len(p.complianceBuffer) == 0 {
 		p.bufferMutex.Unlock()
 		log.Debug().Msg("No analytics data to pulse - skipping")
 		return
@@ -418,13 +449,17 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 	copy(proxySnapshot, p.proxyBuffer)
 	p.proxyBuffer = p.proxyBuffer[:0]
 
+	complianceSnapshot := make([]ComplianceEventBuffer, len(p.complianceBuffer))
+	copy(complianceSnapshot, p.complianceBuffer)
+	p.complianceBuffer = p.complianceBuffer[:0]
+
 	sequenceNum := p.sequenceNumber
 	p.sequenceNumber++
 
 	p.bufferMutex.Unlock()
 
 	// Build and send pulse
-	pulse := p.buildPulseMessage(analyticsSnapshot, metadataSnapshot, budgetSnapshot, proxySnapshot, sequenceNum)
+	pulse := p.buildPulseMessage(analyticsSnapshot, metadataSnapshot, budgetSnapshot, proxySnapshot, complianceSnapshot, sequenceNum)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.TimeoutSeconds)*time.Second)
 	defer cancel()
@@ -434,6 +469,7 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 		Int("analytics_events", len(analyticsSnapshot)).
 		Int("budget_events", len(budgetSnapshot)).
 		Int("proxy_summaries", len(proxySnapshot)).
+		Int("compliance_events", len(complianceSnapshot)).
 		Uint32("total_records", pulse.TotalRecords).
 		Msg("Sending analytics pulse to control server")
 
@@ -471,6 +507,7 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 	metadata []AnalyticsMetadata,
 	budgetData []BudgetUsageBuffer,
 	proxyData []ProxyLogBuffer,
+	complianceData []ComplianceEventBuffer,
 	sequenceNum uint64,
 ) *pb.AnalyticsPulse {
 	now := time.Now()
@@ -575,7 +612,26 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 		}
 	}
 
-	totalRecords := uint32(len(analyticsEvents) + len(budgetEvents) + len(proxySummaries))
+	// Convert compliance events
+	var complianceEvents []*pb.ComplianceEventProto
+	for _, ce := range complianceData {
+		complianceEvents = append(complianceEvents, &pb.ComplianceEventProto{
+			AppId:       ce.AppID,
+			UserId:      ce.UserID,
+			LlmId:       ce.LLMID,
+			FilterName:  ce.FilterName,
+			FilterScope: ce.FilterScope,
+			EventType:   ce.EventType,
+			Severity:    ce.Severity,
+			Description: ce.Description,
+			Metadata:    ce.Metadata,
+			Vendor:      ce.Vendor,
+			ModelName:   ce.ModelName,
+			Timestamp:   timestamppb.New(ce.Timestamp),
+		})
+	}
+
+	totalRecords := uint32(len(analyticsEvents) + len(budgetEvents) + len(proxySummaries) + len(complianceEvents))
 
 	return &pb.AnalyticsPulse{
 		EdgeId:           p.edgeID,
@@ -587,6 +643,7 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 		AnalyticsEvents:  analyticsEvents,
 		BudgetEvents:     budgetEvents,
 		ProxySummaries:   proxySummaries,
+		ComplianceEvents: complianceEvents,
 		IsCompressed:     p.config.CompressionEnabled,
 		TotalRecords:     totalRecords,
 		DataSizeBytes:    0, // TODO: Calculate if needed

--- a/microgateway/internal/services/analytics_handler.go
+++ b/microgateway/internal/services/analytics_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/TykTechnologies/midsommar/v2/models"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/config"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/database"
+	internalPlugins "github.com/TykTechnologies/midsommar/microgateway/internal/plugins"
 	"github.com/TykTechnologies/midsommar/microgateway/plugins"
 	"github.com/TykTechnologies/midsommar/microgateway/plugins/interfaces"
 	"github.com/rs/zerolog/log"
@@ -688,6 +689,34 @@ func (h *MicrogatewaAnalyticsHandler) RecordProxyLogsBatch(_ context.Context, lo
 	default:
 		log.Warn().Int("count", len(logs)).Msg("Proxy log batch buffer full, dropping batch")
 	}
+}
+
+// RecordComplianceEvents forwards compliance events to the analytics pulse plugin
+// for batch transmission to the control plane during the next pulse.
+func (h *MicrogatewaAnalyticsHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+	if len(events) == 0 || h.pluginManager == nil {
+		return
+	}
+
+	bufferEvents := make([]internalPlugins.ComplianceEventBuffer, len(events))
+	for i, e := range events {
+		bufferEvents[i] = internalPlugins.ComplianceEventBuffer{
+			AppID:       uint32(e.AppID),
+			UserID:      uint32(e.UserID),
+			LLMID:       uint32(e.LLMID),
+			FilterName:  e.FilterName,
+			FilterScope: e.FilterScope,
+			EventType:   e.EventType,
+			Severity:    e.Severity,
+			Description: e.Description,
+			Metadata:    e.Metadata,
+			Vendor:      e.Vendor,
+			ModelName:   e.ModelName,
+			Timestamp:   e.TimeStamp,
+		}
+	}
+
+	h.pluginManager.BufferComplianceEvents(bufferEvents)
 }
 
 // SetAsGlobalHandler sets this handler as the global midsommar analytics handler

--- a/microgateway/plugins/manager.go
+++ b/microgateway/plugins/manager.go
@@ -1736,6 +1736,25 @@ func (pm *PluginManager) ExecuteDataCollectionPlugins(hookType string, data inte
 	return nil
 }
 
+// BufferComplianceEvents forwards compliance events to the built-in analytics pulse plugin
+// for batch transmission to the control plane during the next pulse.
+func (pm *PluginManager) BufferComplianceEvents(events []plugins.ComplianceEventBuffer) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	for _, globalPlugin := range pm.globalDataPlugins {
+		if globalPlugin.LoadedPlugin.BuiltinPlugin == nil {
+			continue
+		}
+		if pulsePlugin, ok := globalPlugin.LoadedPlugin.BuiltinPlugin.(*plugins.AnalyticsPulsePlugin); ok {
+			pulsePlugin.BufferComplianceEvents(events)
+			return
+		}
+	}
+
+	log.Debug().Int("count", len(events)).Msg("No analytics pulse plugin found for compliance events - events dropped")
+}
+
 // executeDataCollectionPlugin executes a specific plugin for the given data type
 func (pm *PluginManager) executeDataCollectionPlugin(ctx context.Context, plugin *GlobalPlugin, hookType string, data interface{}) error {
 	// Check if this is a built-in plugin

--- a/models/compliance_event.go
+++ b/models/compliance_event.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ComplianceEvent records a compliance-relevant event reported by a filter script.
+// Scripts can flag any type of compliance event (redactions, rewrites, PII detection,
+// silent failures, etc.) by setting compliance_events in their output object.
+type ComplianceEvent struct {
+	gorm.Model
+	AppID       uint      `json:"app_id" gorm:"index:idx_ce_app_time,priority:1"`
+	UserID      uint      `json:"user_id" gorm:"index"`
+	LLMID       uint      `json:"llm_id" gorm:"index"`
+	FilterName  string    `json:"filter_name" gorm:"index"`
+	FilterScope string    `json:"filter_scope"` // "proxy_request", "proxy_response", "chat_request", "chat_response", "file_reference", "tool_response"
+	EventType   string    `json:"event_type" gorm:"index"`   // Free-form: "pii_redacted", "content_rewritten", "silent_failure", etc.
+	Severity    string    `json:"severity" gorm:"index"`     // "info", "warning", "critical"
+	Description string    `json:"description"`
+	Metadata    string    `json:"metadata"`                  // JSON blob for arbitrary key-value data
+	Vendor      string    `json:"vendor"`
+	ModelName   string    `json:"model_name"`
+	TimeStamp   time.Time `json:"timestamp" gorm:"index:idx_ce_time;index:idx_ce_app_time,priority:2"`
+}

--- a/pkg/aigateway/http_analytics_handler.go
+++ b/pkg/aigateway/http_analytics_handler.go
@@ -179,6 +179,10 @@ func (h *HTTPAnalyticsHandler) RecordProxyLogsBatch(_ context.Context, logs []*m
 	h.postJSON("/analytics/batch", batchData)
 }
 
+// RecordComplianceEvents implements analytics.AnalyticsHandler (no-op for HTTP handler)
+func (h *HTTPAnalyticsHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+}
+
 // SetAsGlobalHandler sets this handler as the global analytics handler
 func (h *HTTPAnalyticsHandler) SetAsGlobalHandler() {
 	analytics.SetHandler(h)

--- a/proto/config_sync.pb.go
+++ b/proto/config_sync.pb.go
@@ -1552,9 +1552,10 @@ type AnalyticsPulse struct {
 	DataTo         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=data_to,json=dataTo,proto3" json:"data_to,omitempty"`                          // End time of data in this pulse
 	SequenceNumber uint64                 `protobuf:"varint,6,opt,name=sequence_number,json=sequenceNumber,proto3" json:"sequence_number,omitempty"` // Incremental sequence for ordering
 	// Batched analytics data
-	AnalyticsEvents []*AnalyticsEvent   `protobuf:"bytes,7,rep,name=analytics_events,json=analyticsEvents,proto3" json:"analytics_events,omitempty"` // Analytics/token usage events
-	BudgetEvents    []*BudgetUsageEvent `protobuf:"bytes,8,rep,name=budget_events,json=budgetEvents,proto3" json:"budget_events,omitempty"`          // Budget usage events
-	ProxySummaries  []*ProxyLogSummary  `protobuf:"bytes,9,rep,name=proxy_summaries,json=proxySummaries,proto3" json:"proxy_summaries,omitempty"`    // Summarized proxy logs (not full payloads)
+	AnalyticsEvents  []*AnalyticsEvent       `protobuf:"bytes,7,rep,name=analytics_events,json=analyticsEvents,proto3" json:"analytics_events,omitempty"`     // Analytics/token usage events
+	BudgetEvents     []*BudgetUsageEvent     `protobuf:"bytes,8,rep,name=budget_events,json=budgetEvents,proto3" json:"budget_events,omitempty"`              // Budget usage events
+	ProxySummaries   []*ProxyLogSummary      `protobuf:"bytes,9,rep,name=proxy_summaries,json=proxySummaries,proto3" json:"proxy_summaries,omitempty"`        // Summarized proxy logs (not full payloads)
+	ComplianceEvents []*ComplianceEventProto `protobuf:"bytes,13,rep,name=compliance_events,json=complianceEvents,proto3" json:"compliance_events,omitempty"` // Script-reported compliance events
 	// Pulse metadata
 	IsCompressed  bool   `protobuf:"varint,10,opt,name=is_compressed,json=isCompressed,proto3" json:"is_compressed,omitempty"`      // Whether data is compressed
 	TotalRecords  uint32 `protobuf:"varint,11,opt,name=total_records,json=totalRecords,proto3" json:"total_records,omitempty"`      // Total number of records in pulse
@@ -1652,6 +1653,13 @@ func (x *AnalyticsPulse) GetBudgetEvents() []*BudgetUsageEvent {
 func (x *AnalyticsPulse) GetProxySummaries() []*ProxyLogSummary {
 	if x != nil {
 		return x.ProxySummaries
+	}
+	return nil
+}
+
+func (x *AnalyticsPulse) GetComplianceEvents() []*ComplianceEventProto {
+	if x != nil {
+		return x.ComplianceEvents
 	}
 	return nil
 }
@@ -2391,6 +2399,140 @@ func (x *ProxyLogSummary) GetTotalCost() float64 {
 	return 0
 }
 
+// ComplianceEventProto represents a compliance event reported by a filter script
+// Used for transmitting compliance events from edge gateways to the control plane
+type ComplianceEventProto struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AppId         uint32                 `protobuf:"varint,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	UserId        uint32                 `protobuf:"varint,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	LlmId         uint32                 `protobuf:"varint,3,opt,name=llm_id,json=llmId,proto3" json:"llm_id,omitempty"`
+	FilterName    string                 `protobuf:"bytes,4,opt,name=filter_name,json=filterName,proto3" json:"filter_name,omitempty"`
+	FilterScope   string                 `protobuf:"bytes,5,opt,name=filter_scope,json=filterScope,proto3" json:"filter_scope,omitempty"` // "proxy_request", "proxy_response", etc.
+	EventType     string                 `protobuf:"bytes,6,opt,name=event_type,json=eventType,proto3" json:"event_type,omitempty"`       // Free-form: "pii_redacted", "content_rewritten", etc.
+	Severity      string                 `protobuf:"bytes,7,opt,name=severity,proto3" json:"severity,omitempty"`                          // "info", "warning", "critical"
+	Description   string                 `protobuf:"bytes,8,opt,name=description,proto3" json:"description,omitempty"`
+	Metadata      string                 `protobuf:"bytes,9,opt,name=metadata,proto3" json:"metadata,omitempty"` // JSON blob
+	Vendor        string                 `protobuf:"bytes,10,opt,name=vendor,proto3" json:"vendor,omitempty"`
+	ModelName     string                 `protobuf:"bytes,11,opt,name=model_name,json=modelName,proto3" json:"model_name,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,12,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ComplianceEventProto) Reset() {
+	*x = ComplianceEventProto{}
+	mi := &file_proto_config_sync_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ComplianceEventProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ComplianceEventProto) ProtoMessage() {}
+
+func (x *ComplianceEventProto) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_config_sync_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ComplianceEventProto.ProtoReflect.Descriptor instead.
+func (*ComplianceEventProto) Descriptor() ([]byte, []int) {
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *ComplianceEventProto) GetAppId() uint32 {
+	if x != nil {
+		return x.AppId
+	}
+	return 0
+}
+
+func (x *ComplianceEventProto) GetUserId() uint32 {
+	if x != nil {
+		return x.UserId
+	}
+	return 0
+}
+
+func (x *ComplianceEventProto) GetLlmId() uint32 {
+	if x != nil {
+		return x.LlmId
+	}
+	return 0
+}
+
+func (x *ComplianceEventProto) GetFilterName() string {
+	if x != nil {
+		return x.FilterName
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetFilterScope() string {
+	if x != nil {
+		return x.FilterScope
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetEventType() string {
+	if x != nil {
+		return x.EventType
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetSeverity() string {
+	if x != nil {
+		return x.Severity
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetMetadata() string {
+	if x != nil {
+		return x.Metadata
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetVendor() string {
+	if x != nil {
+		return x.Vendor
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetModelName() string {
+	if x != nil {
+		return x.ModelName
+	}
+	return ""
+}
+
+func (x *ComplianceEventProto) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
 // PluginControlPayload represents a single payload from an edge plugin to control
 type PluginControlPayload struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2407,7 +2549,7 @@ type PluginControlPayload struct {
 
 func (x *PluginControlPayload) Reset() {
 	*x = PluginControlPayload{}
-	mi := &file_proto_config_sync_proto_msgTypes[23]
+	mi := &file_proto_config_sync_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2561,7 @@ func (x *PluginControlPayload) String() string {
 func (*PluginControlPayload) ProtoMessage() {}
 
 func (x *PluginControlPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[23]
+	mi := &file_proto_config_sync_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2432,7 +2574,7 @@ func (x *PluginControlPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlPayload.ProtoReflect.Descriptor instead.
 func (*PluginControlPayload) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{23}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *PluginControlPayload) GetPluginId() uint32 {
@@ -2499,7 +2641,7 @@ type PluginControlBatch struct {
 
 func (x *PluginControlBatch) Reset() {
 	*x = PluginControlBatch{}
-	mi := &file_proto_config_sync_proto_msgTypes[24]
+	mi := &file_proto_config_sync_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2511,7 +2653,7 @@ func (x *PluginControlBatch) String() string {
 func (*PluginControlBatch) ProtoMessage() {}
 
 func (x *PluginControlBatch) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[24]
+	mi := &file_proto_config_sync_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2524,7 +2666,7 @@ func (x *PluginControlBatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlBatch.ProtoReflect.Descriptor instead.
 func (*PluginControlBatch) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{24}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PluginControlBatch) GetEdgeId() string {
@@ -2584,7 +2726,7 @@ type PluginControlBatchResponse struct {
 
 func (x *PluginControlBatchResponse) Reset() {
 	*x = PluginControlBatchResponse{}
-	mi := &file_proto_config_sync_proto_msgTypes[25]
+	mi := &file_proto_config_sync_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2596,7 +2738,7 @@ func (x *PluginControlBatchResponse) String() string {
 func (*PluginControlBatchResponse) ProtoMessage() {}
 
 func (x *PluginControlBatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[25]
+	mi := &file_proto_config_sync_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2609,7 +2751,7 @@ func (x *PluginControlBatchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlBatchResponse.ProtoReflect.Descriptor instead.
 func (*PluginControlBatchResponse) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{25}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PluginControlBatchResponse) GetSuccess() bool {
@@ -2666,7 +2808,7 @@ type PluginPayloadError struct {
 
 func (x *PluginPayloadError) Reset() {
 	*x = PluginPayloadError{}
-	mi := &file_proto_config_sync_proto_msgTypes[26]
+	mi := &file_proto_config_sync_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2678,7 +2820,7 @@ func (x *PluginPayloadError) String() string {
 func (*PluginPayloadError) ProtoMessage() {}
 
 func (x *PluginPayloadError) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[26]
+	mi := &file_proto_config_sync_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2691,7 +2833,7 @@ func (x *PluginPayloadError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginPayloadError.ProtoReflect.Descriptor instead.
 func (*PluginPayloadError) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{26}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PluginPayloadError) GetPluginId() uint32 {
@@ -2839,7 +2981,7 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	"\amessage\x18\x05 \x01(\tR\amessage\x122\n" +
 	"\x15config_version_before\x18\x06 \x01(\tR\x13configVersionBefore\x120\n" +
 	"\x14config_version_after\x18\a \x01(\tR\x12configVersionAfter\x128\n" +
-	"\ttimestamp\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xf4\x04\n" +
+	"\ttimestamp\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc5\x05\n" +
 	"\x0eAnalyticsPulse\x12\x17\n" +
 	"\aedge_id\x18\x01 \x01(\tR\x06edgeId\x12%\n" +
 	"\x0eedge_namespace\x18\x02 \x01(\tR\redgeNamespace\x12C\n" +
@@ -2849,7 +2991,8 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	"\x0fsequence_number\x18\x06 \x01(\x04R\x0esequenceNumber\x12G\n" +
 	"\x10analytics_events\x18\a \x03(\v2\x1c.microgateway.AnalyticsEventR\x0fanalyticsEvents\x12C\n" +
 	"\rbudget_events\x18\b \x03(\v2\x1e.microgateway.BudgetUsageEventR\fbudgetEvents\x12F\n" +
-	"\x0fproxy_summaries\x18\t \x03(\v2\x1d.microgateway.ProxyLogSummaryR\x0eproxySummaries\x12#\n" +
+	"\x0fproxy_summaries\x18\t \x03(\v2\x1d.microgateway.ProxyLogSummaryR\x0eproxySummaries\x12O\n" +
+	"\x11compliance_events\x18\r \x03(\v2\".microgateway.ComplianceEventProtoR\x10complianceEvents\x12#\n" +
 	"\ris_compressed\x18\n" +
 	" \x01(\bR\fisCompressed\x12#\n" +
 	"\rtotal_records\x18\v \x01(\rR\ftotalRecords\x12&\n" +
@@ -2935,7 +3078,24 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	"\runique_models\x18\f \x03(\tR\funiqueModels\x12!\n" +
 	"\ftotal_tokens\x18\r \x01(\rR\vtotalTokens\x12\x1d\n" +
 	"\n" +
-	"total_cost\x18\x0e \x01(\x01R\ttotalCost\"\xf9\x02\n" +
+	"total_cost\x18\x0e \x01(\x01R\ttotalCost\"\x8b\x03\n" +
+	"\x14ComplianceEventProto\x12\x15\n" +
+	"\x06app_id\x18\x01 \x01(\rR\x05appId\x12\x17\n" +
+	"\auser_id\x18\x02 \x01(\rR\x06userId\x12\x15\n" +
+	"\x06llm_id\x18\x03 \x01(\rR\x05llmId\x12\x1f\n" +
+	"\vfilter_name\x18\x04 \x01(\tR\n" +
+	"filterName\x12!\n" +
+	"\ffilter_scope\x18\x05 \x01(\tR\vfilterScope\x12\x1d\n" +
+	"\n" +
+	"event_type\x18\x06 \x01(\tR\teventType\x12\x1a\n" +
+	"\bseverity\x18\a \x01(\tR\bseverity\x12 \n" +
+	"\vdescription\x18\b \x01(\tR\vdescription\x12\x1a\n" +
+	"\bmetadata\x18\t \x01(\tR\bmetadata\x12\x16\n" +
+	"\x06vendor\x18\n" +
+	" \x01(\tR\x06vendor\x12\x1d\n" +
+	"\n" +
+	"model_name\x18\v \x01(\tR\tmodelName\x128\n" +
+	"\ttimestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xf9\x02\n" +
 	"\x14PluginControlPayload\x12\x1b\n" +
 	"\tplugin_id\x18\x01 \x01(\rR\bpluginId\x12\x18\n" +
 	"\apayload\x18\x02 \x01(\fR\apayload\x12\x17\n" +
@@ -2996,7 +3156,7 @@ func file_proto_config_sync_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_config_sync_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_config_sync_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
+var file_proto_config_sync_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_proto_config_sync_proto_goTypes = []any{
 	(ReloadPhase)(0),                    // 0: microgateway.ReloadPhase
 	(*EdgeRegistrationRequest)(nil),     // 1: microgateway.EdgeRegistrationRequest
@@ -3022,25 +3182,26 @@ var file_proto_config_sync_proto_goTypes = []any{
 	(*AnalyticsEvent)(nil),              // 21: microgateway.AnalyticsEvent
 	(*BudgetUsageEvent)(nil),            // 22: microgateway.BudgetUsageEvent
 	(*ProxyLogSummary)(nil),             // 23: microgateway.ProxyLogSummary
-	(*PluginControlPayload)(nil),        // 24: microgateway.PluginControlPayload
-	(*PluginControlBatch)(nil),          // 25: microgateway.PluginControlBatch
-	(*PluginControlBatchResponse)(nil),  // 26: microgateway.PluginControlBatchResponse
-	(*PluginPayloadError)(nil),          // 27: microgateway.PluginPayloadError
-	nil,                                 // 28: microgateway.EdgeRegistrationRequest.MetadataEntry
-	nil,                                 // 29: microgateway.EdgeMetrics.CustomMetricsEntry
-	nil,                                 // 30: microgateway.PluginControlPayload.MetadataEntry
-	(*HealthStatus)(nil),                // 31: microgateway.HealthStatus
-	(*ConfigurationSnapshot)(nil),       // 32: microgateway.ConfigurationSnapshot
-	(*timestamppb.Timestamp)(nil),       // 33: google.protobuf.Timestamp
-	(*ConfigurationChange)(nil),         // 34: microgateway.ConfigurationChange
-	(*AppConfig)(nil),                   // 35: microgateway.AppConfig
-	(*emptypb.Empty)(nil),               // 36: google.protobuf.Empty
+	(*ComplianceEventProto)(nil),        // 24: microgateway.ComplianceEventProto
+	(*PluginControlPayload)(nil),        // 25: microgateway.PluginControlPayload
+	(*PluginControlBatch)(nil),          // 26: microgateway.PluginControlBatch
+	(*PluginControlBatchResponse)(nil),  // 27: microgateway.PluginControlBatchResponse
+	(*PluginPayloadError)(nil),          // 28: microgateway.PluginPayloadError
+	nil,                                 // 29: microgateway.EdgeRegistrationRequest.MetadataEntry
+	nil,                                 // 30: microgateway.EdgeMetrics.CustomMetricsEntry
+	nil,                                 // 31: microgateway.PluginControlPayload.MetadataEntry
+	(*HealthStatus)(nil),                // 32: microgateway.HealthStatus
+	(*ConfigurationSnapshot)(nil),       // 33: microgateway.ConfigurationSnapshot
+	(*timestamppb.Timestamp)(nil),       // 34: google.protobuf.Timestamp
+	(*ConfigurationChange)(nil),         // 35: microgateway.ConfigurationChange
+	(*AppConfig)(nil),                   // 36: microgateway.AppConfig
+	(*emptypb.Empty)(nil),               // 37: google.protobuf.Empty
 }
 var file_proto_config_sync_proto_depIdxs = []int32{
-	28, // 0: microgateway.EdgeRegistrationRequest.metadata:type_name -> microgateway.EdgeRegistrationRequest.MetadataEntry
-	31, // 1: microgateway.EdgeRegistrationRequest.health:type_name -> microgateway.HealthStatus
-	32, // 2: microgateway.EdgeRegistrationResponse.initial_config:type_name -> microgateway.ConfigurationSnapshot
-	33, // 3: microgateway.ConfigurationRequest.last_sync_time:type_name -> google.protobuf.Timestamp
+	29, // 0: microgateway.EdgeRegistrationRequest.metadata:type_name -> microgateway.EdgeRegistrationRequest.MetadataEntry
+	32, // 1: microgateway.EdgeRegistrationRequest.health:type_name -> microgateway.HealthStatus
+	33, // 2: microgateway.EdgeRegistrationResponse.initial_config:type_name -> microgateway.ConfigurationSnapshot
+	34, // 3: microgateway.ConfigurationRequest.last_sync_time:type_name -> google.protobuf.Timestamp
 	1,  // 4: microgateway.EdgeMessage.registration:type_name -> microgateway.EdgeRegistrationRequest
 	7,  // 5: microgateway.EdgeMessage.heartbeat:type_name -> microgateway.HeartbeatRequest
 	3,  // 6: microgateway.EdgeMessage.config_request:type_name -> microgateway.ConfigurationRequest
@@ -3048,62 +3209,64 @@ var file_proto_config_sync_proto_depIdxs = []int32{
 	17, // 8: microgateway.EdgeMessage.reload_response:type_name -> microgateway.ConfigurationReloadResponse
 	6,  // 9: microgateway.EdgeMessage.event:type_name -> microgateway.EventFrame
 	2,  // 10: microgateway.ControlMessage.registration_response:type_name -> microgateway.EdgeRegistrationResponse
-	32, // 11: microgateway.ControlMessage.configuration:type_name -> microgateway.ConfigurationSnapshot
-	34, // 12: microgateway.ControlMessage.change:type_name -> microgateway.ConfigurationChange
+	33, // 11: microgateway.ControlMessage.configuration:type_name -> microgateway.ConfigurationSnapshot
+	35, // 12: microgateway.ControlMessage.change:type_name -> microgateway.ConfigurationChange
 	8,  // 13: microgateway.ControlMessage.heartbeat_response:type_name -> microgateway.HeartbeatResponse
 	11, // 14: microgateway.ControlMessage.error:type_name -> microgateway.ErrorMessage
 	16, // 15: microgateway.ControlMessage.reload_request:type_name -> microgateway.ConfigurationReloadRequest
 	6,  // 16: microgateway.ControlMessage.event:type_name -> microgateway.EventFrame
-	31, // 17: microgateway.HeartbeatRequest.health:type_name -> microgateway.HealthStatus
+	32, // 17: microgateway.HeartbeatRequest.health:type_name -> microgateway.HealthStatus
 	10, // 18: microgateway.HeartbeatRequest.metrics:type_name -> microgateway.EdgeMetrics
-	33, // 19: microgateway.HeartbeatRequest.timestamp:type_name -> google.protobuf.Timestamp
-	29, // 20: microgateway.EdgeMetrics.custom_metrics:type_name -> microgateway.EdgeMetrics.CustomMetricsEntry
-	33, // 21: microgateway.TokenValidationResponse.expires_at:type_name -> google.protobuf.Timestamp
-	35, // 22: microgateway.TokenValidationResponse.app:type_name -> microgateway.AppConfig
-	33, // 23: microgateway.ConfigurationReloadRequest.initiated_at:type_name -> google.protobuf.Timestamp
+	34, // 19: microgateway.HeartbeatRequest.timestamp:type_name -> google.protobuf.Timestamp
+	30, // 20: microgateway.EdgeMetrics.custom_metrics:type_name -> microgateway.EdgeMetrics.CustomMetricsEntry
+	34, // 21: microgateway.TokenValidationResponse.expires_at:type_name -> google.protobuf.Timestamp
+	36, // 22: microgateway.TokenValidationResponse.app:type_name -> microgateway.AppConfig
+	34, // 23: microgateway.ConfigurationReloadRequest.initiated_at:type_name -> google.protobuf.Timestamp
 	0,  // 24: microgateway.ConfigurationReloadResponse.phase:type_name -> microgateway.ReloadPhase
-	33, // 25: microgateway.ConfigurationReloadResponse.timestamp:type_name -> google.protobuf.Timestamp
-	33, // 26: microgateway.AnalyticsPulse.pulse_timestamp:type_name -> google.protobuf.Timestamp
-	33, // 27: microgateway.AnalyticsPulse.data_from:type_name -> google.protobuf.Timestamp
-	33, // 28: microgateway.AnalyticsPulse.data_to:type_name -> google.protobuf.Timestamp
+	34, // 25: microgateway.ConfigurationReloadResponse.timestamp:type_name -> google.protobuf.Timestamp
+	34, // 26: microgateway.AnalyticsPulse.pulse_timestamp:type_name -> google.protobuf.Timestamp
+	34, // 27: microgateway.AnalyticsPulse.data_from:type_name -> google.protobuf.Timestamp
+	34, // 28: microgateway.AnalyticsPulse.data_to:type_name -> google.protobuf.Timestamp
 	21, // 29: microgateway.AnalyticsPulse.analytics_events:type_name -> microgateway.AnalyticsEvent
 	22, // 30: microgateway.AnalyticsPulse.budget_events:type_name -> microgateway.BudgetUsageEvent
 	23, // 31: microgateway.AnalyticsPulse.proxy_summaries:type_name -> microgateway.ProxyLogSummary
-	33, // 32: microgateway.AnalyticsPulseResponse.processed_at:type_name -> google.protobuf.Timestamp
-	20, // 33: microgateway.AnalyticsPulseResponse.updated_config:type_name -> microgateway.AnalyticsPulseConfig
-	33, // 34: microgateway.AnalyticsEvent.timestamp:type_name -> google.protobuf.Timestamp
-	33, // 35: microgateway.BudgetUsageEvent.timestamp:type_name -> google.protobuf.Timestamp
-	33, // 36: microgateway.BudgetUsageEvent.period_start:type_name -> google.protobuf.Timestamp
-	33, // 37: microgateway.BudgetUsageEvent.period_end:type_name -> google.protobuf.Timestamp
-	33, // 38: microgateway.ProxyLogSummary.first_request:type_name -> google.protobuf.Timestamp
-	33, // 39: microgateway.ProxyLogSummary.last_request:type_name -> google.protobuf.Timestamp
-	33, // 40: microgateway.PluginControlPayload.timestamp:type_name -> google.protobuf.Timestamp
-	30, // 41: microgateway.PluginControlPayload.metadata:type_name -> microgateway.PluginControlPayload.MetadataEntry
-	24, // 42: microgateway.PluginControlBatch.payloads:type_name -> microgateway.PluginControlPayload
-	33, // 43: microgateway.PluginControlBatch.batch_timestamp:type_name -> google.protobuf.Timestamp
-	33, // 44: microgateway.PluginControlBatchResponse.processed_at:type_name -> google.protobuf.Timestamp
-	27, // 45: microgateway.PluginControlBatchResponse.errors:type_name -> microgateway.PluginPayloadError
-	1,  // 46: microgateway.ConfigurationSyncService.RegisterEdge:input_type -> microgateway.EdgeRegistrationRequest
-	3,  // 47: microgateway.ConfigurationSyncService.GetFullConfiguration:input_type -> microgateway.ConfigurationRequest
-	4,  // 48: microgateway.ConfigurationSyncService.SubscribeToChanges:input_type -> microgateway.EdgeMessage
-	7,  // 49: microgateway.ConfigurationSyncService.SendHeartbeat:input_type -> microgateway.HeartbeatRequest
-	9,  // 50: microgateway.ConfigurationSyncService.UnregisterEdge:input_type -> microgateway.EdgeUnregistrationRequest
-	14, // 51: microgateway.ConfigurationSyncService.ValidateToken:input_type -> microgateway.TokenValidationRequest
-	18, // 52: microgateway.ConfigurationSyncService.SendAnalyticsPulse:input_type -> microgateway.AnalyticsPulse
-	25, // 53: microgateway.ConfigurationSyncService.SendPluginControlBatch:input_type -> microgateway.PluginControlBatch
-	2,  // 54: microgateway.ConfigurationSyncService.RegisterEdge:output_type -> microgateway.EdgeRegistrationResponse
-	32, // 55: microgateway.ConfigurationSyncService.GetFullConfiguration:output_type -> microgateway.ConfigurationSnapshot
-	5,  // 56: microgateway.ConfigurationSyncService.SubscribeToChanges:output_type -> microgateway.ControlMessage
-	8,  // 57: microgateway.ConfigurationSyncService.SendHeartbeat:output_type -> microgateway.HeartbeatResponse
-	36, // 58: microgateway.ConfigurationSyncService.UnregisterEdge:output_type -> google.protobuf.Empty
-	15, // 59: microgateway.ConfigurationSyncService.ValidateToken:output_type -> microgateway.TokenValidationResponse
-	19, // 60: microgateway.ConfigurationSyncService.SendAnalyticsPulse:output_type -> microgateway.AnalyticsPulseResponse
-	26, // 61: microgateway.ConfigurationSyncService.SendPluginControlBatch:output_type -> microgateway.PluginControlBatchResponse
-	54, // [54:62] is the sub-list for method output_type
-	46, // [46:54] is the sub-list for method input_type
-	46, // [46:46] is the sub-list for extension type_name
-	46, // [46:46] is the sub-list for extension extendee
-	0,  // [0:46] is the sub-list for field type_name
+	24, // 32: microgateway.AnalyticsPulse.compliance_events:type_name -> microgateway.ComplianceEventProto
+	34, // 33: microgateway.AnalyticsPulseResponse.processed_at:type_name -> google.protobuf.Timestamp
+	20, // 34: microgateway.AnalyticsPulseResponse.updated_config:type_name -> microgateway.AnalyticsPulseConfig
+	34, // 35: microgateway.AnalyticsEvent.timestamp:type_name -> google.protobuf.Timestamp
+	34, // 36: microgateway.BudgetUsageEvent.timestamp:type_name -> google.protobuf.Timestamp
+	34, // 37: microgateway.BudgetUsageEvent.period_start:type_name -> google.protobuf.Timestamp
+	34, // 38: microgateway.BudgetUsageEvent.period_end:type_name -> google.protobuf.Timestamp
+	34, // 39: microgateway.ProxyLogSummary.first_request:type_name -> google.protobuf.Timestamp
+	34, // 40: microgateway.ProxyLogSummary.last_request:type_name -> google.protobuf.Timestamp
+	34, // 41: microgateway.ComplianceEventProto.timestamp:type_name -> google.protobuf.Timestamp
+	34, // 42: microgateway.PluginControlPayload.timestamp:type_name -> google.protobuf.Timestamp
+	31, // 43: microgateway.PluginControlPayload.metadata:type_name -> microgateway.PluginControlPayload.MetadataEntry
+	25, // 44: microgateway.PluginControlBatch.payloads:type_name -> microgateway.PluginControlPayload
+	34, // 45: microgateway.PluginControlBatch.batch_timestamp:type_name -> google.protobuf.Timestamp
+	34, // 46: microgateway.PluginControlBatchResponse.processed_at:type_name -> google.protobuf.Timestamp
+	28, // 47: microgateway.PluginControlBatchResponse.errors:type_name -> microgateway.PluginPayloadError
+	1,  // 48: microgateway.ConfigurationSyncService.RegisterEdge:input_type -> microgateway.EdgeRegistrationRequest
+	3,  // 49: microgateway.ConfigurationSyncService.GetFullConfiguration:input_type -> microgateway.ConfigurationRequest
+	4,  // 50: microgateway.ConfigurationSyncService.SubscribeToChanges:input_type -> microgateway.EdgeMessage
+	7,  // 51: microgateway.ConfigurationSyncService.SendHeartbeat:input_type -> microgateway.HeartbeatRequest
+	9,  // 52: microgateway.ConfigurationSyncService.UnregisterEdge:input_type -> microgateway.EdgeUnregistrationRequest
+	14, // 53: microgateway.ConfigurationSyncService.ValidateToken:input_type -> microgateway.TokenValidationRequest
+	18, // 54: microgateway.ConfigurationSyncService.SendAnalyticsPulse:input_type -> microgateway.AnalyticsPulse
+	26, // 55: microgateway.ConfigurationSyncService.SendPluginControlBatch:input_type -> microgateway.PluginControlBatch
+	2,  // 56: microgateway.ConfigurationSyncService.RegisterEdge:output_type -> microgateway.EdgeRegistrationResponse
+	33, // 57: microgateway.ConfigurationSyncService.GetFullConfiguration:output_type -> microgateway.ConfigurationSnapshot
+	5,  // 58: microgateway.ConfigurationSyncService.SubscribeToChanges:output_type -> microgateway.ControlMessage
+	8,  // 59: microgateway.ConfigurationSyncService.SendHeartbeat:output_type -> microgateway.HeartbeatResponse
+	37, // 60: microgateway.ConfigurationSyncService.UnregisterEdge:output_type -> google.protobuf.Empty
+	15, // 61: microgateway.ConfigurationSyncService.ValidateToken:output_type -> microgateway.TokenValidationResponse
+	19, // 62: microgateway.ConfigurationSyncService.SendAnalyticsPulse:output_type -> microgateway.AnalyticsPulseResponse
+	27, // 63: microgateway.ConfigurationSyncService.SendPluginControlBatch:output_type -> microgateway.PluginControlBatchResponse
+	56, // [56:64] is the sub-list for method output_type
+	48, // [48:56] is the sub-list for method input_type
+	48, // [48:48] is the sub-list for extension type_name
+	48, // [48:48] is the sub-list for extension extendee
+	0,  // [0:48] is the sub-list for field type_name
 }
 
 func init() { file_proto_config_sync_proto_init() }
@@ -3135,7 +3298,7 @@ func file_proto_config_sync_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_config_sync_proto_rawDesc), len(file_proto_config_sync_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   30,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/config_sync.proto
+++ b/proto/config_sync.proto
@@ -224,6 +224,7 @@ message AnalyticsPulse {
   repeated AnalyticsEvent analytics_events = 7;   // Analytics/token usage events
   repeated BudgetUsageEvent budget_events = 8;    // Budget usage events
   repeated ProxyLogSummary proxy_summaries = 9;   // Summarized proxy logs (not full payloads)
+  repeated ComplianceEventProto compliance_events = 13; // Script-reported compliance events
 
   // Pulse metadata
   bool is_compressed = 10;        // Whether data is compressed
@@ -332,6 +333,23 @@ message ProxyLogSummary {
   repeated string unique_models = 12; // List of unique model names called
   uint32 total_tokens = 13;       // Total tokens across all requests
   double total_cost = 14;         // Total cost as cents (dollars * 10000, providing 4 decimal precision)
+}
+
+// ComplianceEventProto represents a compliance event reported by a filter script
+// Used for transmitting compliance events from edge gateways to the control plane
+message ComplianceEventProto {
+  uint32 app_id = 1;
+  uint32 user_id = 2;
+  uint32 llm_id = 3;
+  string filter_name = 4;
+  string filter_scope = 5;           // "proxy_request", "proxy_response", etc.
+  string event_type = 6;             // Free-form: "pii_redacted", "content_rewritten", etc.
+  string severity = 7;               // "info", "warning", "critical"
+  string description = 8;
+  string metadata = 9;               // JSON blob
+  string vendor = 10;
+  string model_name = 11;
+  google.protobuf.Timestamp timestamp = 12;
 }
 
 // Plugin Control Payload Messages

--- a/proxy/analyze_utils_body_test.go
+++ b/proxy/analyze_utils_body_test.go
@@ -26,7 +26,8 @@ func (h *captureHandler) RecordChatRecord(_ context.Context, record *models.LLMC
 func (h *captureHandler) RecordToolCall(_ context.Context, name string, t time.Time, execTime int, toolID uint) {}
 func (h *captureHandler) SetAsGlobalHandler()                                               { analytics.SetHandler(h) }
 func (h *captureHandler) RecordChatRecordsBatch(_ context.Context, records []*models.LLMChatRecord) {}
-func (h *captureHandler) RecordProxyLogsBatch(_ context.Context, logs []*models.ProxyLog)   {}
+func (h *captureHandler) RecordProxyLogsBatch(_ context.Context, logs []*models.ProxyLog)          {}
+func (h *captureHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {}
 
 // TestProxyLogBodySuppression_Unit is a synchronous unit test that verifies body
 // suppression at the ProxyLog construction level without relying on the async

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1430,6 +1430,9 @@ func (p *Proxy) screenProxyRequestByVendor(llm *models.LLM, r *http.Request, isS
 			return fmt.Errorf("script error in filter '%s': %v", filter.Name, err)
 		}
 
+		// Record any compliance events reported by the script
+		scripting.RecordComplianceEvents(r.Context(), output, filter.Name, "proxy_request", appID, 0, llm.ID, string(llm.Vendor), modelName)
+
 		// Check if request should be blocked
 		if output.Block {
 			msg := output.Message

--- a/proxy/response_filter_utils.go
+++ b/proxy/response_filter_utils.go
@@ -102,6 +102,9 @@ func ExecuteResponseFilters(
 			return false, "", fmt.Errorf("filter '%s' error: %w", filter.Name, err)
 		}
 
+		// Record any compliance events reported by the script
+		scripting.RecordComplianceEvents(r.Context(), output, filter.Name, "proxy_response", uint(appID), 0, llm.ID, string(llm.Vendor), modelName)
+
 		// Check if filter blocks the response
 		if output.Block {
 			msg := output.Message

--- a/scripting/compliance_recorder.go
+++ b/scripting/compliance_recorder.go
@@ -1,0 +1,45 @@
+package scripting
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/TykTechnologies/midsommar/v2/analytics"
+	"github.com/TykTechnologies/midsommar/v2/models"
+)
+
+// RecordComplianceEvents converts script output compliance events to model events
+// enriched with context from the filter execution site, then records them asynchronously.
+func RecordComplianceEvents(ctx context.Context, output *ScriptOutput, filterName, filterScope string, appID, userID, llmID uint, vendor, modelName string) {
+	if output == nil || len(output.ComplianceEvents) == 0 {
+		return
+	}
+
+	now := time.Now()
+	events := make([]*models.ComplianceEvent, 0, len(output.ComplianceEvents))
+	for _, ce := range output.ComplianceEvents {
+		metadataJSON := ""
+		if ce.Metadata != nil {
+			if b, err := json.Marshal(ce.Metadata); err == nil {
+				metadataJSON = string(b)
+			}
+		}
+		events = append(events, &models.ComplianceEvent{
+			AppID:       appID,
+			UserID:      userID,
+			LLMID:       llmID,
+			FilterName:  filterName,
+			FilterScope: filterScope,
+			EventType:   ce.EventType,
+			Severity:    ce.Severity,
+			Description: ce.Description,
+			Metadata:    metadataJSON,
+			Vendor:      vendor,
+			ModelName:   modelName,
+			TimeStamp:   now,
+		})
+	}
+
+	analytics.RecordComplianceEvents(ctx, events)
+}

--- a/scripting/compliance_recorder_test.go
+++ b/scripting/compliance_recorder_test.go
@@ -1,0 +1,183 @@
+package scripting
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/midsommar/v2/analytics"
+	"github.com/TykTechnologies/midsommar/v2/models"
+)
+
+// testAnalyticsHandler captures compliance events for test assertions
+type testAnalyticsHandler struct {
+	mu     sync.Mutex
+	events []*models.ComplianceEvent
+}
+
+func (h *testAnalyticsHandler) RecordComplianceEvents(_ context.Context, events []*models.ComplianceEvent) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.events = append(h.events, events...)
+}
+func (h *testAnalyticsHandler) RecordChatRecord(_ context.Context, record *models.LLMChatRecord)  {}
+func (h *testAnalyticsHandler) RecordChatLogEntry(_ context.Context, log *models.LLMChatLogEntry)  {}
+func (h *testAnalyticsHandler) RecordProxyLog(_ context.Context, log *models.ProxyLog)             {}
+func (h *testAnalyticsHandler) RecordToolCall(_ context.Context, name string, t time.Time, execTime int, toolID uint) {
+}
+func (h *testAnalyticsHandler) SetAsGlobalHandler()                                                  {}
+func (h *testAnalyticsHandler) RecordChatRecordsBatch(_ context.Context, records []*models.LLMChatRecord) {}
+func (h *testAnalyticsHandler) RecordProxyLogsBatch(_ context.Context, logs []*models.ProxyLog)    {}
+
+func (h *testAnalyticsHandler) getEvents() []*models.ComplianceEvent {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	result := make([]*models.ComplianceEvent, len(h.events))
+	copy(result, h.events)
+	return result
+}
+
+func TestRecordComplianceEvents_EnrichesContext(t *testing.T) {
+	handler := &testAnalyticsHandler{}
+	analytics.SetHandler(handler)
+	defer analytics.ResetHandler()
+
+	output := &ScriptOutput{
+		Block:   false,
+		Payload: "[REDACTED]",
+		ComplianceEvents: []ComplianceEventOutput{
+			{
+				EventType:   "pii_redacted",
+				Severity:    "warning",
+				Description: "SSN pattern found",
+				Metadata:    map[string]interface{}{"pattern": "ssn", "count": int64(3)},
+			},
+			{
+				EventType:   "content_logged",
+				Severity:    "info",
+				Description: "Input logged for audit",
+			},
+		},
+	}
+
+	RecordComplianceEvents(
+		context.Background(),
+		output,
+		"my-pii-filter",   // filterName
+		"proxy_request",    // filterScope
+		42,                 // appID
+		7,                  // userID
+		15,                 // llmID
+		"openai",           // vendor
+		"gpt-4",            // modelName
+	)
+
+	events := handler.getEvents()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+
+	// Verify first event is enriched with context
+	e := events[0]
+	if e.AppID != 42 {
+		t.Errorf("AppID = %d, want 42", e.AppID)
+	}
+	if e.UserID != 7 {
+		t.Errorf("UserID = %d, want 7", e.UserID)
+	}
+	if e.LLMID != 15 {
+		t.Errorf("LLMID = %d, want 15", e.LLMID)
+	}
+	if e.FilterName != "my-pii-filter" {
+		t.Errorf("FilterName = %q, want %q", e.FilterName, "my-pii-filter")
+	}
+	if e.FilterScope != "proxy_request" {
+		t.Errorf("FilterScope = %q, want %q", e.FilterScope, "proxy_request")
+	}
+	if e.EventType != "pii_redacted" {
+		t.Errorf("EventType = %q, want %q", e.EventType, "pii_redacted")
+	}
+	if e.Severity != "warning" {
+		t.Errorf("Severity = %q, want %q", e.Severity, "warning")
+	}
+	if e.Description != "SSN pattern found" {
+		t.Errorf("Description = %q, want %q", e.Description, "SSN pattern found")
+	}
+	if e.Vendor != "openai" {
+		t.Errorf("Vendor = %q, want %q", e.Vendor, "openai")
+	}
+	if e.ModelName != "gpt-4" {
+		t.Errorf("ModelName = %q, want %q", e.ModelName, "gpt-4")
+	}
+	if e.TimeStamp.IsZero() {
+		t.Error("TimeStamp should not be zero")
+	}
+
+	// Verify metadata was serialized to JSON
+	if e.Metadata == "" {
+		t.Error("Metadata should not be empty")
+	}
+	if e.Metadata != `{"count":3,"pattern":"ssn"}` {
+		t.Errorf("Metadata = %q, want JSON with pattern and count", e.Metadata)
+	}
+
+	// Verify second event
+	e2 := events[1]
+	if e2.EventType != "content_logged" {
+		t.Errorf("second event EventType = %q, want %q", e2.EventType, "content_logged")
+	}
+	if e2.FilterName != "my-pii-filter" {
+		t.Errorf("second event FilterName = %q, want %q", e2.FilterName, "my-pii-filter")
+	}
+}
+
+func TestRecordComplianceEvents_NilOutput(t *testing.T) {
+	handler := &testAnalyticsHandler{}
+	analytics.SetHandler(handler)
+	defer analytics.ResetHandler()
+
+	// Should not panic
+	RecordComplianceEvents(context.Background(), nil, "filter", "scope", 1, 1, 1, "v", "m")
+
+	events := handler.getEvents()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for nil output, got %d", len(events))
+	}
+}
+
+func TestRecordComplianceEvents_EmptyEvents(t *testing.T) {
+	handler := &testAnalyticsHandler{}
+	analytics.SetHandler(handler)
+	defer analytics.ResetHandler()
+
+	output := &ScriptOutput{
+		Block:            false,
+		ComplianceEvents: []ComplianceEventOutput{},
+	}
+
+	RecordComplianceEvents(context.Background(), output, "filter", "scope", 1, 1, 1, "v", "m")
+
+	events := handler.getEvents()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events for empty slice, got %d", len(events))
+	}
+}
+
+func TestRecordComplianceEvents_NoComplianceEvents(t *testing.T) {
+	handler := &testAnalyticsHandler{}
+	analytics.SetHandler(handler)
+	defer analytics.ResetHandler()
+
+	output := &ScriptOutput{
+		Block:   false,
+		Payload: "clean",
+	}
+
+	RecordComplianceEvents(context.Background(), output, "filter", "scope", 1, 1, 1, "v", "m")
+
+	events := handler.getEvents()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events when no compliance events set, got %d", len(events))
+	}
+}

--- a/scripting/scripting_ent.go
+++ b/scripting/scripting_ent.go
@@ -34,9 +34,23 @@ func (sr *ScriptRunner) RunScript(input *ScriptInput, serviceRef services.Servic
 
 	// Convert enterprise ScriptOutput back to base ScriptOutput
 	output := &ScriptOutput{
-		Block:   entOutput.Block,
-		Payload: entOutput.Payload,
-		Message: entOutput.Message,
+		Block:    entOutput.Block,
+		Payload:  entOutput.Payload,
+		Messages: entOutput.Messages,
+		Message:  entOutput.Message,
+	}
+
+	// Convert compliance events
+	if len(entOutput.ComplianceEvents) > 0 {
+		output.ComplianceEvents = make([]ComplianceEventOutput, len(entOutput.ComplianceEvents))
+		for i, ce := range entOutput.ComplianceEvents {
+			output.ComplianceEvents[i] = ComplianceEventOutput{
+				EventType:   ce.EventType,
+				Severity:    ce.Severity,
+				Description: ce.Description,
+				Metadata:    ce.Metadata,
+			}
+		}
 	}
 
 	return output, nil

--- a/scripting/scripting_test.go
+++ b/scripting/scripting_test.go
@@ -843,6 +843,277 @@ func TestToolResponseFilters(t *testing.T) {
 	}
 }
 
+func TestRunScript_ComplianceEvents(t *testing.T) {
+	tests := []struct {
+		name             string
+		sourceCode       string
+		input            *ScriptInput
+		wantBlock        bool
+		wantPayload      string
+		wantEventCount   int
+		wantEventTypes   []string
+		wantSeverities   []string
+		wantDescriptions []string
+		wantMetadataKeys [][]string // per-event list of expected metadata keys
+		wantErr          bool
+	}{
+		{
+			name: "single compliance event with metadata",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: "[REDACTED]",
+					message: "",
+					compliance_events: [
+						{
+							event_type: "pii_redacted",
+							severity: "warning",
+							description: "SSN pattern found and redacted",
+							metadata: { "pattern": "ssn", "count": 3 }
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{"prompt": "my ssn is 123-45-6789"}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:        false,
+			wantPayload:      "[REDACTED]",
+			wantEventCount:   1,
+			wantEventTypes:   []string{"pii_redacted"},
+			wantSeverities:   []string{"warning"},
+			wantDescriptions: []string{"SSN pattern found and redacted"},
+			wantMetadataKeys: [][]string{{"pattern", "count"}},
+		},
+		{
+			name: "multiple compliance events",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: input.raw_input,
+					compliance_events: [
+						{
+							event_type: "pii_detected",
+							severity: "critical",
+							description: "Email address found"
+						},
+						{
+							event_type: "content_rewritten",
+							severity: "info",
+							description: "Rewrote greeting to formal tone"
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{"text": "hello"}`,
+				Messages:   []MessageContent{},
+				VendorName: "anthropic",
+				ModelName:  "claude-3",
+			},
+			wantBlock:        false,
+			wantPayload:      `{"text": "hello"}`,
+			wantEventCount:   2,
+			wantEventTypes:   []string{"pii_detected", "content_rewritten"},
+			wantSeverities:   []string{"critical", "info"},
+			wantDescriptions: []string{"Email address found", "Rewrote greeting to formal tone"},
+		},
+		{
+			name: "compliance events with block true",
+			sourceCode: `
+				output := {
+					block: true,
+					message: "Blocked due to policy violation",
+					compliance_events: [
+						{
+							event_type: "policy_violation",
+							severity: "critical",
+							description: "Prohibited content detected"
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{"prompt": "bad content"}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      true,
+			wantEventCount: 1,
+			wantEventTypes: []string{"policy_violation"},
+			wantSeverities: []string{"critical"},
+		},
+		{
+			name: "no compliance events",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: input.raw_input,
+					message: ""
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{"test": "clean data"}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      false,
+			wantPayload:    `{"test": "clean data"}`,
+			wantEventCount: 0,
+		},
+		{
+			name: "empty compliance events array",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: input.raw_input,
+					compliance_events: []
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{"test": "data"}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      false,
+			wantPayload:    `{"test": "data"}`,
+			wantEventCount: 0,
+		},
+		{
+			name: "invalid severity defaults to info",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: "",
+					compliance_events: [
+						{
+							event_type: "custom_check",
+							severity: "SUPER_BAD",
+							description: "some check"
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      false,
+			wantEventCount: 1,
+			wantEventTypes: []string{"custom_check"},
+			wantSeverities: []string{"info"}, // invalid severity defaults to info
+		},
+		{
+			name: "event without event_type is skipped",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: "",
+					compliance_events: [
+						{
+							severity: "warning",
+							description: "no type"
+						},
+						{
+							event_type: "valid_event",
+							severity: "warning",
+							description: "has type"
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      false,
+			wantEventCount: 1, // first event skipped, second kept
+			wantEventTypes: []string{"valid_event"},
+			wantSeverities: []string{"warning"},
+		},
+		{
+			name: "missing severity defaults to info",
+			sourceCode: `
+				output := {
+					block: false,
+					payload: "",
+					compliance_events: [
+						{
+							event_type: "simple_event",
+							description: "no severity specified"
+						}
+					]
+				}
+			`,
+			input: &ScriptInput{
+				RawInput:   `{}`,
+				Messages:   []MessageContent{},
+				VendorName: "openai",
+				ModelName:  "gpt-4",
+			},
+			wantBlock:      false,
+			wantEventCount: 1,
+			wantEventTypes: []string{"simple_event"},
+			wantSeverities: []string{"info"}, // missing severity defaults to info
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewScriptRunner([]byte(tt.sourceCode))
+			output, err := runner.RunScript(tt.input, nil)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("RunScript() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if output.Block != tt.wantBlock {
+				t.Errorf("Block = %v, want %v", output.Block, tt.wantBlock)
+			}
+
+			if tt.wantPayload != "" && output.Payload != tt.wantPayload {
+				t.Errorf("Payload = %v, want %v", output.Payload, tt.wantPayload)
+			}
+
+			if len(output.ComplianceEvents) != tt.wantEventCount {
+				t.Fatalf("ComplianceEvents count = %d, want %d", len(output.ComplianceEvents), tt.wantEventCount)
+			}
+
+			for i, event := range output.ComplianceEvents {
+				if i < len(tt.wantEventTypes) && event.EventType != tt.wantEventTypes[i] {
+					t.Errorf("ComplianceEvents[%d].EventType = %q, want %q", i, event.EventType, tt.wantEventTypes[i])
+				}
+				if i < len(tt.wantSeverities) && event.Severity != tt.wantSeverities[i] {
+					t.Errorf("ComplianceEvents[%d].Severity = %q, want %q", i, event.Severity, tt.wantSeverities[i])
+				}
+				if i < len(tt.wantDescriptions) && event.Description != tt.wantDescriptions[i] {
+					t.Errorf("ComplianceEvents[%d].Description = %q, want %q", i, event.Description, tt.wantDescriptions[i])
+				}
+				if i < len(tt.wantMetadataKeys) {
+					for _, key := range tt.wantMetadataKeys[i] {
+						if _, ok := event.Metadata[key]; !ok {
+							t.Errorf("ComplianceEvents[%d].Metadata missing key %q", i, key)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func contains(s, substr string) bool {
 	// Simple substring check
 	for i := 0; i <= len(s)-len(substr); i++ {

--- a/scripting/types.go
+++ b/scripting/types.go
@@ -19,10 +19,20 @@ type ScriptInput struct {
 	StatusCode    int                     `json:"status_code"`    // HTTP status code from LLM
 }
 
+// ComplianceEventOutput represents a compliance event reported by a filter script.
+// Script developers set these in the output object to flag compliance-relevant activity.
+type ComplianceEventOutput struct {
+	EventType   string                 // Free-form type: "pii_redacted", "content_rewritten", "silent_failure", etc.
+	Severity    string                 // "info", "warning", "critical"
+	Description string                 // Human-readable description of what happened
+	Metadata    map[string]interface{} // Arbitrary key-value data
+}
+
 // ScriptOutput represents the result of script execution
 type ScriptOutput struct {
-	Block    bool                     // If true, stops the request/response chain
-	Payload  string                   // Modified content (empty = no modification)
-	Messages []map[string]interface{} // Modified messages array (alternative to Payload)
-	Message  string                   // Optional blocking reason or log message
+	Block            bool                     // If true, stops the request/response chain
+	Payload          string                   // Modified content (empty = no modification)
+	Messages         []map[string]interface{} // Modified messages array (alternative to Payload)
+	Message          string                   // Optional blocking reason or log message
+	ComplianceEvents []ComplianceEventOutput  // Compliance events to record (enterprise only)
 }

--- a/services/compliance/community.go
+++ b/services/compliance/community.go
@@ -63,3 +63,8 @@ func (s *communityService) ExportData(startDate, endDate time.Time, view string)
 func (s *communityService) GetViolationRecords(startDate, endDate time.Time, appID *uint, limit int) ([]ViolationRecord, error) {
 	return nil, ErrEnterpriseFeature
 }
+
+// GetComplianceEvents returns an enterprise feature error in Community Edition.
+func (s *communityService) GetComplianceEvents(startDate, endDate time.Time, appID *uint, eventType *string, severity *string, limit int, offset int) (*ComplianceEventsData, error) {
+	return nil, ErrEnterpriseFeature
+}

--- a/services/compliance/interface.go
+++ b/services/compliance/interface.go
@@ -139,6 +139,34 @@ type ViolationRecord struct {
 	Vendor        string    `json:"vendor"`
 }
 
+// ComplianceEventRecord represents a script-reported compliance event for API responses
+type ComplianceEventRecord struct {
+	ID          uint                   `json:"id"`
+	AppID       uint                   `json:"app_id"`
+	AppName     string                 `json:"app_name,omitempty"`
+	UserID      uint                   `json:"user_id"`
+	LLMID       uint                   `json:"llm_id"`
+	FilterName  string                 `json:"filter_name"`
+	FilterScope string                 `json:"filter_scope"`
+	EventType   string                 `json:"event_type"`
+	Severity    string                 `json:"severity"`
+	Description string                 `json:"description"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Vendor      string                 `json:"vendor"`
+	ModelName   string                 `json:"model_name"`
+	Timestamp   time.Time              `json:"timestamp"`
+}
+
+// ComplianceEventsData contains aggregated compliance event data
+type ComplianceEventsData struct {
+	Events     []ComplianceEventRecord `json:"events"`
+	TotalCount int64                   `json:"total_count"`
+	BySeverity map[string]int          `json:"by_severity"`
+	ByType     map[string]int          `json:"by_type"`
+	ByFilter   map[string]int          `json:"by_filter"`
+	Timeline   []TimelineData          `json:"timeline"`
+}
+
 // Service defines the interface for compliance management.
 // Community Edition provides stub implementations that return enterprise feature errors.
 // Enterprise Edition provides full compliance monitoring and risk analysis.
@@ -187,4 +215,9 @@ type Service interface {
 	// CE: Returns ErrEnterpriseFeature
 	// ENT: Returns individual violation records with parsed details
 	GetViolationRecords(startDate, endDate time.Time, appID *uint, limit int) ([]ViolationRecord, error)
+
+	// GetComplianceEvents returns script-reported compliance events.
+	// CE: Returns ErrEnterpriseFeature
+	// ENT: Returns compliance events with filtering and aggregation
+	GetComplianceEvents(startDate, endDate time.Time, appID *uint, eventType *string, severity *string, limit int, offset int) (*ComplianceEventsData, error)
 }


### PR DESCRIPTION
## Summary

- Adds a general-purpose compliance event reporting mechanism to the enterprise filter scripting system, allowing script developers to flag **any** compliance-relevant activity (redactions, rewrites, PII detection, silent failures, third-party model calls, etc.)
- Events flow through the full analytics pipeline: script output → async recording → database storage → gRPC transmission from edge gateways to control plane → compliance API
- Introduces `GET /compliance/events` API endpoint with filtering by severity, event type, app ID, and pagination

Closes #370

## How it works

Script developers set `compliance_events` in their Tengo output object:

```tengo
tyk := import("tyk")
modified := tyk.redact_pattern(input, "\\d{3}-\\d{2}-\\d{4}", "[SSN]")

output := {
    block: false,
    payload: modified,
    compliance_events: [
        {
            event_type: "pii_redacted",
            severity: "warning",
            description: "SSN pattern found and redacted",
            metadata: { "pattern": "ssn", "count": 2 }
        }
    ]
}
```

## Changes by layer

**Scripting** — New `ComplianceEventOutput` type on `ScriptOutput`, Tengo extraction with severity validation, bridge mapping in `scripting_ent.go`

**Analytics** — `RecordComplianceEvents` on `AnalyticsHandler` interface, async channel+worker in `DatabaseHandler`, `aistudio_compliance_events_total` Prometheus metric, shared context-enrichment helper

**Filter execution** — Recording wired up at all 6 filter sites: proxy request/response, chat request/response, file reference, tool response

**Compliance service** — `GetComplianceEvents` with date range, app ID, event type, severity filtering, aggregation (by_severity, by_type, by_filter), timeline, pagination

**API** — `GET /compliance/events` endpoint

**gRPC edge→control** — `ComplianceEventProto` message in `AnalyticsPulse`, pulse plugin buffering on edge, control server processing and DB storage on receipt

## Test plan

- [ ] Enterprise scripting tests: 8 Tengo extraction tests (single/multiple events, metadata, severity validation, missing fields, block+events combo)
- [ ] Analytics pipeline tests: handler forwarding + Prometheus metric emission, nil/empty edge cases
- [ ] Compliance recorder tests: context enrichment, JSON metadata serialization, nil/empty output handling
- [ ] API endpoint tests: 7 sub-tests (empty response, data insertion + aggregation verification, severity/type/app_id filtering, limit+offset pagination, metadata JSON parsing)
- [ ] gRPC pulse tests: 6 control server tests (full compliance pulse, compliance-only pulse, zero-field events, empty list, mixed analytics+compliance, record count verification)
- [ ] Pulse plugin tests: 7 tests (buffering, empty slice, concurrent access, proto message building with full/empty/missing fields, mixed data)
- [ ] All existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)