### PR TITLE
[TT-17030] Migrate from ORG_GH_TOKEN PAT to GitHub App tokens

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -157,15 +157,23 @@ jobs:
     needs: build-frontend
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           submodules: true
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git for Enterprise Access
         run: |
-          git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
 
       - name: Initialize Enterprise Submodule
         run: |
@@ -225,10 +233,18 @@ jobs:
     needs: [build-frontend, build-ent-binaries]
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download Frontend Build
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,14 @@ jobs:
       commit_author: ${{ steps.set_outputs.outputs.commit_author}}
     steps:
       -
+        name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+      -
         name: Free disk space
         if: matrix.component == 'studio'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
@@ -112,7 +120,7 @@ jobs:
         with:
           repository: TykTechnologies/ai-studio-enterprise
           path: midsommar/enterprise
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       -
         name: Checkout langchaingo repository
@@ -203,7 +211,7 @@ jobs:
           ls
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ secrets.ORG_GH_TOKEN }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/midsommar
           if [ "$EDITION" = "ce" ]; then
             sed -i "/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d" go.mod


### PR DESCRIPTION
## Summary
- Replace all `ORG_GH_TOKEN` usages in `release.yml` and `prod.yml` with tokens generated by `actions/create-github-app-token`
- Each job that needs the token gets its own `app-token` generation step

### Files changed
- `.github/workflows/release.yml` — enterprise submodule checkout token (goreleaser job) and `git config insteadOf` inside the Docker build script
- `.github/workflows/prod.yml` — checkout token and `git config insteadOf` in `build-ent-binaries` job, checkout token in `build-ent-image` job

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org-level secrets are available to this repo
- [ ] Trigger a release build and confirm enterprise submodule checkout works
- [ ] Confirm prod deployment pipeline builds enterprise edition binaries and images successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)