### PR TITLE
Fix 12 OpenAPI summary collisions causing wrong Mintlify pages to render

### DIFF
--- a/api/catalogue_handlers_community.go
+++ b/api/catalogue_handlers_community.go
@@ -10,7 +10,7 @@ import (
 
 // LLM Catalogue management endpoints - CE: All return 402 Payment Required
 
-// @Summary Create a new catalogue
+// @Summary Create a new catalogue (Community Edition)
 // @Description Create a new LLM catalogue (Enterprise Edition only)
 // @Tags catalogues
 // @Accept json
@@ -134,7 +134,7 @@ func (a *API) listCatalogueLLMs(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("LLM catalogue management requires Enterprise Edition"))
 }
 
-// @Summary Search catalogues by name
+// @Summary Search catalogues by name (Community Edition)
 // @Description Search LLM catalogues by name prefix (Enterprise Edition only)
 // @Tags catalogues
 // @Accept json

--- a/api/data_catalogue_handlers_community.go
+++ b/api/data_catalogue_handlers_community.go
@@ -10,7 +10,7 @@ import (
 
 // Data Catalogue management endpoints - CE: All return 402 Payment Required
 
-// @Summary Create a new data catalogue
+// @Summary Create a new data catalogue (Community Edition)
 // @Description Create a new data catalogue (Enterprise Edition only)
 // @Tags data-catalogues
 // @Accept json
@@ -78,7 +78,7 @@ func (a *API) listDataCatalogues(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Data catalogue management requires Enterprise Edition"))
 }
 
-// @Summary Search data catalogues
+// @Summary Search data catalogues (Community Edition)
 // @Description Search data catalogues (Enterprise Edition only)
 // @Tags data-catalogues
 // @Accept json
@@ -149,7 +149,7 @@ func (a *API) removeDatasourceFromDataCatalogue(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Data catalogue management requires Enterprise Edition"))
 }
 
-// @Summary Get data catalogues by tag
+// @Summary Get data catalogues by tag (Community Edition)
 // @Description Get all data catalogues with a specific tag (Enterprise Edition only)
 // @Tags data-catalogues
 // @Accept json
@@ -163,7 +163,7 @@ func (a *API) getDataCataloguesByTag(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Data catalogue management requires Enterprise Edition"))
 }
 
-// @Summary Get data catalogues by datasource
+// @Summary Get data catalogues by datasource (Community Edition)
 // @Description Get all data catalogues containing a specific datasource (Enterprise Edition only)
 // @Tags data-catalogues
 // @Accept json

--- a/api/group_handlers_community.go
+++ b/api/group_handlers_community.go
@@ -14,7 +14,7 @@ import (
 
 // Group management endpoints - CE: All return 402 Payment Required
 
-// @Summary Create a new group
+// @Summary Create a new group (Community Edition)
 // @Description Create a new group (Enterprise Edition only)
 // @Tags groups
 // @Accept json
@@ -198,7 +198,7 @@ func (a *API) listGroupUsers(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Group management requires Enterprise Edition"))
 }
 
-// @Summary Update group users
+// @Summary Update group users (Community Edition)
 // @Description Bulk update users in a specific group (Enterprise Edition only)
 // @Tags groups
 // @Accept json
@@ -377,7 +377,7 @@ func (a *API) listGroupToolCatalogues(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Group management requires Enterprise Edition"))
 }
 
-// @Summary Update group catalogues
+// @Summary Update group catalogues (Community Edition)
 // @Description Bulk update all catalogues (LLM, data, tool) for a group (Enterprise Edition only)
 // @Tags groups
 // @Accept json

--- a/api/prices_handlers.go
+++ b/api/prices_handlers.go
@@ -326,16 +326,6 @@ func serializeModelPrices(mps models.ModelPrices) []ModelPriceResponse {
 	return result
 }
 
-// @Summary Get or create a model price by name
-// @Description Get a model price by its name, creating it with default values if it doesn't exist
-// @Tags model-prices
-// @Accept json
-// @Produce json
-// @Param model_name query string true "Model name"
-// @Success 200 {object} ModelPriceResponse
-// @Failure 500 {object} ErrorResponse
-// @Router /model-prices/by-name [get]
-// @Security BearerAuth
 // @Summary Update a model price and recalculate historical costs
 // @Description Update an existing model price's information and recalculate all historical chat record costs
 // @Tags model-prices
@@ -403,6 +393,16 @@ func (a *API) updateModelPriceAndRecalculate(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeModelPrice(modelPrice)})
 }
 
+// @Summary Get or create a model price by name
+// @Description Get a model price by its name, creating it with default values if it doesn't exist
+// @Tags model-prices
+// @Accept json
+// @Produce json
+// @Param model_name query string true "Model name"
+// @Success 200 {object} ModelPriceResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /model-prices/by-name [get]
+// @Security BearerAuth
 func (a *API) getOrCreateModelPriceByName(c *gin.Context) {
 	modelName := c.Query("model_name")
 	if modelName == "" {

--- a/api/tool_catalogue_handlers_community.go
+++ b/api/tool_catalogue_handlers_community.go
@@ -10,7 +10,7 @@ import (
 
 // Tool Catalogue management endpoints - CE: All return 402 Payment Required
 
-// @Summary Create a new tool catalogue
+// @Summary Create a new tool catalogue (Community Edition)
 // @Description Create a new tool catalogue (Enterprise Edition only)
 // @Tags tool-catalogues
 // @Accept json
@@ -78,7 +78,7 @@ func (a *API) listToolCatalogues(c *gin.Context) {
 	helpers.SendErrorResponse(c, helpers.NewPaymentRequiredError("Tool catalogue management requires Enterprise Edition"))
 }
 
-// @Summary Search tool catalogues
+// @Summary Search tool catalogues (Community Edition)
 // @Description Search tool catalogues (Enterprise Edition only)
 // @Tags tool-catalogues
 // @Accept json

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1709,7 +1709,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Create a new catalogue",
+                "summary": "Create a new catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -1779,7 +1779,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Search catalogues by name",
+                "summary": "Search catalogues by name (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2104,7 +2104,7 @@ const docTemplate = `{
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Create a new data catalogue",
+                "summary": "Create a new data catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -2139,7 +2139,7 @@ const docTemplate = `{
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Get data catalogues by datasource",
+                "summary": "Get data catalogues by datasource (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -2183,7 +2183,7 @@ const docTemplate = `{
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Get data catalogues by tag",
+                "summary": "Get data catalogues by tag (Community Edition)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2227,7 +2227,7 @@ const docTemplate = `{
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Search data catalogues",
+                "summary": "Search data catalogues (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2671,7 +2671,9 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "type": "array",
-                            "items": {}
+                            "items": {
+                                "type": "object"
+                            }
                         }
                     }
                 }
@@ -2869,7 +2871,7 @@ const docTemplate = `{
                 "tags": [
                     "groups"
                 ],
-                "summary": "Create a new group",
+                "summary": "Create a new group (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -3070,7 +3072,7 @@ const docTemplate = `{
                 "tags": [
                     "groups"
                 ],
-                "summary": "Update group catalogues",
+                "summary": "Update group catalogues (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3511,7 +3513,7 @@ const docTemplate = `{
                 "tags": [
                     "groups"
                 ],
-                "summary": "Update group users",
+                "summary": "Update group users (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -4120,7 +4122,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest"
+                            "$ref": "#/definitions/services.CreatePluginRequest"
                         }
                     }
                 ],
@@ -4585,7 +4587,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest"
+                            "$ref": "#/definitions/services.UpdatePluginRequest"
                         }
                     }
                 ],
@@ -5845,7 +5847,7 @@ const docTemplate = `{
                 "tags": [
                     "tool-catalogues"
                 ],
-                "summary": "Create a new tool catalogue",
+                "summary": "Create a new tool catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -5880,7 +5882,7 @@ const docTemplate = `{
                 "tags": [
                     "tool-catalogues"
                 ],
-                "summary": "Search tool catalogues",
+                "summary": "Search tool catalogues (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -14119,25 +14121,19 @@ const docTemplate = `{
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "BearerAuth": []
                     }
                 ],
-                "description": "Get a model price by its name, creating it with default values if it doesn't exist\nUpdate an existing model price's information and recalculate all historical chat record costs",
+                "description": "Get a model price by its name, creating it with default values if it doesn't exist",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
                 "tags": [
-                    "model-prices",
                     "model-prices"
                 ],
-                "summary": "Update a model price and recalculate historical costs",
+                "summary": "Get or create a model price by name",
                 "parameters": [
                     {
                         "type": "string",
@@ -14145,15 +14141,6 @@ const docTemplate = `{
                         "name": "model_name",
                         "in": "query",
                         "required": true
-                    },
-                    {
-                        "description": "Updated model price information",
-                        "name": "modelPrice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.ModelPriceInput"
-                        }
                     }
                 ],
                 "responses": {
@@ -14161,12 +14148,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/api.ModelPriceResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
@@ -14378,33 +14359,20 @@ const docTemplate = `{
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "BearerAuth": []
                     }
                 ],
-                "description": "Get a model price by its name, creating it with default values if it doesn't exist\nUpdate an existing model price's information and recalculate all historical chat record costs",
+                "description": "Update an existing model price's information and recalculate all historical chat record costs",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
                 "tags": [
-                    "model-prices",
                     "model-prices"
                 ],
                 "summary": "Update a model price and recalculate historical costs",
                 "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Model name",
-                        "name": "model_name",
-                        "in": "query",
-                        "required": true
-                    },
                     {
                         "type": "integer",
                         "description": "Model Price ID",
@@ -22960,105 +22928,6 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest": {
-            "type": "object",
-            "required": [
-                "command",
-                "name"
-            ],
-            "properties": {
-                "checksum": {
-                    "description": "Optional",
-                    "type": "string"
-                },
-                "command": {
-                    "type": "string"
-                },
-                "config": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "description": {
-                    "type": "string"
-                },
-                "hook_type": {
-                    "description": "Optional - will be populated from manifest",
-                    "type": "string"
-                },
-                "hook_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hook_types_customized": {
-                    "type": "boolean"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "load_immediately": {
-                    "description": "Auto-load AI Studio plugins",
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "oci_reference": {
-                    "description": "OCI artifact reference",
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest": {
-            "type": "object",
-            "properties": {
-                "checksum": {
-                    "type": "string"
-                },
-                "command": {
-                    "type": "string"
-                },
-                "config": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "description": {
-                    "type": "string"
-                },
-                "hook_type": {
-                    "type": "string"
-                },
-                "hook_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hook_types_customized": {
-                    "type": "boolean"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "load_immediately": {
-                    "description": "Auto-load AI Studio plugins",
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "oci_reference": {
-                    "type": "string"
-                }
-            }
-        },
         "models.AppBudgetUsageResponse": {
             "type": "object",
             "properties": {
@@ -23475,6 +23344,105 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "oci_reference": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.CreatePluginRequest": {
+            "type": "object",
+            "required": [
+                "command",
+                "name"
+            ],
+            "properties": {
+                "checksum": {
+                    "description": "Optional",
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "hook_type": {
+                    "description": "Optional - will be populated from manifest",
+                    "type": "string"
+                },
+                "hook_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hook_types_customized": {
+                    "type": "boolean"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "load_immediately": {
+                    "description": "Auto-load AI Studio plugins",
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "oci_reference": {
+                    "description": "OCI artifact reference",
+                    "type": "string"
+                }
+            }
+        },
+        "services.UpdatePluginRequest": {
+            "type": "object",
+            "properties": {
+                "checksum": {
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "hook_type": {
+                    "type": "string"
+                },
+                "hook_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hook_types_customized": {
+                    "type": "boolean"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "load_immediately": {
+                    "description": "Auto-load AI Studio plugins",
                     "type": "boolean"
                 },
                 "name": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1703,7 +1703,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Create a new catalogue",
+                "summary": "Create a new catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -1773,7 +1773,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Search catalogues by name",
+                "summary": "Search catalogues by name (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2098,7 +2098,7 @@
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Create a new data catalogue",
+                "summary": "Create a new data catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -2133,7 +2133,7 @@
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Get data catalogues by datasource",
+                "summary": "Get data catalogues by datasource (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -2177,7 +2177,7 @@
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Get data catalogues by tag",
+                "summary": "Get data catalogues by tag (Community Edition)",
                 "parameters": [
                     {
                         "type": "string",
@@ -2221,7 +2221,7 @@
                 "tags": [
                     "data-catalogues"
                 ],
-                "summary": "Search data catalogues",
+                "summary": "Search data catalogues (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -2665,7 +2665,9 @@
                         "description": "OK",
                         "schema": {
                             "type": "array",
-                            "items": {}
+                            "items": {
+                                "type": "object"
+                            }
                         }
                     }
                 }
@@ -2863,7 +2865,7 @@
                 "tags": [
                     "groups"
                 ],
-                "summary": "Create a new group",
+                "summary": "Create a new group (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -3064,7 +3066,7 @@
                 "tags": [
                     "groups"
                 ],
-                "summary": "Update group catalogues",
+                "summary": "Update group catalogues (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -3505,7 +3507,7 @@
                 "tags": [
                     "groups"
                 ],
-                "summary": "Update group users",
+                "summary": "Update group users (Community Edition)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -4114,7 +4116,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest"
+                            "$ref": "#/definitions/services.CreatePluginRequest"
                         }
                     }
                 ],
@@ -4579,7 +4581,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest"
+                            "$ref": "#/definitions/services.UpdatePluginRequest"
                         }
                     }
                 ],
@@ -5839,7 +5841,7 @@
                 "tags": [
                     "tool-catalogues"
                 ],
-                "summary": "Create a new tool catalogue",
+                "summary": "Create a new tool catalogue (Community Edition)",
                 "responses": {
                     "201": {
                         "description": "Created",
@@ -5874,7 +5876,7 @@
                 "tags": [
                     "tool-catalogues"
                 ],
-                "summary": "Search tool catalogues",
+                "summary": "Search tool catalogues (Community Edition)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -14113,25 +14115,19 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "BearerAuth": []
                     }
                 ],
-                "description": "Get a model price by its name, creating it with default values if it doesn't exist\nUpdate an existing model price's information and recalculate all historical chat record costs",
+                "description": "Get a model price by its name, creating it with default values if it doesn't exist",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
                 "tags": [
-                    "model-prices",
                     "model-prices"
                 ],
-                "summary": "Update a model price and recalculate historical costs",
+                "summary": "Get or create a model price by name",
                 "parameters": [
                     {
                         "type": "string",
@@ -14139,15 +14135,6 @@
                         "name": "model_name",
                         "in": "query",
                         "required": true
-                    },
-                    {
-                        "description": "Updated model price information",
-                        "name": "modelPrice",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.ModelPriceInput"
-                        }
                     }
                 ],
                 "responses": {
@@ -14155,12 +14142,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/api.ModelPriceResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/api.ErrorResponse"
                         }
                     },
                     "500": {
@@ -14372,33 +14353,20 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "BearerAuth": []
                     }
                 ],
-                "description": "Get a model price by its name, creating it with default values if it doesn't exist\nUpdate an existing model price's information and recalculate all historical chat record costs",
+                "description": "Update an existing model price's information and recalculate all historical chat record costs",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
                 "tags": [
-                    "model-prices",
                     "model-prices"
                 ],
                 "summary": "Update a model price and recalculate historical costs",
                 "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Model name",
-                        "name": "model_name",
-                        "in": "query",
-                        "required": true
-                    },
                     {
                         "type": "integer",
                         "description": "Model Price ID",
@@ -22954,105 +22922,6 @@
                 }
             }
         },
-        "github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest": {
-            "type": "object",
-            "required": [
-                "command",
-                "name"
-            ],
-            "properties": {
-                "checksum": {
-                    "description": "Optional",
-                    "type": "string"
-                },
-                "command": {
-                    "type": "string"
-                },
-                "config": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "description": {
-                    "type": "string"
-                },
-                "hook_type": {
-                    "description": "Optional - will be populated from manifest",
-                    "type": "string"
-                },
-                "hook_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hook_types_customized": {
-                    "type": "boolean"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "load_immediately": {
-                    "description": "Auto-load AI Studio plugins",
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "oci_reference": {
-                    "description": "OCI artifact reference",
-                    "type": "string"
-                }
-            }
-        },
-        "github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest": {
-            "type": "object",
-            "properties": {
-                "checksum": {
-                    "type": "string"
-                },
-                "command": {
-                    "type": "string"
-                },
-                "config": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "description": {
-                    "type": "string"
-                },
-                "hook_type": {
-                    "type": "string"
-                },
-                "hook_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "hook_types_customized": {
-                    "type": "boolean"
-                },
-                "is_active": {
-                    "type": "boolean"
-                },
-                "load_immediately": {
-                    "description": "Auto-load AI Studio plugins",
-                    "type": "boolean"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "namespace": {
-                    "type": "string"
-                },
-                "oci_reference": {
-                    "type": "string"
-                }
-            }
-        },
         "models.AppBudgetUsageResponse": {
             "type": "object",
             "properties": {
@@ -23469,6 +23338,105 @@
                     "type": "string"
                 },
                 "is_active": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "oci_reference": {
+                    "type": "string"
+                }
+            }
+        },
+        "services.CreatePluginRequest": {
+            "type": "object",
+            "required": [
+                "command",
+                "name"
+            ],
+            "properties": {
+                "checksum": {
+                    "description": "Optional",
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "hook_type": {
+                    "description": "Optional - will be populated from manifest",
+                    "type": "string"
+                },
+                "hook_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hook_types_customized": {
+                    "type": "boolean"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "load_immediately": {
+                    "description": "Auto-load AI Studio plugins",
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "namespace": {
+                    "type": "string"
+                },
+                "oci_reference": {
+                    "description": "OCI artifact reference",
+                    "type": "string"
+                }
+            }
+        },
+        "services.UpdatePluginRequest": {
+            "type": "object",
+            "properties": {
+                "checksum": {
+                    "type": "string"
+                },
+                "command": {
+                    "type": "string"
+                },
+                "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "description": {
+                    "type": "string"
+                },
+                "hook_type": {
+                    "type": "string"
+                },
+                "hook_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hook_types_customized": {
+                    "type": "boolean"
+                },
+                "is_active": {
+                    "type": "boolean"
+                },
+                "load_immediately": {
+                    "description": "Auto-load AI Studio plugins",
                     "type": "boolean"
                 },
                 "name": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2835,74 +2835,6 @@ definitions:
         description: filter_block, model_access, budget_exceeded, auth_failure
         type: string
     type: object
-  github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest:
-    properties:
-      checksum:
-        description: Optional
-        type: string
-      command:
-        type: string
-      config:
-        additionalProperties: true
-        type: object
-      description:
-        type: string
-      hook_type:
-        description: Optional - will be populated from manifest
-        type: string
-      hook_types:
-        items:
-          type: string
-        type: array
-      hook_types_customized:
-        type: boolean
-      is_active:
-        type: boolean
-      load_immediately:
-        description: Auto-load AI Studio plugins
-        type: boolean
-      name:
-        type: string
-      namespace:
-        type: string
-      oci_reference:
-        description: OCI artifact reference
-        type: string
-    required:
-    - command
-    - name
-    type: object
-  github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest:
-    properties:
-      checksum:
-        type: string
-      command:
-        type: string
-      config:
-        additionalProperties: true
-        type: object
-      description:
-        type: string
-      hook_type:
-        type: string
-      hook_types:
-        items:
-          type: string
-        type: array
-      hook_types_customized:
-        type: boolean
-      is_active:
-        type: boolean
-      load_immediately:
-        description: Auto-load AI Studio plugins
-        type: boolean
-      name:
-        type: string
-      namespace:
-        type: string
-      oci_reference:
-        type: string
-    type: object
   models.AppBudgetUsageResponse:
     properties:
       current_usage:
@@ -3192,6 +3124,74 @@ definitions:
     - hook_type
     - name
     - oci_reference
+    type: object
+  services.CreatePluginRequest:
+    properties:
+      checksum:
+        description: Optional
+        type: string
+      command:
+        type: string
+      config:
+        additionalProperties: true
+        type: object
+      description:
+        type: string
+      hook_type:
+        description: Optional - will be populated from manifest
+        type: string
+      hook_types:
+        items:
+          type: string
+        type: array
+      hook_types_customized:
+        type: boolean
+      is_active:
+        type: boolean
+      load_immediately:
+        description: Auto-load AI Studio plugins
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+      oci_reference:
+        description: OCI artifact reference
+        type: string
+    required:
+    - command
+    - name
+    type: object
+  services.UpdatePluginRequest:
+    properties:
+      checksum:
+        type: string
+      command:
+        type: string
+      config:
+        additionalProperties: true
+        type: object
+      description:
+        type: string
+      hook_type:
+        type: string
+      hook_types:
+        items:
+          type: string
+        type: array
+      hook_types_customized:
+        type: boolean
+      is_active:
+        type: boolean
+      load_immediately:
+        description: Auto-load AI Studio plugins
+        type: boolean
+      name:
+        type: string
+      namespace:
+        type: string
+      oci_reference:
+        type: string
     type: object
   sso.NonceTokenRequest:
     properties:
@@ -4368,7 +4368,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new catalogue
+      summary: Create a new catalogue (Community Edition)
       tags:
       - catalogues
   /api/v1/catalogues/{id}:
@@ -4576,7 +4576,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Search catalogues by name
+      summary: Search catalogues by name (Community Edition)
       tags:
       - catalogues
   /api/v1/data-catalogues:
@@ -4619,7 +4619,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new data catalogue
+      summary: Create a new data catalogue (Community Edition)
       tags:
       - data-catalogues
   /api/v1/data-catalogues/{id}:
@@ -4846,7 +4846,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Get data catalogues by datasource
+      summary: Get data catalogues by datasource (Community Edition)
       tags:
       - data-catalogues
   /api/v1/data-catalogues/by-tag/{tagName}:
@@ -4875,7 +4875,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Get data catalogues by tag
+      summary: Get data catalogues by tag (Community Edition)
       tags:
       - data-catalogues
   /api/v1/data-catalogues/search:
@@ -4897,7 +4897,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Search data catalogues
+      summary: Search data catalogues (Community Edition)
       tags:
       - data-catalogues
   /api/v1/edges:
@@ -5065,7 +5065,8 @@ paths:
         "200":
           description: OK
           schema:
-            items: {}
+            items:
+              type: object
             type: array
       security:
       - BearerAuth: []
@@ -5112,7 +5113,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new group
+      summary: Create a new group (Community Edition)
       tags:
       - groups
   /api/v1/groups/{id}:
@@ -5275,7 +5276,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update group catalogues
+      summary: Update group catalogues (Community Edition)
       tags:
       - groups
   /api/v1/groups/{id}/catalogues/{catalogueId}:
@@ -5562,7 +5563,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update group users
+      summary: Update group users (Community Edition)
       tags:
       - groups
   /api/v1/groups/{id}/users/{userId}:
@@ -5909,7 +5910,7 @@ paths:
         name: plugin
         required: true
         schema:
-          $ref: '#/definitions/github_com_TykTechnologies_midsommar_v2_services.CreatePluginRequest'
+          $ref: '#/definitions/services.CreatePluginRequest'
       produces:
       - application/json
       responses:
@@ -6008,7 +6009,7 @@ paths:
         name: plugin
         required: true
         schema:
-          $ref: '#/definitions/github_com_TykTechnologies_midsommar_v2_services.UpdatePluginRequest'
+          $ref: '#/definitions/services.UpdatePluginRequest'
       produces:
       - application/json
       responses:
@@ -7025,7 +7026,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new tool catalogue
+      summary: Create a new tool catalogue (Community Edition)
       tags:
       - tool-catalogues
   /api/v1/tool-catalogues/{catalogueId}/tools/{toolId}/apps:
@@ -7396,7 +7397,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Search tool catalogues
+      summary: Search tool catalogues (Community Edition)
       tags:
       - tool-catalogues
   /api/v1/users/{userId}/groups:
@@ -12461,16 +12462,9 @@ paths:
     patch:
       consumes:
       - application/json
-      - application/json
-      description: |-
-        Get a model price by its name, creating it with default values if it doesn't exist
-        Update an existing model price's information and recalculate all historical chat record costs
+      description: Update an existing model price's information and recalculate all
+        historical chat record costs
       parameters:
-      - description: Model name
-        in: query
-        name: model_name
-        required: true
-        type: string
       - description: Model Price ID
         in: path
         name: id
@@ -12484,7 +12478,6 @@ paths:
           $ref: '#/definitions/api.ModelPriceInput'
       produces:
       - application/json
-      - application/json
       responses:
         "200":
           description: OK
@@ -12500,53 +12493,36 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      - BearerAuth: []
       summary: Update a model price and recalculate historical costs
       tags:
-      - model-prices
       - model-prices
   /model-prices/by-name:
     get:
       consumes:
       - application/json
-      - application/json
-      description: |-
-        Get a model price by its name, creating it with default values if it doesn't exist
-        Update an existing model price's information and recalculate all historical chat record costs
+      description: Get a model price by its name, creating it with default values
+        if it doesn't exist
       parameters:
       - description: Model name
         in: query
         name: model_name
         required: true
         type: string
-      - description: Updated model price information
-        in: body
-        name: modelPrice
-        required: true
-        schema:
-          $ref: '#/definitions/api.ModelPriceInput'
       produces:
-      - application/json
       - application/json
       responses:
         "200":
           description: OK
           schema:
             $ref: '#/definitions/api.ModelPriceResponse'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/api.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      - BearerAuth: []
-      summary: Update a model price and recalculate historical costs
+      summary: Get or create a model price by name
       tags:
-      - model-prices
       - model-prices
   /model-prices/by-vendor:
     get:


### PR DESCRIPTION
## Summary

tyk-docs added a per-spec Mintlify directory split to stop cross-spec collisions (different specs sharing a generated page), which surfaced 12 within-spec duplicate tag+summary slugs in this spec specifically - two operations sharing the exact same generated page URL, so one silently overwrites the other's docs page (Mintlify's URL scheme is `<tag>/<summary>`, slugified).

## Root causes

**11 of these** are Community Edition stub endpoints (all in `*_handlers_community.go` files, build-tagged `!enterprise`, always return `402 Payment Required`) that happen to share their exact summary text with the real Enterprise Edition operation registered at a different path. Since `swag` scans all Go files regardless of build tags, both end up in the same generated spec even though they never coexist in a running binary. Appended `(Community Edition)` to the CE side of each pair so they render as distinct docs pages:

- catalogues: `Create a new catalogue`, `Search catalogues by name`
- data-catalogues: `Create a new data catalogue`, `Search data catalogues`, `Get data catalogues by tag`, `Get data catalogues by datasource`
- groups: `Create a new group`, `Update group users`, `Update group catalogues`
- tool-catalogues: `Create a new tool catalogue`, `Search tool catalogues`

**The 12th is a real bug** in `prices_handlers.go`: the swag annotation block for `getOrCreateModelPriceByName` (`GET /model-prices/by-name`) was physically misplaced immediately above `updateModelPriceAndRecalculate`'s own annotations instead of preceding its own function (which had no annotation block at all). Both operations ended up documented as "Update a model price and recalculate historical costs". Moved the block to precede the correct function - `getOrCreateModelPriceByName` now correctly reports as "Get or create a model price by name".

## Regeneration

Ran `swag init -g api/api.go -o docs/swagger` (same process as #342). The diff includes some unrelated `definitions:` block reordering - confirmed this is inherent to `swag`, not caused by this change, by regenerating again from the *unmodified* source and seeing the same kind of reordering with zero semantic difference.

## Test plan

- [x] `gofmt -l` on all changed Go files - no output, valid syntax
- [x] `swag init` completes without new errors (pre-existing unrelated warning about `/common/tool-catalogues/{id}/tools` untouched)
- [x] Verified 0 remaining tag+summary collisions in the regenerated `swagger.yaml` (was 12)
- [ ] CI / swagger lint on this PR