### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Configure Git for Enterprise Access
         run: |
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Initialize Enterprise Submodule
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
           ls
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          git config --global url."https://${{ steps.app-token.outputs.token }}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/midsommar
           if [ "$EDITION" = "ce" ]; then
             sed -i "/github.com\/TykTechnologies\/midsommar\/v2\/enterprise/d" go.mod


### PR DESCRIPTION
## Summary
- Replace `url."https://${TOKEN}@github.com".insteadOf` with `url."https://x-access-token:${TOKEN}@github.com/".insteadOf` in release.yml (1 occurrence) and prod.yml (1 occurrence)
- The bare token format doesn't work when `actions/checkout` has configured a credential helper; the `x-access-token:` prefix and trailing slashes fix this

## Test plan
- [ ] Verify release workflow can pull private Go modules
- [ ] Verify prod workflow authenticates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)