### PR TITLE
fix: propagate LLMID through edge analytics pulse to studio

### DIFF
--- a/grpc/analytics_pulse_test.go
+++ b/grpc/analytics_pulse_test.go
@@ -167,6 +167,16 @@ func TestSendAnalyticsPulse_BatchProcessing(t *testing.T) {
 		assert.Equal(t, models.ProxyInteraction, record.InteractionType)
 	}
 
+	// LLMID must be propagated from the pulse to the ProxyLog so that
+	// GetProxyLogsForLLM (which filters on llm_id) can return edge-sourced
+	// logs in the LLM detail view. Without this, no logs show up at all.
+	expectedLLMIDs := map[string]uint{"openai": 1, "anthropic": 2}
+	for _, pl := range proxyLogs {
+		want, ok := expectedLLMIDs[pl.Vendor]
+		require.True(t, ok, "unexpected vendor %q in proxy log", pl.Vendor)
+		assert.Equal(t, want, pl.LLMID, "ProxyLog for vendor %q should carry LLMID from pulse", pl.Vendor)
+	}
+
 	// Performance assertion: batch processing should be fast
 	assert.Less(t, processingTime.Milliseconds(), int64(500),
 		"Batch processing should complete quickly (got %v)", processingTime)

--- a/grpc/control_server.go
+++ b/grpc/control_server.go
@@ -814,10 +814,15 @@ func (s *ControlServer) SendAnalyticsPulse(ctx context.Context, req *pb.Analytic
 				vendor = s.extractVendorFromEvent(event)
 			}
 
-			// Create ProxyLog for request/response tracking
+			// Create ProxyLog for request/response tracking.
+			// LLMID must be propagated from the pulse event so that the LLM
+			// detail view can isolate logs by specific LLM entry — without
+			// it, edge-sourced logs land with llm_id = 0 and are invisible
+			// to GetProxyLogsForLLM, which filters on llm_id directly.
 			proxyLogs[i] = &models.ProxyLog{
 				AppID:        uint(event.AppId),
 				UserID:       uint(event.UserId), // User ID synced from edge (via config sync)
+				LLMID:        uint(event.LlmId),
 				Vendor:       vendor,
 				ModelName:    modelName,
 				RequestBody:  event.RequestBody,  // Now included from pulse if configured


### PR DESCRIPTION
## Summary

Follow-up to #376. That PR fixed proxy-log attribution at the **embedded gateway** layer and at the display query (`GetProxyLogsForLLM` now filters on `llm_id` directly). It missed the **edge-gateway → studio** path: in `SendAnalyticsPulse` the studio reconstructs `models.ProxyLog` from each incoming `pb.AnalyticsEvent`, but the ProxyLog construction never copied `LlmId` across, so every edge-pulsed log landed with `llm_id = 0` and was invisible to the new query.

User-visible symptom: with the new query in place, the LLM detail page showed **no proxy logs at all** for any deployment routing through the microgateway.

## Root cause

`grpc/control_server.go:818` — the proto already carries `event.LlmId` (it's populated on the gateway side via the analytics pulse plugin), but the studio's ProxyLog construction was missing the `LLMID` field. Adding `LLMID: uint(event.LlmId)` closes the gap.

## Changes

- **`grpc/control_server.go`** — set `LLMID` from `event.LlmId` when constructing `ProxyLog` in `SendAnalyticsPulse`.
- **`grpc/analytics_pulse_test.go`** — extend `TestSendAnalyticsPulse_BatchProcessing` to assert each persisted `ProxyLog` carries the expected `LLMID` (mapped per vendor in the test fixture). The previous version verified counts and chat-record costs but not LLM attribution on the proxy log side, which is exactly the gap that let this slip through.

## Test plan

- [x] `go test ./grpc/... ./analytics/...` — all pass
- [ ] Manual: with a microgateway pulsing to studio, hit an LLM, then open the LLM detail page and confirm proxy logs appear and are isolated to the correct LLM entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)