### PR TITLE
docs: add compliance event reporting to filter scripts and documentation

### DIFF
--- a/docs/site/docs/filters.md
+++ b/docs/site/docs/filters.md
@@ -814,7 +814,7 @@ output := {
             event_type: "pii_redacted",
             severity: "info",
             description: "Email addresses redacted from request",
-            metadata: { "pattern": "email" }
+            metadata: { "redacted_types": ["email"] }
         }
     ]
 }
@@ -847,7 +847,7 @@ if should_block {
             event_type: "sensitive_content_detected",
             severity: "critical",
             description: "Blocked: keyword '" + found_keyword + "' detected",
-            metadata: { "keyword": found_keyword }
+            metadata: { "matched_pattern": found_keyword }
         }
     ]
 }
@@ -894,7 +894,7 @@ if !input.is_chunk || len(response_text) >= 150 {
                 event_type: "harmful_content_detected",
                 severity: "critical",
                 description: "Harmful pattern detected: '" + detected + "'",
-                metadata: { "pattern": detected }
+                metadata: { "matched_pattern": detected }
             }
         ]
     }

--- a/docs/site/docs/filters.md
+++ b/docs/site/docs/filters.md
@@ -168,7 +168,8 @@ output := {
     block: false,           // Set true to block the request
     payload: "",            // Modified JSON payload (or empty for no change)
     messages: [],           // Alternative: modified message array
-    message: ""             // Optional reason/log message
+    message: "",            // Optional reason/log message
+    compliance_events: []   // Optional: compliance audit events (see Compliance Event Reporting)
 }
 ```
 
@@ -767,6 +768,157 @@ output := {
 
 ---
 
+## Compliance Event Reporting
+
+Filter scripts can emit **compliance events** for non-blocking governance reporting. These events are recorded in the analytics pipeline and stored for compliance auditing. Compliance events never affect the filter's block/allow decision -- they are purely informational.
+
+This is useful for tracking:
+- PII redactions performed by filters
+- Content rewrites or modifications
+- Policy violations detected (even when not blocking)
+- Silent failures or degraded processing
+
+### Compliance Event Object
+
+Each compliance event has the following fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event_type` | string | Yes | Free-form event type (e.g., `"pii_redacted"`, `"policy_violation"`, `"content_rewritten"`) |
+| `severity` | string | No | `"info"`, `"warning"`, or `"critical"` (defaults to `"info"` if omitted or invalid) |
+| `description` | string | No | Human-readable description of what happened |
+| `metadata` | map | No | Arbitrary key-value data for additional context |
+
+**Validation rules:**
+- Events without an `event_type` are silently skipped
+- Invalid `severity` values default to `"info"`
+
+### Example: Request Filter with Compliance Events
+
+```tengo
+tyk := import("tyk")
+
+// Redact email addresses
+modified_payload := tyk.redact_pattern(
+    input,
+    "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+    "[EMAIL_REDACTED]"
+)
+
+output := {
+    block: false,
+    payload: modified_payload,
+    message: "",
+    compliance_events: [
+        {
+            event_type: "pii_redacted",
+            severity: "info",
+            description: "Email addresses redacted from request",
+            metadata: { "pattern": "email" }
+        }
+    ]
+}
+```
+
+### Example: Conditional Compliance Events
+
+When events should only be emitted under certain conditions, build the list before the output:
+
+```tengo
+text := import("text")
+
+should_block := false
+found_keyword := ""
+
+for msg in input.messages {
+    if msg.role == "user" {
+        if text.contains(msg.content, "password") {
+            should_block = true
+            found_keyword = "password"
+            break
+        }
+    }
+}
+
+compliance_events_list := []
+if should_block {
+    compliance_events_list = [
+        {
+            event_type: "sensitive_content_detected",
+            severity: "critical",
+            description: "Blocked: keyword '" + found_keyword + "' detected",
+            metadata: { "keyword": found_keyword }
+        }
+    ]
+}
+
+output := {
+    block: should_block,
+    payload: input.raw_input,
+    message: should_block ? "Blocked: contains sensitive content" : "",
+    compliance_events: compliance_events_list
+}
+```
+
+### Example: Response Filter with Compliance Events
+
+Response filters also support compliance events. This is useful for logging when harmful content is detected in LLM responses:
+
+```tengo
+text := import("text")
+
+response_text := input.is_chunk ? input.current_buffer : input.raw_input
+
+output := {
+    block: false,
+    message: ""
+}
+
+if !input.is_chunk || len(response_text) >= 150 {
+    harmful := ["instructions for making", "how to build a weapon"]
+    is_harmful := false
+    detected := ""
+
+    for pattern in harmful {
+        if text.contains(text.to_lower(response_text), pattern) {
+            is_harmful = true
+            detected = pattern
+            break
+        }
+    }
+
+    compliance_events_list := []
+    if is_harmful {
+        compliance_events_list = [
+            {
+                event_type: "harmful_content_detected",
+                severity: "critical",
+                description: "Harmful pattern detected: '" + detected + "'",
+                metadata: { "pattern": detected }
+            }
+        ]
+    }
+
+    output = {
+        block: is_harmful,
+        message: is_harmful ? "Response blocked: harmful content detected" : "",
+        compliance_events: compliance_events_list
+    }
+}
+```
+
+### Querying Compliance Events
+
+Compliance events are accessible via the admin API:
+
+```
+GET /api/v1/compliance/events?start_date=2025-01-01&end_date=2025-01-31&severity=critical
+```
+
+Query parameters: `start_date`, `end_date`, `app_id`, `event_type`, `severity`, `limit`, `offset`.
+
+---
+
 ## Response Filters
 
 **Response Filters** enable administrators to block LLM responses based on content analysis, providing governance controls on what LLMs can say to end users.
@@ -826,12 +978,13 @@ input := {
 **Output Object:**
 ```tengo
 output := {
-    block: false,   // Set true to block/interrupt response
-    message: ""     // Block reason (shown to user)
+    block: false,           // Set true to block/interrupt response
+    message: "",            // Block reason (shown to user)
+    compliance_events: []   // Optional: compliance audit events (supported)
 }
 ```
 
-**Note**: The `payload` and `messages` fields in output are **ignored** for response filters.
+**Note**: The `payload` and `messages` fields in output are **ignored** for response filters. However, `compliance_events` are fully supported and will be processed and stored for audit purposes.
 
 ### Example 1: Block Refund Promises (Works for Streaming and Non-Streaming)
 

--- a/examples/filter-scripts/README.md
+++ b/examples/filter-scripts/README.md
@@ -34,7 +34,8 @@ output := {
     block: false,           // Set true to block the request
     payload: "",            // Modified JSON payload (empty = no change)
     messages: [],           // Alternative: return modified message array
-    message: ""             // Optional reason/log message
+    message: "",            // Optional reason/log message
+    compliance_events: []   // Optional: compliance events for audit trail (see below)
 }
 ```
 
@@ -331,6 +332,91 @@ modified := tyk.redact_pattern(input, "\\d{3}-\\d{2}-\\d{4}", "[SSN]")
 6. **Use helpers for simple patterns** - `redact_pattern` handles vendor differences
 7. **Check roles before modifying** - Different logic for system, user, assistant messages
 8. **Handle empty arrays** - Check `len(input.messages)` before iterating
+
+## Compliance Event Reporting
+
+Filters can emit **compliance events** for non-blocking governance reporting. These events flow through the analytics pipeline and are stored for compliance auditing. They never affect the filter's block/allow decision.
+
+### Compliance Event Object
+
+```javascript
+{
+    event_type: "pii_redacted",           // Required - free-form string (events without this are skipped)
+    severity: "warning",                   // Optional - "info", "warning", or "critical" (defaults to "info")
+    description: "SSN pattern redacted",   // Optional - human-readable description
+    metadata: { "pattern": "ssn" }         // Optional - arbitrary key-value data
+}
+```
+
+**Validation rules:**
+- `event_type` is required. Events missing this field are silently skipped.
+- `severity` must be `"info"`, `"warning"`, or `"critical"`. Invalid values default to `"info"`.
+
+### Example: PII Redaction with Compliance Reporting
+
+```javascript
+tyk := import("tyk")
+
+// Redact email addresses
+modified_payload := tyk.redact_pattern(
+    input,
+    "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+    "[EMAIL_REDACTED]"
+)
+
+output := {
+    block: false,
+    payload: modified_payload,
+    message: "",
+    compliance_events: [
+        {
+            event_type: "pii_redacted",
+            severity: "info",
+            description: "Email addresses redacted",
+            metadata: { "pattern": "email" }
+        }
+    ]
+}
+```
+
+### Example: Conditional Compliance Events
+
+```javascript
+text := import("text")
+
+should_block := false
+found_keyword := ""
+
+for msg in input.messages {
+    if msg.role == "user" {
+        if text.contains(msg.content, "password") {
+            should_block = true
+            found_keyword = "password"
+            break
+        }
+    }
+}
+
+// Only emit a compliance event when something is detected
+compliance_events_list := []
+if should_block {
+    compliance_events_list = [
+        {
+            event_type: "sensitive_content_detected",
+            severity: "critical",
+            description: "Blocked: keyword '" + found_keyword + "' detected",
+            metadata: { "keyword": found_keyword }
+        }
+    ]
+}
+
+output := {
+    block: should_block,
+    payload: input.raw_input,
+    message: should_block ? "Blocked: contains sensitive content" : "",
+    compliance_events: compliance_events_list
+}
+```
 
 ## Debugging Tips
 

--- a/examples/filter-scripts/README.md
+++ b/examples/filter-scripts/README.md
@@ -373,7 +373,7 @@ output := {
             event_type: "pii_redacted",
             severity: "info",
             description: "Email addresses redacted",
-            metadata: { "pattern": "email" }
+            metadata: { "redacted_types": ["email"] }
         }
     ]
 }
@@ -405,7 +405,7 @@ if should_block {
             event_type: "sensitive_content_detected",
             severity: "critical",
             description: "Blocked: keyword '" + found_keyword + "' detected",
-            metadata: { "keyword": found_keyword }
+            metadata: { "matched_pattern": found_keyword }
         }
     ]
 }

--- a/examples/filter-scripts/content-blocker.tengo
+++ b/examples/filter-scripts/content-blocker.tengo
@@ -25,8 +25,21 @@ for msg in input.messages {
     }
 }
 
+compliance_events_list := []
+if should_block {
+    compliance_events_list = [
+        {
+            event_type: "sensitive_content_detected",
+            severity: "critical",
+            description: "Blocked: sensitive keyword '" + found_keyword + "' detected",
+            metadata: { "keyword": found_keyword }
+        }
+    ]
+}
+
 output := {
     block: should_block,
     payload: input.raw_input,
-    message: should_block ? "Blocked: message contains '" + found_keyword + "'" : ""
+    message: should_block ? "Blocked: message contains '" + found_keyword + "'" : "",
+    compliance_events: compliance_events_list
 }

--- a/examples/filter-scripts/content-blocker.tengo
+++ b/examples/filter-scripts/content-blocker.tengo
@@ -32,7 +32,7 @@ if should_block {
             event_type: "sensitive_content_detected",
             severity: "critical",
             description: "Blocked: sensitive keyword '" + found_keyword + "' detected",
-            metadata: { "keyword": found_keyword }
+            metadata: { "matched_pattern": found_keyword }
         }
     ]
 }

--- a/examples/filter-scripts/email-redaction.tengo
+++ b/examples/filter-scripts/email-redaction.tengo
@@ -13,5 +13,13 @@ modified_payload := tyk.redact_pattern(
 output := {
     block: false,
     payload: modified_payload,
-    message: ""
+    message: "",
+    compliance_events: [
+        {
+            event_type: "pii_redacted",
+            severity: "info",
+            description: "Email addresses redacted",
+            metadata: { "pattern": "email" }
+        }
+    ]
 }

--- a/examples/filter-scripts/email-redaction.tengo
+++ b/examples/filter-scripts/email-redaction.tengo
@@ -19,7 +19,7 @@ output := {
             event_type: "pii_redacted",
             severity: "info",
             description: "Email addresses redacted",
-            metadata: { "pattern": "email" }
+            metadata: { "redacted_types": ["email"] }
         }
     ]
 }

--- a/examples/filter-scripts/pii-redaction.tengo
+++ b/examples/filter-scripts/pii-redaction.tengo
@@ -67,5 +67,13 @@ final_payload := tyk.redact_pattern(
 output := {
     block: false,
     payload: final_payload,
-    message: "PII redacted"
+    message: "PII redacted",
+    compliance_events: [
+        {
+            event_type: "pii_redacted",
+            severity: "warning",
+            description: "Email, phone, and SSN patterns redacted",
+            metadata: { "patterns": "email,phone,ssn" }
+        }
+    ]
 }

--- a/examples/filter-scripts/pii-redaction.tengo
+++ b/examples/filter-scripts/pii-redaction.tengo
@@ -73,7 +73,7 @@ output := {
             event_type: "pii_redacted",
             severity: "warning",
             description: "Email, phone, and SSN patterns redacted",
-            metadata: { "patterns": "email,phone,ssn" }
+            metadata: { "redacted_types": ["email", "phone", "ssn"] }
         }
     ]
 }

--- a/examples/filter-scripts/response-block-refunds.tengo
+++ b/examples/filter-scripts/response-block-refunds.tengo
@@ -55,7 +55,7 @@ if !input.is_chunk || len(check_text) >= min_buffer_length {
                 event_type: "refund_promise_detected",
                 severity: "critical",
                 description: "LLM attempted to promise a refund: '" + matched_pattern + "'",
-                metadata: { "pattern": matched_pattern }
+                metadata: { "matched_pattern": matched_pattern }
             }
         ]
     }

--- a/examples/filter-scripts/response-block-refunds.tengo
+++ b/examples/filter-scripts/response-block-refunds.tengo
@@ -47,9 +47,23 @@ if !input.is_chunk || len(check_text) >= min_buffer_length {
         }
     }
 
+    // Build compliance events for audit trail
+    compliance_events_list := []
+    if should_block {
+        compliance_events_list = [
+            {
+                event_type: "refund_promise_detected",
+                severity: "critical",
+                description: "LLM attempted to promise a refund: '" + matched_pattern + "'",
+                metadata: { "pattern": matched_pattern }
+            }
+        ]
+    }
+
     // Update output (use = not :=)
     output = {
         block: should_block,
-        message: should_block ? "Response blocked: Contains forbidden phrase '" + matched_pattern + "'" : ""
+        message: should_block ? "Response blocked: Contains forbidden phrase '" + matched_pattern + "'" : "",
+        compliance_events: compliance_events_list
     }
 }

--- a/examples/filter-scripts/response-harmful-content.tengo
+++ b/examples/filter-scripts/response-harmful-content.tengo
@@ -39,8 +39,21 @@ if !input.is_chunk || len(response_text) >= min_evaluation_length {
         }
     }
 
+    compliance_events_list := []
+    if is_harmful {
+        compliance_events_list = [
+            {
+                event_type: "harmful_content_detected",
+                severity: "critical",
+                description: "Harmful pattern detected: '" + detected_pattern + "'",
+                metadata: { "pattern": detected_pattern }
+            }
+        ]
+    }
+
     output = {
         block: is_harmful,
-        message: is_harmful ? "Response blocked: Potentially harmful content detected (" + detected_pattern + ")" : ""
+        message: is_harmful ? "Response blocked: Potentially harmful content detected (" + detected_pattern + ")" : "",
+        compliance_events: compliance_events_list
     }
 }

--- a/examples/filter-scripts/response-harmful-content.tengo
+++ b/examples/filter-scripts/response-harmful-content.tengo
@@ -46,7 +46,7 @@ if !input.is_chunk || len(response_text) >= min_evaluation_length {
                 event_type: "harmful_content_detected",
                 severity: "critical",
                 description: "Harmful pattern detected: '" + detected_pattern + "'",
-                metadata: { "pattern": detected_pattern }
+                metadata: { "matched_pattern": detected_pattern }
             }
         ]
     }

--- a/examples/filter-scripts/response-llm-policy-check.tengo
+++ b/examples/filter-scripts/response-llm-policy-check.tengo
@@ -39,8 +39,21 @@ Text: ` + response_text
     // Check if LLM detected a violation
     violates_policy := text.contains(text.to_lower(policy_result), "yes")
 
+    // Build compliance events for audit trail
+    compliance_events_list := []
+    if violates_policy {
+        compliance_events_list = [
+            {
+                event_type: "policy_violation_detected",
+                severity: "critical",
+                description: "LLM policy checker flagged response as violating policy"
+            }
+        ]
+    }
+
     output = {
         block: violates_policy,
-        message: violates_policy ? "Response blocked: LLM detected policy violation" : ""
+        message: violates_policy ? "Response blocked: LLM detected policy violation" : "",
+        compliance_events: compliance_events_list
     }
 }

--- a/features/Filters.md
+++ b/features/Filters.md
@@ -95,6 +95,7 @@ flowchart LR
 *   **Custom Functions:**
     *   `tyk.makeHTTPRequest(method, url, body, headers)`: Makes an HTTP call.
     *   `tyk.llm(llm_id, prompt)`: Calls another LLM managed by Midsommar.
+*   **Compliance Events:** Scripts can optionally include a `compliance_events` array in the output object. Each event requires an `event_type` (string), and can include `severity` ("info"/"warning"/"critical"), `description` (string), and `metadata` (map). Events are stored in the `compliance_events` table (`models/compliance_event.go`) for audit reporting via `GET /compliance/events`. Events are non-blocking and do not affect the filter's block/allow decision.
 *   **Error Handling:** Compilation or runtime errors in the script, or a `result` of `false`, lead to request rejection (HTTP 403).
 *   **Association:** Filters are linked to LLMs and Chats via many-to-many relationships in the database, managed through the respective entity's update endpoints or specific association endpoints (like for Tools).
 *   **API Endpoints:**
@@ -123,6 +124,7 @@ flowchart LR
 *   **Security Risks:** The `makeHTTPRequest` function allows scripts to call arbitrary URLs, which could be a security risk if not carefully managed. Access control or sandboxing might be needed. Calling internal services could also be risky.
 *   **Error Reporting:** Clearer error messages from failed scripts back to the client or admin logs would be helpful.
 *   **Script Complexity:** Managing complex logic in Tengo scripts might become difficult. Versioning or testing frameworks for scripts could be beneficial.
+*   **Compliance Event Reporting:** Implemented in `models/compliance_event.go` and `scripting/compliance_recorder.go`. Scripts can emit governance events (PII redaction, policy violations, etc.) that are stored for compliance auditing. Events flow through the analytics pipeline and are queryable via `GET /compliance/events`. Prometheus metrics are tracked via `aistudio_compliance_events_total`.
 *   **Filter Ordering:** If multiple filters are applied, their execution order might matter but isn't explicitly defined in the findings.
 *   **Request/Response Filtering:** Currently, filtering seems focused on the *request* payload (`outboundRequestMiddleware`, `screenProxyRequestByVendor`). Filtering the *response* from the LLM might be a future enhancement.
 *   **Middleware Scripting:** The `scripting` package also contains `RunMiddleware`, suggesting scripts might also be usable for modifying requests/responses, not just filtering/blocking. This wasn't the focus but is related.

--- a/ui/admin-frontend/src/admin/components/filters/ScriptTemplateSelector.js
+++ b/ui/admin-frontend/src/admin/components/filters/ScriptTemplateSelector.js
@@ -88,7 +88,15 @@ final_payload := tyk.redact_pattern(
 output := {
     block: false,
     payload: final_payload,
-    message: "PII redacted"
+    message: "PII redacted",
+    compliance_events: [
+        {
+            event_type: "pii_redacted",
+            severity: "warning",
+            description: "Email, phone, and SSN patterns redacted",
+            metadata: { "patterns": "email,phone,ssn" }
+        }
+    ]
 }`,
     },
   ],
@@ -155,9 +163,22 @@ if !input.is_chunk || len(response_text) >= min_evaluation_length {
         }
     }
 
+    compliance_events_list := []
+    if detected_pattern != "" {
+        compliance_events_list = [
+            {
+                event_type: "harmful_content_detected",
+                severity: is_blocked ? "critical" : "warning",
+                description: "Detected pattern: '" + detected_pattern + "'",
+                metadata: { "pattern": detected_pattern, "blocked": is_blocked ? "true" : "false" }
+            }
+        ]
+    }
+
     output = {
         block: is_blocked,
-        message: is_blocked ? "Response blocked: Contains forbidden phrase '" + detected_pattern + "'" : ""
+        message: is_blocked ? "Response blocked: Contains forbidden phrase '" + detected_pattern + "'" : "",
+        compliance_events: compliance_events_list
     }
 }`,
     },
@@ -210,9 +231,21 @@ Text: \` + response_text
     // Check if LLM detected a violation
     violates_policy := text.contains(text.to_lower(policy_result), "yes")
 
+    compliance_events_list := []
+    if violates_policy {
+        compliance_events_list = [
+            {
+                event_type: "policy_violation_detected",
+                severity: "critical",
+                description: "LLM policy checker flagged response as violating policy"
+            }
+        ]
+    }
+
     output = {
         block: violates_policy,
-        message: violates_policy ? "Response blocked: LLM detected policy violation" : ""
+        message: violates_policy ? "Response blocked: LLM detected policy violation" : "",
+        compliance_events: compliance_events_list
     }
 }`,
     },

--- a/ui/admin-frontend/src/admin/components/filters/ScriptTemplateSelector.js
+++ b/ui/admin-frontend/src/admin/components/filters/ScriptTemplateSelector.js
@@ -94,7 +94,7 @@ output := {
             event_type: "pii_redacted",
             severity: "warning",
             description: "Email, phone, and SSN patterns redacted",
-            metadata: { "patterns": "email,phone,ssn" }
+            metadata: { "redacted_types": ["email", "phone", "ssn"] }
         }
     ]
 }`,
@@ -170,7 +170,7 @@ if !input.is_chunk || len(response_text) >= min_evaluation_length {
                 event_type: "harmful_content_detected",
                 severity: is_blocked ? "critical" : "warning",
                 description: "Detected pattern: '" + detected_pattern + "'",
-                metadata: { "pattern": detected_pattern, "blocked": is_blocked ? "true" : "false" }
+                metadata: { "matched_pattern": detected_pattern, "blocked": is_blocked ? "true" : "false" }
             }
         ]
     }


### PR DESCRIPTION
## Summary
- Updated all 6 pre-provided filter scripts in `examples/filter-scripts/` to emit `compliance_events` (PII redaction, content blocking, harmful content detection, refund promises, LLM policy checks)
- Updated all 3 embedded UI templates in `ScriptTemplateSelector.js` with compliance event examples
- Added full "Compliance Event Reporting" documentation section to `docs/site/docs/filters.md` with schema reference, validation rules, and examples for both request and response filters
- Updated `examples/filter-scripts/README.md` with compliance event field reference and usage examples
- Updated `features/Filters.md` feature spec with compliance event implementation details

## Test plan
- [x] `go test -tags enterprise ./scripting/...` passes
- [x] JS syntax validated with acorn parser
- [ ] Load each embedded template in admin UI filter editor and confirm rendering
- [ ] Create a filter using the PII Redaction template and verify compliance events appear in analytics

🤖 Generated with [Claude Code](https://claude.com/claude-code)