### PR TITLE
fix: correct microgateway image refs in quickstart compose

### DIFF
--- a/quickstart/ce/compose.yaml
+++ b/quickstart/ce/compose.yaml
@@ -16,16 +16,10 @@ services:
       - 3000:8080
       - 9595:9090
     restart: always
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 15s
   mgw:
     networks:
       - tyk-network
-    image: tykio/microgateway:v2.0.0
+    image: tykio/tyk-microgateway:v2.0.0
     volumes:
       - ../confs/mgw-ce.env:/app/.env
       - ../confs/mgw-analytics.yaml:/app/mgw-analytics.yaml
@@ -39,11 +33,4 @@ services:
     restart: always
     depends_on:
       midsommar:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9091/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 10s
-    
+        condition: service_started

--- a/quickstart/enterprise/compose.yaml
+++ b/quickstart/enterprise/compose.yaml
@@ -5,7 +5,7 @@ services:
   midsommar:
     networks:
       - tyk-network
-    image: tykio/tyk-ai-studio:pre-release-latest-ent
+    image: tykio/tyk-ai-studio-ent:v2.0.0
     volumes:
       - ../confs/midsommar-ent.env:/app/.env
       - ./keys/plugins/plugin-live.pub:/app/keys/plugins/plugin-live.pub:ro
@@ -18,16 +18,10 @@ services:
       - 8585:8080
       - 9595:9090
     restart: always
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/ready"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 15s
   mgw:
     networks:
       - tyk-network
-    image: tykio/microgateway:pre-release-latest-ent
+    image: tykio/tyk-microgateway-ent:v2.0.0
     volumes:
       - ../confs/mgw-ent.env:/app/.env
       - ../confs/mgw-analytics.yaml:/app/mgw-analytics.yaml
@@ -41,11 +35,4 @@ services:
     restart: always
     depends_on:
       midsommar:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9091/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 10s
-    
+        condition: service_started


### PR DESCRIPTION
## Summary
- Quickstart CE and EE compose files referenced `tykio/microgateway`, but `release.yml` publishes microgateway images as `tykio/tyk-microgateway` (CE) and `tykio/tyk-microgateway-ent` (EE). Pinned all four images to `v2.0.0` and aligned the EE studio image with the same release-workflow naming (`tykio/tyk-ai-studio-ent`).
- Removed the wget-based healthchecks: the published images are distroless (`gcr.io/distroless/base-debian12:nonroot`) with no `wget`/`curl`/`sh`, so the healthchecks always failed and blocked `mgw` from starting via `depends_on: service_healthy`. Switched to `service_started`.

Closes #378

## Test plan
- [ ] `cd quickstart/ce && docker compose up` — both `midsommar` and `mgw` come up cleanly, no image-pull errors, no healthcheck failures
- [ ] `cd quickstart/enterprise && docker compose up` — same, with a valid `TYK_AI_LICENSE` in `../required.env`
- [ ] `curl http://localhost:3000/ready` (CE) and `curl http://localhost:9091/health` (mgw) return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)