### PR TITLE
Move app edit action above proxy logs

### DIFF
--- a/ui/admin-frontend/src/admin/components/apps/AppDetails.js
+++ b/ui/admin-frontend/src/admin/components/apps/AppDetails.js
@@ -639,13 +639,22 @@ const AppDetails = () => {
     <>
       <TitleBox top="64px">
         <Typography variant="headingXLarge">App details</Typography>
-        <SecondaryLinkButton
-          startIcon={<ArrowBackIcon />}
-          onClick={() => navigate("/admin/apps")}
-          color="inherit"
-        >
-          Back to apps
-        </SecondaryLinkButton>
+        <Box display="flex" alignItems="center" gap={2}>
+          <PrimaryButton
+            variant="contained"
+            startIcon={<EditIcon />}
+            onClick={() => navigate(`/admin/apps/edit/${id}`)}
+          >
+            Edit app
+          </PrimaryButton>
+          <SecondaryLinkButton
+            startIcon={<ArrowBackIcon />}
+            onClick={() => navigate("/admin/apps")}
+            color="inherit"
+          >
+            Back to apps
+          </SecondaryLinkButton>
+        </Box>
       </TitleBox>
       <ContentBox>
         <SectionTitle>Token Usage</SectionTitle>
@@ -985,21 +994,6 @@ const AppDetails = () => {
             onPageSizeChange={handlePageSizeChange}
           />
         </StyledPaper>
-
-        <Box
-          mt={4}
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          <PrimaryButton
-            variant="contained"
-            startIcon={<EditIcon />}
-            onClick={() => navigate(`/admin/apps/edit/${id}`)}
-          >
-            Edit app
-          </PrimaryButton>
-        </Box>
       </ContentBox>
       <Snackbar
         open={snackbar.open}

--- a/ui/admin-frontend/src/admin/components/apps/AppDetails.test.js
+++ b/ui/admin-frontend/src/admin/components/apps/AppDetails.test.js
@@ -1,0 +1,135 @@
+import React from "react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import AppDetails from "./AppDetails";
+import { renderWithRouterAndTheme } from "../../../test-utils/render-with-theme";
+import apiClient from "../../utils/apiClient";
+import agentService from "../../services/agentService";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-chartjs-2", () => ({
+  Line: () => <div data-testid="line-chart" />,
+}));
+
+jest.mock("../../utils/apiClient", () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    patch: jest.fn(),
+  },
+  appToolAPI: {
+    getAppTools: jest.fn(),
+  },
+}));
+
+jest.mock("../../services/agentService", () => ({
+  __esModule: true,
+  default: {
+    listAgents: jest.fn(),
+  },
+}));
+
+jest.mock("../../context/EditionContext", () => ({
+  useEdition: () => ({ isEnterprise: false }),
+}));
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: "42" }),
+  };
+});
+
+const mockApp = {
+  id: "42",
+  attributes: {
+    name: "Support App",
+    description: "Routes support requests",
+    user_id: "7",
+    is_orphaned: false,
+    llms: [{ id: "llm-1", attributes: { name: "GPT Support" } }],
+    datasources: [{ id: "ds-1", attributes: { name: "Knowledge Base" } }],
+    tools: [{ id: "tool-1", attributes: { name: "Ticket Lookup" } }],
+    plugin_resources: [],
+    monthly_budget: null,
+  },
+};
+
+const mockUser = {
+  id: "7",
+  attributes: {
+    name: "Alex Admin",
+  },
+};
+
+const analyticsResponse = {
+  data: {
+    labels: [],
+    datasets: [],
+  },
+};
+
+describe("AppDetails", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    agentService.listAgents.mockResolvedValue({ data: [] });
+
+    apiClient.get.mockImplementation((url) => {
+      if (url === "/apps/42") {
+        return Promise.resolve({ data: { data: mockApp } });
+      }
+
+      if (url === "/users/7") {
+        return Promise.resolve({ data: { data: mockUser } });
+      }
+
+      if (url === "/analytics/proxy-logs-for-app") {
+        return Promise.resolve({
+          data: {
+            data: [],
+            meta: {
+              total_count: 0,
+              total_pages: 0,
+            },
+          },
+        });
+      }
+
+      if (
+        url === "/analytics/usage" ||
+        url === "/analytics/budget-usage-for-app" ||
+        url === "/analytics/app-interactions-over-time"
+      ) {
+        return Promise.resolve(analyticsResponse);
+      }
+
+      return Promise.reject(new Error(`Unhandled GET ${url}`));
+    });
+  });
+
+  test("renders a single edit action before proxy logs", async () => {
+    renderWithRouterAndTheme(<AppDetails />);
+
+    const editButton = await screen.findByRole("button", { name: /edit app/i });
+    const proxyLogsHeading = await screen.findByRole("heading", { name: /proxy logs/i });
+
+    expect(screen.getAllByRole("button", { name: /edit app/i })).toHaveLength(1);
+    expect(
+      editButton.compareDocumentPosition(proxyLogsHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  test("navigates to the app edit page from the header action", async () => {
+    renderWithRouterAndTheme(<AppDetails />);
+
+    const editButton = await screen.findByRole("button", { name: /edit app/i });
+    fireEvent.click(editButton);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/admin/apps/edit/42");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Move the AI app `Edit app` action into the sticky details page header
- Remove the duplicate bottom-only edit action after the proxy log table
- Add regression coverage for the edit action placement and navigation

Fixes #236.

## Validation
- `npm test -- AppDetails.test.js --watchAll=false`
- `make test-frontend-unit`

## Notes
The full frontend unit suite passed locally. The test run emits existing console warnings from unrelated tests, but no failures.