### PR TITLE
TAS-32: Anthropic Bedrock Bridge

### DIFF
--- a/microgateway/internal/api/gateway_routes_test.go
+++ b/microgateway/internal/api/gateway_routes_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// mountGatewayRoutes mirrors the `if config.Gateway != nil` block in SetupRouter so the
+// gateway route table can be exercised without building the full router/config (same
+// approach as registerTestMetricsRoute in metrics_endpoint_test.go). Keep in sync with
+// SetupRouter.
+func mountGatewayRoutes(router *gin.Engine, h http.Handler) {
+	gateway := router.Group("/")
+	gateway.Any("/llm/*path", gin.WrapH(h))
+	gateway.Any("/tools/*path", gin.WrapH(h))
+	gateway.Any("/datasource/*path", gin.WrapH(h))
+	gateway.Any("/ai/*path", gin.WrapH(h))
+	gateway.Any("/anthropic/*path", gin.WrapH(h))
+}
+
+// TestGatewayRoutes_ForwardAnthropicBridge verifies the microgateway forwards the
+// Anthropic Messages bridge path prefix to the gateway handler (which owns routing,
+// auth, and translation), alongside the existing /ai and /llm prefixes.
+func TestGatewayRoutes_ForwardAnthropicBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var gotPath string
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	router := gin.New()
+	mountGatewayRoutes(router, stub)
+
+	cases := []struct {
+		name        string
+		path        string
+		wantStatus  int
+		wantForward bool
+	}{
+		{"anthropic bridge", "/anthropic/aws-bedrock/v1/messages", http.StatusOK, true},
+		{"openai-compatible", "/ai/aws-bedrock/v1/chat/completions", http.StatusOK, true},
+		{"llm passthrough", "/llm/call/aws-bedrock/v1/messages", http.StatusOK, true},
+		{"unmounted path", "/nope/x", http.StatusNotFound, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath = ""
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, tc.path, nil))
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantForward && gotPath != tc.path {
+				t.Errorf("expected forward to handler with path %q, got %q", tc.path, gotPath)
+			}
+			if !tc.wantForward && gotPath != "" {
+				t.Errorf("did not expect forward, but handler saw %q", gotPath)
+			}
+		})
+	}
+}

--- a/microgateway/internal/api/router.go
+++ b/microgateway/internal/api/router.go
@@ -282,6 +282,10 @@ func SetupRouter(config *RouterConfig) *gin.Engine {
 		gateway.Any("/tools/*path", gin.WrapH(config.Gateway.Handler()))
 		gateway.Any("/datasource/*path", gin.WrapH(config.Gateway.Handler()))
 		gateway.Any("/ai/*path", gin.WrapH(config.Gateway.Handler()))
+		// Anthropic Messages -> Bedrock bridge (Claude Code). Routing + auth + translation
+		// all live inside the gateway handler (proxy.createHandler); the data plane just
+		// needs to forward this path prefix, same as /ai/.
+		gateway.Any("/anthropic/*path", gin.WrapH(config.Gateway.Handler()))
 
 		// Model Router endpoints (Enterprise)
 		// Routes requests to LLM vendors based on model name patterns

--- a/proxy/anthropic_bedrock_auth_test.go
+++ b/proxy/anthropic_bedrock_auth_test.go
@@ -1,0 +1,103 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gosimple/slug"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/services"
+	"github.com/TykTechnologies/midsommar/v2/services/budget"
+)
+
+// TestAnthropicBridgeAuth exercises the credential-validator wiring for the
+// /anthropic/{routeId}/v1/messages route end to end (through createHandler), covering
+// both the x-api-key and Authorization: Bearer app-secret paths.
+//
+// The Bedrock LLM is configured with no default_model on purpose: a successfully
+// authenticated request stops at model resolution (HTTP 400) *before* any AWS call,
+// so authentication can be asserted in isolation without a live Bedrock backend.
+func TestAnthropicBridgeAuth(t *testing.T) {
+	db, cancel := setupTest(t)
+	defer tearDownTest(db, cancel)
+
+	service := services.NewService(db)
+	notificationSvc := services.NewTestNotificationService(db)
+	budgetService := budget.NewService(db, notificationSvc)
+	p := NewProxy(service, &Config{Port: 9999}, budgetService)
+	require.NotNil(t, p)
+
+	llm := &models.LLM{
+		Name:        "AWS Bedrock",
+		Vendor:      models.BEDROCK,
+		Active:      true,
+		APIEndpoint: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		// DefaultModel intentionally empty (see doc comment).
+	}
+	require.NoError(t, db.Create(llm).Error)
+
+	user := &models.User{Email: "test@example.com"}
+	require.NoError(t, db.Create(user).Error)
+
+	app := &models.App{Name: "TestApp", UserID: user.ID}
+	require.NoError(t, db.Create(app).Error)
+
+	cred := &models.Credential{Secret: "valid-secret", Active: true}
+	require.NoError(t, db.Create(cred).Error)
+	app.CredentialID = cred.ID
+	require.NoError(t, db.Save(app).Error)
+	require.NoError(t, app.AddLLM(db, llm))
+
+	require.NoError(t, p.loadResources())
+
+	srv := httptest.NewServer(p.createHandler())
+	defer srv.Close()
+
+	url := srv.URL + "/anthropic/" + slug.Make(llm.Name) + "/v1/messages"
+	body := `{"model":"claude","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`
+
+	do := func(t *testing.T, setAuth func(*http.Request)) *http.Response {
+		t.Helper()
+		req, err := http.NewRequest("POST", url, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		setAuth(req)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	// Valid credentials must pass auth and reach model resolution (400), never an auth
+	// rejection (401/403).
+	t.Run("valid x-api-key authenticates", func(t *testing.T) {
+		resp := do(t, func(r *http.Request) { r.Header.Set("x-api-key", "valid-secret") })
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "should pass auth and stop at model resolution")
+		b, _ := io.ReadAll(resp.Body)
+		assert.Contains(t, string(b), "default_model")
+	})
+
+	t.Run("valid Bearer token authenticates", func(t *testing.T) {
+		resp := do(t, func(r *http.Request) { r.Header.Set("Authorization", "Bearer valid-secret") })
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "should pass auth and stop at model resolution")
+	})
+
+	t.Run("invalid x-api-key is rejected", func(t *testing.T) {
+		resp := do(t, func(r *http.Request) { r.Header.Set("x-api-key", "wrong-secret") })
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("missing credentials is rejected", func(t *testing.T) {
+		resp := do(t, func(r *http.Request) {})
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}

--- a/proxy/anthropic_bedrock_handler_test.go
+++ b/proxy/anthropic_bedrock_handler_test.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+)
+
+// anthropicErrorType decodes an Anthropic-format error body and returns error.type,
+// asserting the envelope is a well-formed error.
+func anthropicErrorType(t *testing.T, body []byte) string {
+	t.Helper()
+	var parsed struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	assert.Equal(t, "error", parsed.Type)
+	return parsed.Error.Type
+}
+
+// TestHandleAnthropicMessagesEntry_ErrorBranches covers the entry handler's early
+// rejections, which return before any auth/AWS involvement.
+func TestHandleAnthropicMessagesEntry_ErrorBranches(t *testing.T) {
+	bedrockLLM := &models.LLM{Name: "bedrock", Vendor: models.BEDROCK, DefaultModel: "anthropic.claude-3-haiku-20240307-v1:0"}
+	openaiLLM := &models.LLM{Name: "openai", Vendor: models.OPENAI}
+
+	validBody := `{"model":"claude","max_tokens":10,"messages":[{"role":"user","content":"hi"}]}`
+
+	tests := []struct {
+		name        string
+		llms        map[string]*models.LLM
+		routeID     string
+		body        string
+		wantStatus  int
+		wantErrType string
+	}{
+		{"route not found", map[string]*models.LLM{}, "missing", validBody, 404, "not_found_error"},
+		{"non-bedrock vendor rejected", map[string]*models.LLM{"openai": openaiLLM}, "openai", validBody, 400, "invalid_request_error"},
+		{"invalid json body", map[string]*models.LLM{"bedrock": bedrockLLM}, "bedrock", "{not json", 400, "invalid_request_error"},
+		{"empty messages", map[string]*models.LLM{"bedrock": bedrockLLM}, "bedrock", `{"model":"claude","max_tokens":10,"messages":[]}`, 400, "invalid_request_error"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Proxy{llms: tc.llms}
+			r := httptest.NewRequest("POST", "/anthropic/"+tc.routeID+"/v1/messages", strings.NewReader(tc.body))
+			r = mux.SetURLVars(r, map[string]string{"routeId": tc.routeID})
+			w := httptest.NewRecorder()
+
+			p.handleAnthropicMessagesEntry(w, r)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+			assert.Equal(t, tc.wantErrType, anthropicErrorType(t, w.Body.Bytes()))
+		})
+	}
+}
+
+// TestResolveAnthropicModelID covers model governance: the bridge uses the configured
+// default_model (Claude Code's own model name is not a Bedrock ID) and validates it
+// against allowed_models.
+func TestResolveAnthropicModelID(t *testing.T) {
+	p := &Proxy{}
+
+	t.Run("missing default_model -> 400", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		model, ok := p.resolveAnthropicModelID(w, &models.LLM{})
+		assert.False(t, ok)
+		assert.Empty(t, model)
+		assert.Equal(t, 400, w.Code)
+		assert.Equal(t, "invalid_request_error", anthropicErrorType(t, w.Body.Bytes()))
+	})
+
+	t.Run("default_model not in allowed_models -> 403", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		conf := &models.LLM{
+			DefaultModel:  "anthropic.claude-3-haiku-20240307-v1:0",
+			AllowedModels: []string{`^cohere\.`},
+		}
+		model, ok := p.resolveAnthropicModelID(w, conf)
+		assert.False(t, ok)
+		assert.Empty(t, model)
+		assert.Equal(t, 403, w.Code)
+		assert.Equal(t, "permission_error", anthropicErrorType(t, w.Body.Bytes()))
+	})
+
+	t.Run("allowed (empty list) -> ok, nothing written", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		conf := &models.LLM{DefaultModel: "anthropic.claude-3-haiku-20240307-v1:0"}
+		model, ok := p.resolveAnthropicModelID(w, conf)
+		assert.True(t, ok)
+		assert.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", model)
+		assert.Equal(t, 200, w.Code) // default: handler wrote nothing
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("allowed (matching pattern) -> ok", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		conf := &models.LLM{
+			DefaultModel:  "anthropic.claude-3-haiku-20240307-v1:0",
+			AllowedModels: []string{`^anthropic\.`},
+		}
+		model, ok := p.resolveAnthropicModelID(w, conf)
+		assert.True(t, ok)
+		assert.Equal(t, "anthropic.claude-3-haiku-20240307-v1:0", model)
+	})
+}

--- a/proxy/anthropic_bedrock_helpers_test.go
+++ b/proxy/anthropic_bedrock_helpers_test.go
@@ -13,13 +13,18 @@ import (
 )
 
 // makeConverseOutput builds a Converse response for response-mapping tests.
-func makeConverseOutput(blocks []types.ContentBlock, stop types.StopReason, in, out int32) *bedrockruntime.ConverseOutput {
+func makeConverseOutput(blocks []types.ContentBlock, stop types.StopReason, in, out, cacheWrite, cacheRead int32) *bedrockruntime.ConverseOutput {
 	return &bedrockruntime.ConverseOutput{
 		Output: &types.ConverseOutputMemberMessage{
 			Value: types.Message{Role: types.ConversationRoleAssistant, Content: blocks},
 		},
 		StopReason: stop,
-		Usage:      &types.TokenUsage{InputTokens: aws.Int32(in), OutputTokens: aws.Int32(out)},
+		Usage: &types.TokenUsage{
+			InputTokens:           aws.Int32(in),
+			OutputTokens:          aws.Int32(out),
+			CacheWriteInputTokens: aws.Int32(cacheWrite),
+			CacheReadInputTokens:  aws.Int32(cacheRead),
+		},
 	}
 }
 

--- a/proxy/anthropic_bedrock_helpers_test.go
+++ b/proxy/anthropic_bedrock_helpers_test.go
@@ -1,0 +1,89 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+// makeConverseOutput builds a Converse response for response-mapping tests.
+func makeConverseOutput(blocks []types.ContentBlock, stop types.StopReason, in, out int32) *bedrockruntime.ConverseOutput {
+	return &bedrockruntime.ConverseOutput{
+		Output: &types.ConverseOutputMemberMessage{
+			Value: types.Message{Role: types.ConversationRoleAssistant, Content: blocks},
+		},
+		StopReason: stop,
+		Usage:      &types.TokenUsage{InputTokens: aws.Int32(in), OutputTokens: aws.Int32(out)},
+	}
+}
+
+func lazyDoc(m map[string]any) document.Interface {
+	return document.NewLazyDocument(m)
+}
+
+// sseRecorder is an http.ResponseWriter + Flusher that captures SSE output so tests
+// can assert the exact event sequence and payloads.
+type sseRecorder struct {
+	header http.Header
+	buf    bytes.Buffer
+	status int
+}
+
+func newSSERecorder() *sseRecorder {
+	return &sseRecorder{header: http.Header{}}
+}
+
+func (r *sseRecorder) Header() http.Header         { return r.header }
+func (r *sseRecorder) Write(b []byte) (int, error) { return r.buf.Write(b) }
+func (r *sseRecorder) WriteHeader(status int)      { r.status = status }
+func (r *sseRecorder) Flush()                      {}
+
+type sseFrame struct {
+	event string
+	data  map[string]any
+}
+
+// frames parses the recorded "event: X\ndata: {json}\n\n" stream.
+func (r *sseRecorder) frames() []sseFrame {
+	var frames []sseFrame
+	for _, chunk := range strings.Split(r.buf.String(), "\n\n") {
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		var f sseFrame
+		for _, line := range strings.Split(chunk, "\n") {
+			if strings.HasPrefix(line, "event: ") {
+				f.event = strings.TrimPrefix(line, "event: ")
+			} else if strings.HasPrefix(line, "data: ") {
+				_ = json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &f.data)
+			}
+		}
+		frames = append(frames, f)
+	}
+	return frames
+}
+
+func (r *sseRecorder) eventTypes() []string {
+	var out []string
+	for _, f := range r.frames() {
+		out = append(out, f.event)
+	}
+	return out
+}
+
+func (r *sseRecorder) dataFor(event string) []map[string]any {
+	var out []map[string]any
+	for _, f := range r.frames() {
+		if f.event == event {
+			out = append(out, f.data)
+		}
+	}
+	return out
+}

--- a/proxy/anthropic_bedrock_translator.go
+++ b/proxy/anthropic_bedrock_translator.go
@@ -101,6 +101,8 @@ func (p *Proxy) handleBedrockAnthropicMessages(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// NewBedrockClient returns a cached *bedrockruntime.Client (sync.Map keyed by LLM ID
+	// + credential fingerprint) — it is not constructed per request.
 	client, err := bedrockVendor.NewBedrockClient(conf)
 	if err != nil {
 		respondWithAnthropicError(w, http.StatusInternalServerError, "api_error", "failed to create Bedrock client")
@@ -179,6 +181,8 @@ func (p *Proxy) handleBedrockAnthropicMessagesStream(w http.ResponseWriter, r *h
 		return
 	}
 
+	// NewBedrockClient returns a cached *bedrockruntime.Client (sync.Map keyed by LLM ID
+	// + credential fingerprint) — it is not constructed per request.
 	client, err := bedrockVendor.NewBedrockClient(conf)
 	if err != nil {
 		writeAnthropicSSEError(w, flusher, "api_error", "failed to create Bedrock client")

--- a/proxy/anthropic_bedrock_translator.go
+++ b/proxy/anthropic_bedrock_translator.go
@@ -1,0 +1,596 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/TykTechnologies/midsommar/v2/helpers"
+	"github.com/TykTechnologies/midsommar/v2/models"
+	bedrockVendor "github.com/TykTechnologies/midsommar/v2/vendors/bedrock"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+)
+
+// handleAnthropicMessagesEntry is the entry point for POST /anthropic/{routeId}/v1/messages.
+// It lets Claude Code (which speaks the native Anthropic Messages API) drive Claude models
+// hosted in Amazon Bedrock, with AI Studio applying auth, budget, filters, and analytics.
+// Auth runs in the credential-validator middleware before this handler (mirroring /ai/).
+func (p *Proxy) handleAnthropicMessagesEntry(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	routeID := vars["routeId"]
+
+	conf, ok := p.llms[routeID]
+	if !ok {
+		respondWithAnthropicError(w, http.StatusNotFound, "not_found_error", "route not found")
+		return
+	}
+
+	// The bridge only translates for Bedrock-backed LLMs. Other vendors already speak
+	// their native API via the /llm/ pass-through.
+	if conf.Vendor != models.BEDROCK {
+		respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error",
+			fmt.Sprintf("the Anthropic Messages bridge only supports Bedrock LLMs, not %q", conf.Vendor))
+		return
+	}
+
+	reqBody, err := helpers.CopyRequestBody(r)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusInternalServerError, "api_error", "failed to read request body")
+		return
+	}
+
+	var req AnthropicMessagesRequest
+	if err := json.Unmarshal(reqBody, &req); err != nil {
+		respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "invalid request body")
+		return
+	}
+	if len(req.Messages) == 0 {
+		respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error", "messages is required")
+		return
+	}
+
+	if req.Stream {
+		p.handleBedrockAnthropicMessagesStream(w, r, conf, &req, reqBody)
+	} else {
+		p.handleBedrockAnthropicMessages(w, r, conf, &req, reqBody)
+	}
+}
+
+// resolveAnthropicModelID returns the Bedrock model ID to call. Claude Code sends its own
+// model names (e.g. "claude-sonnet-4-..."), which are not Bedrock IDs, so the configured
+// default_model is the source of truth. Governance is applied by validating that configured
+// model against the LLM's allowed_models.
+func (p *Proxy) resolveAnthropicModelID(w http.ResponseWriter, conf *models.LLM) (string, bool) {
+	modelID := bedrockVendor.GetModelID(conf, "")
+	if modelID == "" {
+		respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error",
+			"this Bedrock LLM has no default_model configured")
+		return "", false
+	}
+	if !NewModelValidator(conf.AllowedModels).IsModelAllowed(modelID) {
+		respondWithAnthropicError(w, http.StatusForbidden, "permission_error",
+			fmt.Sprintf("model %q is not allowed", modelID))
+		return "", false
+	}
+	return modelID, true
+}
+
+// handleBedrockAnthropicMessages handles a non-streaming /v1/messages request.
+func (p *Proxy) handleBedrockAnthropicMessages(w http.ResponseWriter, r *http.Request, conf *models.LLM, req *AnthropicMessagesRequest, reqBody []byte) {
+	timestamp := time.Now()
+
+	app, err := p.getAppFromContext(r, conf)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusUnauthorized, "authentication_error", "authentication required")
+		return
+	}
+
+	if _, _, err := p.budgetService.CheckBudget(app, conf); err != nil {
+		respondWithAnthropicError(w, http.StatusForbidden, "permission_error", fmt.Sprintf("budget exceeded: %s", err.Error()))
+		return
+	}
+
+	modelID, ok := p.resolveAnthropicModelID(w, conf)
+	if !ok {
+		return
+	}
+
+	client, err := bedrockVendor.NewBedrockClient(conf)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusInternalServerError, "api_error", "failed to create Bedrock client")
+		return
+	}
+
+	input, err := p.buildConverseInputFromAnthropic(modelID, req)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	output, err := client.Converse(r.Context(), input)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusBadGateway, "api_error", fmt.Sprintf("Bedrock Converse failed: %s", err.Error()))
+		return
+	}
+
+	response := converseOutputToAnthropicResponse(output, echoModel(req.Model, modelID))
+	respBody, err := json.Marshal(response)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusInternalServerError, "api_error", "failed to marshal response")
+		return
+	}
+
+	// Response filters (non-streaming)
+	if p.hasResponseFilters(conf) {
+		blocked, blockMsg, filterErr := ExecuteResponseFilters(
+			conf, p.gatewayService, respBody, http.StatusOK, false, false, 0, "", r,
+		)
+		if filterErr != nil {
+			log.Error().Err(filterErr).Msg("Response filter error on Bedrock Anthropic response")
+		} else if blocked {
+			respondWithAnthropicError(w, http.StatusBadRequest, "invalid_request_error", fmt.Sprintf("Response blocked by filter: %s", blockMsg))
+			go recordBedrockAnalytics(p, conf, app, modelID, output, reqBody, []byte(blockMsg), r, timestamp)
+			return
+		}
+	}
+
+	go recordBedrockAnalytics(p, conf, app, modelID, output, reqBody, respBody, r, timestamp)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(respBody)
+}
+
+// handleBedrockAnthropicMessagesStream handles a streaming /v1/messages request, translating
+// the Bedrock Converse event stream into the Anthropic Messages SSE event sequence.
+func (p *Proxy) handleBedrockAnthropicMessagesStream(w http.ResponseWriter, r *http.Request, conf *models.LLM, req *AnthropicMessagesRequest, reqBody []byte) {
+	timestamp := time.Now()
+
+	app, err := p.getAppFromContext(r, conf)
+	if err != nil {
+		respondWithAnthropicError(w, http.StatusUnauthorized, "authentication_error", "authentication required")
+		return
+	}
+
+	if _, _, err := p.budgetService.CheckBudget(app, conf); err != nil {
+		respondWithAnthropicError(w, http.StatusForbidden, "permission_error", fmt.Sprintf("budget exceeded: %s", err.Error()))
+		return
+	}
+
+	modelID, ok := p.resolveAnthropicModelID(w, conf)
+	if !ok {
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		respondWithAnthropicError(w, http.StatusInternalServerError, "api_error", "streaming not supported")
+		return
+	}
+
+	client, err := bedrockVendor.NewBedrockClient(conf)
+	if err != nil {
+		writeAnthropicSSEError(w, flusher, "api_error", "failed to create Bedrock client")
+		return
+	}
+
+	streamInput, err := p.buildConverseInputFromAnthropic(modelID, req)
+	if err != nil {
+		writeAnthropicSSEError(w, flusher, "invalid_request_error", err.Error())
+		return
+	}
+
+	output, err := client.ConverseStream(r.Context(), &bedrockruntime.ConverseStreamInput{
+		ModelId:         streamInput.ModelId,
+		Messages:        streamInput.Messages,
+		System:          streamInput.System,
+		InferenceConfig: streamInput.InferenceConfig,
+		ToolConfig:      streamInput.ToolConfig,
+	})
+	if err != nil {
+		writeAnthropicSSEError(w, flusher, "api_error", fmt.Sprintf("Bedrock ConverseStream failed: %s", err.Error()))
+		return
+	}
+
+	stream := output.GetStream()
+	if stream == nil {
+		writeAnthropicSSEError(w, flusher, "api_error", "Bedrock returned no stream")
+		return
+	}
+	defer stream.Close()
+
+	st := &anthropicStreamState{
+		w:          w,
+		flusher:    flusher,
+		msgID:      "msg_" + uuid.New().String(),
+		echoModel:  echoModel(req.Model, modelID),
+		started:    map[int32]bool{},
+		stopped:    map[int32]bool{},
+		hasFilters: p.hasResponseFilters(conf),
+		proxy:      p,
+		conf:       conf,
+		request:    r,
+	}
+
+	for event := range stream.Events() {
+		if err := stream.Err(); err != nil {
+			log.Error().Err(err).Msg("Bedrock Anthropic stream error")
+			break
+		}
+		if blocked := st.handleEvent(event); blocked {
+			return // filter blocked and already emitted an error event
+		}
+	}
+
+	st.finish()
+
+	// Record analytics after the stream completes (ProxyLog first so ChatRecord can enrich it).
+	responseText := st.textBuffer
+	inputTokens, outputTokens := st.inputTokens, st.outputTokens
+	go func() {
+		recordBedrockProxyLog(p, conf, app, modelID, reqBody, responseText, r, timestamp)
+		recordBedrockChatRecord(p, conf, app, modelID, int(inputTokens), int(outputTokens), r, timestamp)
+	}()
+}
+
+// buildConverseInputFromAnthropic maps an Anthropic Messages request to a Bedrock Converse input.
+func (p *Proxy) buildConverseInputFromAnthropic(modelID string, req *AnthropicMessagesRequest) (*bedrockruntime.ConverseInput, error) {
+	msgs, system, err := anthropicMessagesToVendor(req)
+	if err != nil {
+		return nil, err
+	}
+
+	converseMsgs, systemBlocks := bedrockVendor.AnthropicMessagesToConverse(msgs, system)
+
+	var maxTokens *int
+	if req.MaxTokens > 0 {
+		mt := req.MaxTokens
+		maxTokens = &mt
+	}
+	var stop any
+	if len(req.StopSequences) > 0 {
+		stop = req.StopSequences
+	}
+	inferenceConfig := bedrockVendor.BuildInferenceConfig(maxTokens, req.Temperature, req.TopP, stop)
+
+	toolConfig := bedrockVendor.AnthropicToolsToToolConfig(anthropicToolsToVendor(req.Tools), anthropicToolChoiceToVendor(req.ToolChoice))
+
+	return &bedrockruntime.ConverseInput{
+		ModelId:         aws.String(modelID),
+		Messages:        converseMsgs,
+		System:          systemBlocks,
+		InferenceConfig: inferenceConfig,
+		ToolConfig:      toolConfig,
+	}, nil
+}
+
+// --- wire -> vendor mapping helpers ---
+
+func anthropicMessagesToVendor(req *AnthropicMessagesRequest) ([]bedrockVendor.AnthropicMsg, []bedrockVendor.AnthropicSystemBlock, error) {
+	msgs := make([]bedrockVendor.AnthropicMsg, 0, len(req.Messages))
+	for _, m := range req.Messages {
+		blocks, err := parseAnthropicBlocks(m.Content)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid message content: %w", err)
+		}
+		vBlocks := make([]bedrockVendor.AnthropicBlock, 0, len(blocks))
+		for _, b := range blocks {
+			vb := bedrockVendor.AnthropicBlock{
+				Type:       b.Type,
+				Text:       b.Text,
+				CachePoint: b.CacheControl != nil,
+			}
+			switch b.Type {
+			case "tool_use":
+				vb.ToolUseID = b.ID
+				vb.Name = b.Name
+				if len(b.Input) > 0 {
+					_ = json.Unmarshal(b.Input, &vb.Input)
+				}
+			case "tool_result":
+				vb.ToolUseID = b.ToolUseID
+				vb.ResultText = anthropicContentToText(b.Content)
+				vb.IsError = b.IsError
+			}
+			vBlocks = append(vBlocks, vb)
+		}
+		msgs = append(msgs, bedrockVendor.AnthropicMsg{Role: m.Role, Blocks: vBlocks})
+	}
+
+	systemBlocks, err := parseAnthropicBlocks(req.System)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid system prompt: %w", err)
+	}
+	system := make([]bedrockVendor.AnthropicSystemBlock, 0, len(systemBlocks))
+	for _, b := range systemBlocks {
+		system = append(system, bedrockVendor.AnthropicSystemBlock{
+			Text:       b.Text,
+			CachePoint: b.CacheControl != nil,
+		})
+	}
+
+	return msgs, system, nil
+}
+
+func anthropicToolsToVendor(tools []AnthropicTool) []bedrockVendor.AnthropicToolSpec {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]bedrockVendor.AnthropicToolSpec, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, bedrockVendor.AnthropicToolSpec{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: t.InputSchema,
+			CachePoint:  t.CacheControl != nil,
+		})
+	}
+	return out
+}
+
+func anthropicToolChoiceToVendor(tc *AnthropicToolChoice) *bedrockVendor.AnthropicToolChoiceSpec {
+	if tc == nil {
+		return nil
+	}
+	return &bedrockVendor.AnthropicToolChoiceSpec{Type: tc.Type, Name: tc.Name}
+}
+
+// --- response mapping ---
+
+func converseOutputToAnthropicResponse(output *bedrockruntime.ConverseOutput, model string) *AnthropicMessagesResponse {
+	resp := &AnthropicMessagesResponse{
+		ID:      "msg_" + uuid.New().String(),
+		Type:    "message",
+		Role:    "assistant",
+		Model:   model,
+		Content: []AnthropicResponseBlock{},
+	}
+
+	for _, b := range bedrockVendor.ConverseOutputToAnthropicBlocks(output) {
+		block := AnthropicResponseBlock{Type: b.Type, Text: b.Text, ID: b.ID, Name: b.Name}
+		if b.Type == "tool_use" {
+			if raw, err := json.Marshal(b.Input); err == nil {
+				block.Input = raw
+			}
+		}
+		resp.Content = append(resp.Content, block)
+	}
+
+	if output != nil {
+		resp.StopReason = bedrockVendor.ConvertConverseStopReasonAnthropic(output.StopReason)
+		if output.Usage != nil {
+			resp.Usage = AnthropicUsage{
+				InputTokens:  int(aws.ToInt32(output.Usage.InputTokens)),
+				OutputTokens: int(aws.ToInt32(output.Usage.OutputTokens)),
+			}
+		}
+	}
+
+	return resp
+}
+
+// echoModel returns the model name to echo back to the client: the client's requested model
+// when present (Claude Code expects its own name), otherwise the Bedrock model ID.
+func echoModel(requested, fallback string) string {
+	if requested != "" {
+		return requested
+	}
+	return fallback
+}
+
+// --- SSE helpers ---
+
+func writeAnthropicSSE(w http.ResponseWriter, flusher http.Flusher, event string, payload any) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, b)
+	flusher.Flush()
+}
+
+func writeAnthropicSSEError(w http.ResponseWriter, flusher http.Flusher, errType, message string) {
+	writeAnthropicSSE(w, flusher, "error", map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+func respondWithAnthropicError(w http.ResponseWriter, status int, errType, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]any{
+		"type": "error",
+		"error": map[string]any{
+			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+// --- streaming state machine ---
+
+// anthropicStreamState translates a Bedrock Converse event stream into Anthropic SSE events.
+type anthropicStreamState struct {
+	w         http.ResponseWriter
+	flusher   http.Flusher
+	msgID     string
+	echoModel string
+
+	sentStart    bool
+	started      map[int32]bool // content_block_start emitted for index
+	stopped      map[int32]bool // content_block_stop emitted for index
+	stopReason   string
+	inputTokens  int32
+	outputTokens int32
+	textBuffer   string
+
+	// filters
+	hasFilters bool
+	chunkIndex int
+	proxy      *Proxy
+	conf       *models.LLM
+	request    *http.Request
+}
+
+func (s *anthropicStreamState) ensureMessageStart() {
+	if s.sentStart {
+		return
+	}
+	s.sentStart = true
+	writeAnthropicSSE(s.w, s.flusher, "message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id":            s.msgID,
+			"type":          "message",
+			"role":          "assistant",
+			"model":         s.echoModel,
+			"content":       []any{},
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage":         map[string]any{"input_tokens": 0, "output_tokens": 0},
+		},
+	})
+	writeAnthropicSSE(s.w, s.flusher, "ping", map[string]any{"type": "ping"})
+}
+
+func (s *anthropicStreamState) ensureBlockStart(idx int32, isTool bool, toolID, toolName string) {
+	if s.started[idx] {
+		return
+	}
+	s.started[idx] = true
+	var cb map[string]any
+	if isTool {
+		cb = map[string]any{"type": "tool_use", "id": toolID, "name": toolName, "input": map[string]any{}}
+	} else {
+		cb = map[string]any{"type": "text", "text": ""}
+	}
+	writeAnthropicSSE(s.w, s.flusher, "content_block_start", map[string]any{
+		"type":          "content_block_start",
+		"index":         idx,
+		"content_block": cb,
+	})
+}
+
+// handleEvent processes a single Converse stream event. It returns true if a response filter
+// blocked the stream (an error event was already emitted and the stream should end).
+func (s *anthropicStreamState) handleEvent(event types.ConverseStreamOutput) bool {
+	switch v := event.(type) {
+	case *types.ConverseStreamOutputMemberMessageStart:
+		s.ensureMessageStart()
+
+	case *types.ConverseStreamOutputMemberContentBlockStart:
+		s.ensureMessageStart()
+		idx := aws.ToInt32(v.Value.ContentBlockIndex)
+		if tu, ok := v.Value.Start.(*types.ContentBlockStartMemberToolUse); ok {
+			s.ensureBlockStart(idx, true, aws.ToString(tu.Value.ToolUseId), aws.ToString(tu.Value.Name))
+		} else {
+			s.ensureBlockStart(idx, false, "", "")
+		}
+
+	case *types.ConverseStreamOutputMemberContentBlockDelta:
+		s.ensureMessageStart()
+		idx := aws.ToInt32(v.Value.ContentBlockIndex)
+		switch d := v.Value.Delta.(type) {
+		case *types.ContentBlockDeltaMemberText:
+			s.ensureBlockStart(idx, false, "", "")
+			s.textBuffer += d.Value
+			if s.hasFilters && s.runTextFilter(d.Value) {
+				return true
+			}
+			writeAnthropicSSE(s.w, s.flusher, "content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": idx,
+				"delta": map[string]any{"type": "text_delta", "text": d.Value},
+			})
+		case *types.ContentBlockDeltaMemberToolUse:
+			s.ensureBlockStart(idx, true, "", "")
+			writeAnthropicSSE(s.w, s.flusher, "content_block_delta", map[string]any{
+				"type":  "content_block_delta",
+				"index": idx,
+				"delta": map[string]any{"type": "input_json_delta", "partial_json": aws.ToString(d.Value.Input)},
+			})
+		}
+
+	case *types.ConverseStreamOutputMemberContentBlockStop:
+		idx := aws.ToInt32(v.Value.ContentBlockIndex)
+		s.emitBlockStop(idx)
+
+	case *types.ConverseStreamOutputMemberMessageStop:
+		s.stopReason = bedrockVendor.ConvertConverseStopReasonAnthropic(v.Value.StopReason)
+
+	case *types.ConverseStreamOutputMemberMetadata:
+		if v.Value.Usage != nil {
+			s.inputTokens = aws.ToInt32(v.Value.Usage.InputTokens)
+			s.outputTokens = aws.ToInt32(v.Value.Usage.OutputTokens)
+		}
+	}
+	return false
+}
+
+func (s *anthropicStreamState) runTextFilter(text string) bool {
+	chunkBytes, _ := json.Marshal(text)
+	blocked, blockMsg, filterErr := ExecuteResponseFilters(
+		s.conf, s.proxy.gatewayService, chunkBytes, http.StatusOK,
+		true, true, s.chunkIndex, s.textBuffer, s.request,
+	)
+	s.chunkIndex++
+	if filterErr != nil {
+		log.Error().Err(filterErr).Int("chunk", s.chunkIndex).Msg("Response filter error on Bedrock Anthropic stream")
+		return false
+	}
+	if blocked {
+		writeAnthropicSSEError(s.w, s.flusher, "invalid_request_error", fmt.Sprintf("Response blocked by filter: %s", blockMsg))
+		return true
+	}
+	return false
+}
+
+func (s *anthropicStreamState) emitBlockStop(idx int32) {
+	if !s.started[idx] || s.stopped[idx] {
+		return
+	}
+	s.stopped[idx] = true
+	writeAnthropicSSE(s.w, s.flusher, "content_block_stop", map[string]any{
+		"type":  "content_block_stop",
+		"index": idx,
+	})
+}
+
+// finish emits any missing content_block_stop events, then message_delta and message_stop.
+func (s *anthropicStreamState) finish() {
+	s.ensureMessageStart()
+	// Close any content blocks Bedrock started but never stopped.
+	for idx := range s.started {
+		s.emitBlockStop(idx)
+	}
+	if s.stopReason == "" {
+		s.stopReason = "end_turn"
+	}
+	writeAnthropicSSE(s.w, s.flusher, "message_delta", map[string]any{
+		"type": "message_delta",
+		"delta": map[string]any{
+			"stop_reason":   s.stopReason,
+			"stop_sequence": nil,
+		},
+		"usage": map[string]any{
+			"input_tokens":  s.inputTokens,
+			"output_tokens": s.outputTokens,
+		},
+	})
+	writeAnthropicSSE(s.w, s.flusher, "message_stop", map[string]any{"type": "message_stop"})
+}

--- a/proxy/anthropic_bedrock_translator.go
+++ b/proxy/anthropic_bedrock_translator.go
@@ -238,9 +238,10 @@ func (p *Proxy) handleBedrockAnthropicMessagesStream(w http.ResponseWriter, r *h
 	// Record analytics after the stream completes (ProxyLog first so ChatRecord can enrich it).
 	responseText := st.textBuffer
 	inputTokens, outputTokens := st.inputTokens, st.outputTokens
+	cacheWrite, cacheRead := st.cacheWriteTokens, st.cacheReadTokens
 	go func() {
 		recordBedrockProxyLog(p, conf, app, modelID, reqBody, responseText, r, timestamp)
-		recordBedrockChatRecord(p, conf, app, modelID, int(inputTokens), int(outputTokens), r, timestamp)
+		recordBedrockChatRecord(p, conf, app, modelID, int(inputTokens), int(outputTokens), int(cacheWrite), int(cacheRead), r, timestamp)
 	}()
 }
 
@@ -371,8 +372,10 @@ func converseOutputToAnthropicResponse(output *bedrockruntime.ConverseOutput, mo
 		resp.StopReason = bedrockVendor.ConvertConverseStopReasonAnthropic(output.StopReason)
 		if output.Usage != nil {
 			resp.Usage = AnthropicUsage{
-				InputTokens:  int(aws.ToInt32(output.Usage.InputTokens)),
-				OutputTokens: int(aws.ToInt32(output.Usage.OutputTokens)),
+				InputTokens:              int(aws.ToInt32(output.Usage.InputTokens)),
+				OutputTokens:             int(aws.ToInt32(output.Usage.OutputTokens)),
+				CacheCreationInputTokens: int(aws.ToInt32(output.Usage.CacheWriteInputTokens)),
+				CacheReadInputTokens:     int(aws.ToInt32(output.Usage.CacheReadInputTokens)),
 			}
 		}
 	}
@@ -431,13 +434,15 @@ type anthropicStreamState struct {
 	msgID     string
 	echoModel string
 
-	sentStart    bool
-	started      map[int32]bool // content_block_start emitted for index
-	stopped      map[int32]bool // content_block_stop emitted for index
-	stopReason   string
-	inputTokens  int32
-	outputTokens int32
-	textBuffer   string
+	sentStart        bool
+	started          map[int32]bool // content_block_start emitted for index
+	stopped          map[int32]bool // content_block_stop emitted for index
+	stopReason       string
+	inputTokens      int32
+	outputTokens     int32
+	cacheWriteTokens int32
+	cacheReadTokens  int32
+	textBuffer       string
 
 	// filters
 	hasFilters bool
@@ -537,6 +542,8 @@ func (s *anthropicStreamState) handleEvent(event types.ConverseStreamOutput) boo
 		if v.Value.Usage != nil {
 			s.inputTokens = aws.ToInt32(v.Value.Usage.InputTokens)
 			s.outputTokens = aws.ToInt32(v.Value.Usage.OutputTokens)
+			s.cacheWriteTokens = aws.ToInt32(v.Value.Usage.CacheWriteInputTokens)
+			s.cacheReadTokens = aws.ToInt32(v.Value.Usage.CacheReadInputTokens)
 		}
 	}
 	return false
@@ -588,8 +595,10 @@ func (s *anthropicStreamState) finish() {
 			"stop_sequence": nil,
 		},
 		"usage": map[string]any{
-			"input_tokens":  s.inputTokens,
-			"output_tokens": s.outputTokens,
+			"input_tokens":                s.inputTokens,
+			"output_tokens":               s.outputTokens,
+			"cache_creation_input_tokens": s.cacheWriteTokens,
+			"cache_read_input_tokens":     s.cacheReadTokens,
 		},
 	})
 	writeAnthropicSSE(s.w, s.flusher, "message_stop", map[string]any{"type": "message_stop"})

--- a/proxy/anthropic_bedrock_translator_test.go
+++ b/proxy/anthropic_bedrock_translator_test.go
@@ -1,0 +1,279 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	bedrockVendor "github.com/TykTechnologies/midsommar/v2/vendors/bedrock"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+// --- wire -> vendor mapping ---
+
+func TestAnthropicMessagesToVendor_TextToolUseToolResult(t *testing.T) {
+	req := &AnthropicMessagesRequest{
+		System: json.RawMessage(`"You are helpful."`),
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`"hello"`)},
+			{Role: "assistant", Content: json.RawMessage(`[
+				{"type":"text","text":"let me check"},
+				{"type":"tool_use","id":"toolu_1","name":"get_weather","input":{"city":"NYC"}}
+			]`)},
+			{Role: "user", Content: json.RawMessage(`[
+				{"type":"tool_result","tool_use_id":"toolu_1","content":"sunny","is_error":false}
+			]`)},
+		},
+	}
+
+	msgs, system, err := anthropicMessagesToVendor(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(system) != 1 || system[0].Text != "You are helpful." {
+		t.Fatalf("system not mapped: %+v", system)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+
+	// assistant turn: text + tool_use
+	asst := msgs[1]
+	if asst.Role != "assistant" || len(asst.Blocks) != 2 {
+		t.Fatalf("assistant blocks wrong: %+v", asst)
+	}
+	if asst.Blocks[0].Type != "text" || asst.Blocks[0].Text != "let me check" {
+		t.Errorf("text block wrong: %+v", asst.Blocks[0])
+	}
+	tu := asst.Blocks[1]
+	if tu.Type != "tool_use" || tu.ToolUseID != "toolu_1" || tu.Name != "get_weather" {
+		t.Errorf("tool_use block wrong: %+v", tu)
+	}
+	if tu.Input["city"] != "NYC" {
+		t.Errorf("tool_use input not decoded: %+v", tu.Input)
+	}
+
+	// user tool_result turn
+	tr := msgs[2].Blocks[0]
+	if tr.Type != "tool_result" || tr.ToolUseID != "toolu_1" || tr.ResultText != "sunny" || tr.IsError {
+		t.Errorf("tool_result block wrong: %+v", tr)
+	}
+}
+
+func TestAnthropicMessagesToConverse_CachePointInsertion(t *testing.T) {
+	msgs := []bedrockVendor.AnthropicMsg{
+		{Role: "user", Blocks: []bedrockVendor.AnthropicBlock{
+			{Type: "text", Text: "big context", CachePoint: true},
+		}},
+	}
+	system := []bedrockVendor.AnthropicSystemBlock{
+		{Text: "sys prompt", CachePoint: true},
+	}
+
+	converseMsgs, systemBlocks := bedrockVendor.AnthropicMessagesToConverse(msgs, system)
+
+	// user message: text block followed by a cache point => 2 content blocks
+	if len(converseMsgs) != 1 || len(converseMsgs[0].Content) != 2 {
+		t.Fatalf("expected text + cachepoint, got %+v", converseMsgs)
+	}
+	if _, ok := converseMsgs[0].Content[0].(*types.ContentBlockMemberText); !ok {
+		t.Errorf("expected first block text, got %T", converseMsgs[0].Content[0])
+	}
+	if _, ok := converseMsgs[0].Content[1].(*types.ContentBlockMemberCachePoint); !ok {
+		t.Errorf("expected second block cachepoint, got %T", converseMsgs[0].Content[1])
+	}
+
+	// system: text block followed by a cache point => 2 system blocks
+	if len(systemBlocks) != 2 {
+		t.Fatalf("expected system text + cachepoint, got %d", len(systemBlocks))
+	}
+	if _, ok := systemBlocks[1].(*types.SystemContentBlockMemberCachePoint); !ok {
+		t.Errorf("expected system cachepoint, got %T", systemBlocks[1])
+	}
+}
+
+func TestAnthropicMessagesToConverse_SkipsEmptyText(t *testing.T) {
+	msgs := []bedrockVendor.AnthropicMsg{
+		{Role: "assistant", Blocks: []bedrockVendor.AnthropicBlock{
+			{Type: "text", Text: ""},
+			{Type: "tool_use", ToolUseID: "t1", Name: "f", Input: map[string]any{"a": 1}},
+		}},
+	}
+	converseMsgs, _ := bedrockVendor.AnthropicMessagesToConverse(msgs, nil)
+	if len(converseMsgs) != 1 || len(converseMsgs[0].Content) != 1 {
+		t.Fatalf("expected empty text skipped, got %+v", converseMsgs)
+	}
+	if _, ok := converseMsgs[0].Content[0].(*types.ContentBlockMemberToolUse); !ok {
+		t.Errorf("expected tool_use block, got %T", converseMsgs[0].Content[0])
+	}
+}
+
+func TestAnthropicToolsToToolConfig_ChoiceAndCachePoint(t *testing.T) {
+	tools := []bedrockVendor.AnthropicToolSpec{
+		{Name: "get_weather", Description: "d", InputSchema: map[string]any{"type": "object"}, CachePoint: true},
+	}
+	choice := &bedrockVendor.AnthropicToolChoiceSpec{Type: "tool", Name: "get_weather"}
+
+	cfg := bedrockVendor.AnthropicToolsToToolConfig(tools, choice)
+	if cfg == nil {
+		t.Fatal("expected non-nil tool config")
+	}
+	// tool spec + cache point
+	if len(cfg.Tools) != 2 {
+		t.Fatalf("expected toolspec + cachepoint, got %d", len(cfg.Tools))
+	}
+	if _, ok := cfg.Tools[1].(*types.ToolMemberCachePoint); !ok {
+		t.Errorf("expected tool cachepoint, got %T", cfg.Tools[1])
+	}
+	tc, ok := cfg.ToolChoice.(*types.ToolChoiceMemberTool)
+	if !ok {
+		t.Fatalf("expected specific tool choice, got %T", cfg.ToolChoice)
+	}
+	if aws.ToString(tc.Value.Name) != "get_weather" {
+		t.Errorf("tool choice name wrong: %s", aws.ToString(tc.Value.Name))
+	}
+
+	if bedrockVendor.AnthropicToolsToToolConfig(nil, nil) != nil {
+		t.Error("expected nil config for no tools")
+	}
+}
+
+func TestConvertConverseStopReasonAnthropic(t *testing.T) {
+	cases := map[types.StopReason]string{
+		types.StopReasonEndTurn:      "end_turn",
+		types.StopReasonToolUse:      "tool_use",
+		types.StopReasonMaxTokens:    "max_tokens",
+		types.StopReasonStopSequence: "stop_sequence",
+	}
+	for in, want := range cases {
+		if got := bedrockVendor.ConvertConverseStopReasonAnthropic(in); got != want {
+			t.Errorf("%s: got %s want %s", in, got, want)
+		}
+	}
+}
+
+// --- response mapping ---
+
+func TestConverseOutputToAnthropicResponse(t *testing.T) {
+	output := makeConverseOutput(
+		[]types.ContentBlock{
+			&types.ContentBlockMemberText{Value: "hi there"},
+			&types.ContentBlockMemberToolUse{Value: types.ToolUseBlock{
+				ToolUseId: aws.String("toolu_9"),
+				Name:      aws.String("do_thing"),
+				Input:     lazyDoc(map[string]any{"x": 1}),
+			}},
+		},
+		types.StopReasonToolUse, 11, 22,
+	)
+
+	resp := converseOutputToAnthropicResponse(output, "claude-x")
+	if resp.Type != "message" || resp.Role != "assistant" || resp.Model != "claude-x" {
+		t.Fatalf("response envelope wrong: %+v", resp)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Errorf("stop_reason: %s", resp.StopReason)
+	}
+	if resp.Usage.InputTokens != 11 || resp.Usage.OutputTokens != 22 {
+		t.Errorf("usage wrong: %+v", resp.Usage)
+	}
+	if len(resp.Content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(resp.Content))
+	}
+	if resp.Content[0].Type != "text" || resp.Content[0].Text != "hi there" {
+		t.Errorf("text block wrong: %+v", resp.Content[0])
+	}
+	tu := resp.Content[1]
+	if tu.Type != "tool_use" || tu.ID != "toolu_9" || tu.Name != "do_thing" {
+		t.Errorf("tool_use block wrong: %+v", tu)
+	}
+	var input map[string]any
+	if err := json.Unmarshal(tu.Input, &input); err != nil || input["x"] == nil {
+		t.Errorf("tool_use input not marshalled: %s (%v)", tu.Input, err)
+	}
+}
+
+// --- streaming SSE sequence ---
+
+func TestAnthropicStream_TextThenToolUseSequence(t *testing.T) {
+	rec := newSSERecorder()
+	st := &anthropicStreamState{
+		w:         rec,
+		flusher:   rec,
+		msgID:     "msg_test",
+		echoModel: "claude-x",
+		started:   map[int32]bool{},
+		stopped:   map[int32]bool{},
+	}
+
+	events := []types.ConverseStreamOutput{
+		&types.ConverseStreamOutputMemberMessageStart{Value: types.MessageStartEvent{Role: types.ConversationRoleAssistant}},
+		// text block at index 0
+		&types.ConverseStreamOutputMemberContentBlockDelta{Value: types.ContentBlockDeltaEvent{
+			ContentBlockIndex: aws.Int32(0),
+			Delta:             &types.ContentBlockDeltaMemberText{Value: "Hello"},
+		}},
+		&types.ConverseStreamOutputMemberContentBlockStop{Value: types.ContentBlockStopEvent{ContentBlockIndex: aws.Int32(0)}},
+		// tool_use block at index 1
+		&types.ConverseStreamOutputMemberContentBlockStart{Value: types.ContentBlockStartEvent{
+			ContentBlockIndex: aws.Int32(1),
+			Start: &types.ContentBlockStartMemberToolUse{Value: types.ToolUseBlockStart{
+				ToolUseId: aws.String("toolu_1"), Name: aws.String("get_weather"),
+			}},
+		}},
+		&types.ConverseStreamOutputMemberContentBlockDelta{Value: types.ContentBlockDeltaEvent{
+			ContentBlockIndex: aws.Int32(1),
+			Delta:             &types.ContentBlockDeltaMemberToolUse{Value: types.ToolUseBlockDelta{Input: aws.String(`{"city":`)}},
+		}},
+		&types.ConverseStreamOutputMemberContentBlockDelta{Value: types.ContentBlockDeltaEvent{
+			ContentBlockIndex: aws.Int32(1),
+			Delta:             &types.ContentBlockDeltaMemberToolUse{Value: types.ToolUseBlockDelta{Input: aws.String(`"NYC"}`)}},
+		}},
+		&types.ConverseStreamOutputMemberContentBlockStop{Value: types.ContentBlockStopEvent{ContentBlockIndex: aws.Int32(1)}},
+		&types.ConverseStreamOutputMemberMessageStop{Value: types.MessageStopEvent{StopReason: types.StopReasonToolUse}},
+		&types.ConverseStreamOutputMemberMetadata{Value: types.ConverseStreamMetadataEvent{
+			Usage: &types.TokenUsage{InputTokens: aws.Int32(10), OutputTokens: aws.Int32(5)},
+		}},
+	}
+	for _, e := range events {
+		if blocked := st.handleEvent(e); blocked {
+			t.Fatal("unexpected filter block")
+		}
+	}
+	st.finish()
+
+	types_ := rec.eventTypes()
+	want := []string{
+		"message_start", "ping",
+		"content_block_start", "content_block_delta", "content_block_stop", // text
+		"content_block_start", "content_block_delta", "content_block_delta", "content_block_stop", // tool_use
+		"message_delta", "message_stop",
+	}
+	if len(types_) != len(want) {
+		t.Fatalf("event count: got %v (%d) want %v (%d)", types_, len(types_), want, len(want))
+	}
+	for i := range want {
+		if types_[i] != want[i] {
+			t.Errorf("event %d: got %s want %s", i, types_[i], want[i])
+		}
+	}
+
+	// The tool_use partial_json fragments must be forwarded verbatim.
+	got := rec.dataFor("content_block_delta")
+	joined := ""
+	for _, d := range got {
+		if d["delta"].(map[string]any)["type"] == "input_json_delta" {
+			joined += d["delta"].(map[string]any)["partial_json"].(string)
+		}
+	}
+	if joined != `{"city":"NYC"}` {
+		t.Errorf("tool input reconstruction: got %q", joined)
+	}
+
+	// message_delta carries the mapped stop_reason and output tokens.
+	md := rec.dataFor("message_delta")[0]
+	if md["delta"].(map[string]any)["stop_reason"] != "tool_use" {
+		t.Errorf("message_delta stop_reason: %+v", md["delta"])
+	}
+}

--- a/proxy/anthropic_bedrock_translator_test.go
+++ b/proxy/anthropic_bedrock_translator_test.go
@@ -165,7 +165,7 @@ func TestConverseOutputToAnthropicResponse(t *testing.T) {
 				Input:     lazyDoc(map[string]any{"x": 1}),
 			}},
 		},
-		types.StopReasonToolUse, 11, 22,
+		types.StopReasonToolUse, 11, 22, 33, 44,
 	)
 
 	resp := converseOutputToAnthropicResponse(output, "claude-x")
@@ -177,6 +177,10 @@ func TestConverseOutputToAnthropicResponse(t *testing.T) {
 	}
 	if resp.Usage.InputTokens != 11 || resp.Usage.OutputTokens != 22 {
 		t.Errorf("usage wrong: %+v", resp.Usage)
+	}
+	if resp.Usage.CacheCreationInputTokens != 33 || resp.Usage.CacheReadInputTokens != 44 {
+		t.Errorf("cache usage wrong: got creation=%d read=%d, want 33/44",
+			resp.Usage.CacheCreationInputTokens, resp.Usage.CacheReadInputTokens)
 	}
 	if len(resp.Content) != 2 {
 		t.Fatalf("expected 2 content blocks, got %d", len(resp.Content))
@@ -233,7 +237,10 @@ func TestAnthropicStream_TextThenToolUseSequence(t *testing.T) {
 		&types.ConverseStreamOutputMemberContentBlockStop{Value: types.ContentBlockStopEvent{ContentBlockIndex: aws.Int32(1)}},
 		&types.ConverseStreamOutputMemberMessageStop{Value: types.MessageStopEvent{StopReason: types.StopReasonToolUse}},
 		&types.ConverseStreamOutputMemberMetadata{Value: types.ConverseStreamMetadataEvent{
-			Usage: &types.TokenUsage{InputTokens: aws.Int32(10), OutputTokens: aws.Int32(5)},
+			Usage: &types.TokenUsage{
+				InputTokens: aws.Int32(10), OutputTokens: aws.Int32(5),
+				CacheWriteInputTokens: aws.Int32(70), CacheReadInputTokens: aws.Int32(80),
+			},
 		}},
 	}
 	for _, e := range events {
@@ -275,5 +282,11 @@ func TestAnthropicStream_TextThenToolUseSequence(t *testing.T) {
 	md := rec.dataFor("message_delta")[0]
 	if md["delta"].(map[string]any)["stop_reason"] != "tool_use" {
 		t.Errorf("message_delta stop_reason: %+v", md["delta"])
+	}
+	// Cache-token usage must be surfaced on message_delta (JSON numbers decode to float64).
+	usage := md["usage"].(map[string]any)
+	if usage["cache_creation_input_tokens"] != float64(70) || usage["cache_read_input_tokens"] != float64(80) {
+		t.Errorf("message_delta cache usage: got creation=%v read=%v, want 70/80",
+			usage["cache_creation_input_tokens"], usage["cache_read_input_tokens"])
 	}
 }

--- a/proxy/anthropic_messages_models.go
+++ b/proxy/anthropic_messages_models.go
@@ -1,0 +1,142 @@
+package proxy
+
+import "encoding/json"
+
+// This file defines the Anthropic Messages API wire format
+// (https://docs.anthropic.com/en/api/messages) as consumed and produced by the
+// Anthropic -> Bedrock bridge. Only the fields the bridge needs are modelled;
+// unknown fields (e.g. "metadata", beta extras) are ignored by encoding/json.
+
+// --- Request ---
+
+// AnthropicMessagesRequest is the body of POST /anthropic/{routeId}/v1/messages.
+type AnthropicMessagesRequest struct {
+	Model         string               `json:"model"`
+	Messages      []AnthropicMessage   `json:"messages"`
+	System        json.RawMessage      `json:"system,omitempty"` // string | []AnthropicContentBlock
+	MaxTokens     int                  `json:"max_tokens"`
+	Temperature   *float64             `json:"temperature,omitempty"`
+	TopP          *float64             `json:"top_p,omitempty"`
+	StopSequences []string             `json:"stop_sequences,omitempty"`
+	Tools         []AnthropicTool      `json:"tools,omitempty"`
+	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
+	Stream        bool                 `json:"stream,omitempty"`
+}
+
+// AnthropicMessage is a single conversation turn. Content is either a plain
+// string or an array of typed content blocks.
+type AnthropicMessage struct {
+	Role    string          `json:"role"` // "user" | "assistant"
+	Content json.RawMessage `json:"content"`
+}
+
+// AnthropicContentBlock is one block within a message's content array (or a
+// system block). Different block types populate different fields.
+type AnthropicContentBlock struct {
+	Type string `json:"type"` // "text" | "tool_use" | "tool_result"
+
+	// text
+	Text string `json:"text,omitempty"`
+
+	// tool_use (assistant asking to call a tool)
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+
+	// tool_result (user returning a tool's output)
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"` // string | []AnthropicContentBlock
+	IsError   bool            `json:"is_error,omitempty"`
+
+	// prompt caching marker
+	CacheControl *AnthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+// AnthropicCacheControl marks a block as a prompt-cache breakpoint.
+type AnthropicCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// AnthropicTool is a tool definition the model may call.
+type AnthropicTool struct {
+	Name         string                 `json:"name"`
+	Description  string                 `json:"description,omitempty"`
+	InputSchema  map[string]any         `json:"input_schema,omitempty"`
+	CacheControl *AnthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+// AnthropicToolChoice controls whether/which tool the model must use.
+type AnthropicToolChoice struct {
+	Type string `json:"type"` // "auto" | "any" | "tool"
+	Name string `json:"name,omitempty"`
+}
+
+// --- Response (non-streaming) ---
+
+// AnthropicMessagesResponse is the non-streaming response, and also the message
+// skeleton embedded in the streaming "message_start" event.
+type AnthropicMessagesResponse struct {
+	ID           string                   `json:"id"`
+	Type         string                   `json:"type"` // "message"
+	Role         string                   `json:"role"` // "assistant"
+	Model        string                   `json:"model"`
+	Content      []AnthropicResponseBlock `json:"content"`
+	StopReason   string                   `json:"stop_reason,omitempty"`
+	StopSequence *string                  `json:"stop_sequence"`
+	Usage        AnthropicUsage           `json:"usage"`
+}
+
+// AnthropicResponseBlock is an output content block (text or tool_use).
+type AnthropicResponseBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// AnthropicUsage carries token counts. input_tokens is reported in message_start,
+// output_tokens in message_delta (streaming) or both together (non-streaming).
+type AnthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// --- Helpers ---
+
+// parseAnthropicBlocks normalises a field that may be a JSON string or an array
+// of content blocks into a block slice. A bare string becomes a single text block.
+func parseAnthropicBlocks(raw json.RawMessage) ([]AnthropicContentBlock, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if s == "" {
+			return nil, nil
+		}
+		return []AnthropicContentBlock{{Type: "text", Text: s}}, nil
+	}
+	var blocks []AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return nil, err
+	}
+	return blocks, nil
+}
+
+// anthropicContentToText flattens a tool_result content field (string or block
+// array) into plain text for the Bedrock tool result content block.
+func anthropicContentToText(raw json.RawMessage) string {
+	blocks, err := parseAnthropicBlocks(raw)
+	if err != nil {
+		// Fall back to the raw JSON so nothing is silently dropped.
+		return string(raw)
+	}
+	var out string
+	for _, b := range blocks {
+		if b.Type == "text" || b.Text != "" {
+			out += b.Text
+		}
+	}
+	return out
+}

--- a/proxy/anthropic_messages_models.go
+++ b/proxy/anthropic_messages_models.go
@@ -98,8 +98,10 @@ type AnthropicResponseBlock struct {
 // AnthropicUsage carries token counts. input_tokens is reported in message_start,
 // output_tokens in message_delta (streaming) or both together (non-streaming).
 type AnthropicUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 }
 
 // --- Helpers ---

--- a/proxy/bedrock_streaming.go
+++ b/proxy/bedrock_streaming.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/TykTechnologies/midsommar/v2/models"
+	bedrockVendor "github.com/TykTechnologies/midsommar/v2/vendors/bedrock"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream/eventstreamapi"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
-	"github.com/TykTechnologies/midsommar/v2/models"
-	bedrockVendor "github.com/TykTechnologies/midsommar/v2/vendors/bedrock"
 	"github.com/rs/zerolog/log"
 )
 
@@ -91,6 +91,7 @@ func (p *Proxy) handleBedrockStreamingProxy(w http.ResponseWriter, r *http.Reque
 	chunkIndex := 0
 	isErr := false
 	var inputTokens, outputTokens int32
+	var cacheWriteTokens, cacheReadTokens int32
 
 	for event := range stream.Events() {
 		if err := stream.Err(); err != nil {
@@ -104,6 +105,8 @@ func (p *Proxy) handleBedrockStreamingProxy(w http.ResponseWriter, r *http.Reque
 			if metadata.Value.Usage != nil {
 				inputTokens = aws.ToInt32(metadata.Value.Usage.InputTokens)
 				outputTokens = aws.ToInt32(metadata.Value.Usage.OutputTokens)
+				cacheWriteTokens = aws.ToInt32(metadata.Value.Usage.CacheWriteInputTokens)
+				cacheReadTokens = aws.ToInt32(metadata.Value.Usage.CacheReadInputTokens)
 			}
 		}
 
@@ -160,7 +163,7 @@ func (p *Proxy) handleBedrockStreamingProxy(w http.ResponseWriter, r *http.Reque
 		responseText := textBuffer.String()
 		go func() {
 			recordBedrockProxyLog(p, llm, app, modelID, reqBody, responseText, r, startTime)
-			recordBedrockChatRecord(p, llm, app, modelID, int(inputTokens), int(outputTokens), r, startTime)
+			recordBedrockChatRecord(p, llm, app, modelID, int(inputTokens), int(outputTokens), int(cacheWriteTokens), int(cacheReadTokens), r, startTime)
 		}()
 	}
 }

--- a/proxy/bedrock_translator.go
+++ b/proxy/bedrock_translator.go
@@ -8,12 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
-	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/TykTechnologies/midsommar/v2/analytics"
 	"github.com/TykTechnologies/midsommar/v2/models"
 	bedrockVendor "github.com/TykTechnologies/midsommar/v2/vendors/bedrock"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
@@ -201,6 +201,7 @@ func (p *Proxy) handleBedrockChatCompletionStream(
 	created := time.Now().Unix()
 	isFirstChunk := true
 	var inputTokens, outputTokens int32
+	var cacheWriteTokens, cacheReadTokens int32
 	hasResponseFilters := p.hasResponseFilters(conf)
 	var textBuffer strings.Builder
 	chunkIndex := 0
@@ -285,6 +286,8 @@ func (p *Proxy) handleBedrockChatCompletionStream(
 			if v.Value.Usage != nil {
 				inputTokens = aws.ToInt32(v.Value.Usage.InputTokens)
 				outputTokens = aws.ToInt32(v.Value.Usage.OutputTokens)
+				cacheWriteTokens = aws.ToInt32(v.Value.Usage.CacheWriteInputTokens)
+				cacheReadTokens = aws.ToInt32(v.Value.Usage.CacheReadInputTokens)
 
 				// Send final chunk with usage
 				usage := CompletionUsage{
@@ -317,7 +320,7 @@ func (p *Proxy) handleBedrockChatCompletionStream(
 	responseText := textBuffer.String()
 	go func() {
 		recordBedrockProxyLog(p, conf, app, modelID, reqBody, responseText, r, timestamp)
-		recordBedrockChatRecord(p, conf, app, modelID, int(inputTokens), int(outputTokens), r, timestamp)
+		recordBedrockChatRecord(p, conf, app, modelID, int(inputTokens), int(outputTokens), int(cacheWriteTokens), int(cacheReadTokens), r, timestamp)
 	}()
 }
 
@@ -444,6 +447,8 @@ func recordBedrockAnalytics(p *Proxy, llm *models.LLM, app *models.App, modelID 
 		recordBedrockChatRecord(p, llm, app, modelID,
 			int(aws.ToInt32(output.Usage.InputTokens)),
 			int(aws.ToInt32(output.Usage.OutputTokens)),
+			int(aws.ToInt32(output.Usage.CacheWriteInputTokens)),
+			int(aws.ToInt32(output.Usage.CacheReadInputTokens)),
 			r, timestamp)
 	}
 }
@@ -474,8 +479,8 @@ func recordBedrockProxyLog(p *Proxy, llm *models.LLM, app *models.App, modelID s
 
 // recordBedrockChatRecord is the single place that calculates cost and records an LLMChatRecord
 // for all Bedrock paths (non-streaming /ai/, streaming /ai/, and streaming /llm/stream/).
-func recordBedrockChatRecord(p *Proxy, llm *models.LLM, app *models.App, modelID string, promptTokens int, responseTokens int, r *http.Request, timestamp time.Time) {
-	if promptTokens == 0 && responseTokens == 0 {
+func recordBedrockChatRecord(p *Proxy, llm *models.LLM, app *models.App, modelID string, promptTokens int, responseTokens int, cacheWriteTokens int, cacheReadTokens int, r *http.Request, timestamp time.Time) {
+	if promptTokens == 0 && responseTokens == 0 && cacheWriteTokens == 0 && cacheReadTokens == 0 {
 		return
 	}
 
@@ -485,22 +490,27 @@ func recordBedrockChatRecord(p *Proxy, llm *models.LLM, app *models.App, modelID
 		price = &models.ModelPrice{}
 	}
 
-	cost := ((price.CPT * float64(responseTokens)) + (price.CPIT * float64(promptTokens))) * 10000
+	cost := ((price.CPT * float64(responseTokens)) +
+		(price.CPIT * float64(promptTokens)) +
+		(price.CacheWritePT * float64(cacheWriteTokens)) +
+		(price.CacheReadPT * float64(cacheReadTokens))) * 10000
 
 	record := &models.LLMChatRecord{
-		LLMID:           llm.ID,
-		Name:            modelID,
-		Vendor:          string(llm.Vendor),
-		PromptTokens:    promptTokens,
-		ResponseTokens:  responseTokens,
-		TotalTokens:     promptTokens + responseTokens,
-		Cost:            cost,
-		Currency:        price.Currency,
-		Choices:         1,
-		TimeStamp:       timestamp,
-		AppID:           app.ID,
-		UserID:          app.UserID,
-		InteractionType: models.ProxyInteraction,
+		LLMID:                  llm.ID,
+		Name:                   modelID,
+		Vendor:                 string(llm.Vendor),
+		PromptTokens:           promptTokens,
+		ResponseTokens:         responseTokens,
+		TotalTokens:            promptTokens + responseTokens,
+		CacheWritePromptTokens: cacheWriteTokens,
+		CacheReadPromptTokens:  cacheReadTokens,
+		Cost:                   cost,
+		Currency:               price.Currency,
+		Choices:                1,
+		TimeStamp:              timestamp,
+		AppID:                  app.ID,
+		UserID:                 app.UserID,
+		InteractionType:        models.ProxyInteraction,
 	}
 	ctx := context.WithoutCancel(r.Context())
 	analytics.RecordChatRecord(ctx, record)
@@ -508,4 +518,3 @@ func recordBedrockChatRecord(p *Proxy, llm *models.LLM, app *models.App, modelID
 	// Trigger budget analysis
 	p.budgetService.AnalyzeBudgetUsage(app, llm)
 }
-

--- a/proxy/credential_validator.go
+++ b/proxy/credential_validator.go
@@ -235,7 +235,7 @@ func (cv *CredentialValidator) Middleware(next http.Handler) http.Handler {
 				if len(pathParts) > 2 {
 					dsSlug = pathParts[2]
 				}
-			case "ai":
+			case "ai", "anthropic":
 				if len(pathParts) > 2 {
 					routeID = pathParts[2]
 				}
@@ -299,8 +299,17 @@ func (cv *CredentialValidator) Middleware(next http.Handler) http.Handler {
 			if !strings.HasPrefix(authHeader, "Bearer ") && authHeader != "" {
 				apiKey = authHeader
 			} else if authHeader == "" {
-				respondWithError(w, http.StatusUnauthorized, "missing Authorization header for 'ai' route", nil, true) // true for wwwAuth
-				return
+				// The Anthropic Messages bridge (Claude Code) presents the app key via the
+				// x-api-key header (ANTHROPIC_API_KEY). Bearer tokens are handled earlier.
+				if pathParts[1] == "anthropic" {
+					if k, xerr := AnthropicValidator(r); xerr == nil {
+						apiKey = k
+					}
+				}
+				if apiKey == "" {
+					respondWithError(w, http.StatusUnauthorized, "missing credentials for route", nil, true) // true for wwwAuth
+					return
+				}
 			}
 		}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -388,11 +388,21 @@ func (p *Proxy) createHandler() http.Handler {
 	aiRouter.HandleFunc("/ai/{routeId}/v1/completions", p.CreateCompletionHandler).Methods("POST")
 	authenticatedAIHandler := p.credValidator.Middleware(aiRouter)
 
-	// Combine routers: both go through auth, but /ai/ routes are separated for routing
+	// Anthropic Messages bridge: lets Claude Code (native Anthropic Messages API) drive
+	// Bedrock-backed LLMs. Like /ai/, it uses direct AWS SDK calls, so auth must run here
+	// to populate the app context.
+	anthropicRouter := mux.NewRouter()
+	anthropicRouter.HandleFunc("/anthropic/{routeId}/v1/messages", p.handleAnthropicMessagesEntry).Methods("POST")
+	authenticatedAnthropicHandler := p.credValidator.Middleware(anthropicRouter)
+
+	// Combine routers: all go through auth, but /ai/ and /anthropic/ routes are separated for routing
 	combinedHandler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if strings.HasPrefix(req.URL.Path, "/ai/") {
+		switch {
+		case strings.HasPrefix(req.URL.Path, "/ai/"):
 			authenticatedAIHandler.ServeHTTP(w, req)
-		} else {
+		case strings.HasPrefix(req.URL.Path, "/anthropic/"):
+			authenticatedAnthropicHandler.ServeHTTP(w, req)
+		default:
 			authenticatedHandler.ServeHTTP(w, req)
 		}
 	})

--- a/services/llm_metadata_merge_test.go
+++ b/services/llm_metadata_merge_test.go
@@ -1,0 +1,64 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+)
+
+func TestMergeMetadataPreservingRedacted(t *testing.T) {
+	existing := models.JSONMap{
+		"aws_access_key_id":     "AKIAREAL",
+		"aws_secret_access_key": "realsecretvalue",
+		"aws_session_token":     "oldtoken",
+	}
+
+	t.Run("preserves redacted fields, applies changed ones", func(t *testing.T) {
+		incoming := models.JSONMap{
+			"aws_access_key_id":     REDACTED_VALUE, // unchanged in the UI
+			"aws_secret_access_key": "newsecret",    // user re-typed
+			"aws_session_token":     REDACTED_VALUE, // unchanged
+		}
+		got := mergeMetadataPreservingRedacted(existing, incoming)
+		if got["aws_access_key_id"] != "AKIAREAL" {
+			t.Errorf("access key id: got %v, want preserved AKIAREAL", got["aws_access_key_id"])
+		}
+		if got["aws_secret_access_key"] != "newsecret" {
+			t.Errorf("secret: got %v, want newsecret", got["aws_secret_access_key"])
+		}
+		if got["aws_session_token"] != "oldtoken" {
+			t.Errorf("session token: got %v, want preserved oldtoken", got["aws_session_token"])
+		}
+	})
+
+	t.Run("omitted field is dropped (e.g. cleared session token)", func(t *testing.T) {
+		incoming := models.JSONMap{
+			"aws_access_key_id":     REDACTED_VALUE,
+			"aws_secret_access_key": REDACTED_VALUE,
+			// aws_session_token intentionally omitted
+		}
+		got := mergeMetadataPreservingRedacted(existing, incoming)
+		if _, present := got["aws_session_token"]; present {
+			t.Errorf("session token should be dropped when omitted, got %v", got["aws_session_token"])
+		}
+		if got["aws_access_key_id"] != "AKIAREAL" {
+			t.Errorf("access key id should be preserved, got %v", got["aws_access_key_id"])
+		}
+	})
+
+	t.Run("redacted with no existing value is dropped, not stored", func(t *testing.T) {
+		got := mergeMetadataPreservingRedacted(models.JSONMap{}, models.JSONMap{
+			"aws_secret_access_key": REDACTED_VALUE,
+		})
+		if v, present := got["aws_secret_access_key"]; present {
+			t.Errorf("placeholder must not be stored when no existing value, got %v", v)
+		}
+	})
+
+	t.Run("nil incoming returns existing", func(t *testing.T) {
+		got := mergeMetadataPreservingRedacted(existing, nil)
+		if got["aws_access_key_id"] != "AKIAREAL" {
+			t.Errorf("expected existing returned, got %v", got)
+		}
+	})
+}

--- a/services/llm_service.go
+++ b/services/llm_service.go
@@ -30,6 +30,32 @@ func resolveMetadataSecrets(metadata models.JSONMap, preserveRef bool) models.JS
 	return metadata
 }
 
+// mergeMetadataPreservingRedacted returns the incoming metadata, except that any field
+// whose incoming value is the redaction placeholder ("[redacted]") keeps the existing
+// stored value. The edit UI receives secret metadata fields redacted (see
+// redactMetadataSecrets in api/llm_handlers.go), so without this an unchanged secret —
+// e.g. a Bedrock LLM's aws_secret_access_key — would be overwritten with the literal
+// "[redacted]" on save. Fields absent from incoming are dropped (so e.g. an
+// aws_session_token can be cleared); non-redacted fields overwrite as normal.
+func mergeMetadataPreservingRedacted(existing, incoming models.JSONMap) models.JSONMap {
+	if incoming == nil {
+		return existing
+	}
+	merged := make(models.JSONMap, len(incoming))
+	for k, v := range incoming {
+		if str, ok := v.(string); ok && str == REDACTED_VALUE {
+			// Preserve the real stored value; if there is none, drop the placeholder
+			// rather than persisting "[redacted]" as a credential.
+			if orig, has := existing[k]; has {
+				merged[k] = orig
+			}
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
+}
+
 func (s *Service) GetLLMByID(id uint) (*models.LLM, error) {
 	llm := models.NewLLM()
 	if err := llm.Get(s.DB, id); err != nil {
@@ -257,7 +283,7 @@ func (s *Service) UpdateLLM(id uint, name, apiKey, apiEndpoint string,
 	llm.Namespace = namespace
 	llm.DontLogBodies = dontLogBodies
 	if metadata != nil {
-		llm.Metadata = metadata
+		llm.Metadata = mergeMetadataPreservingRedacted(llm.Metadata, metadata)
 	}
 
 	// Execute "before_update" hooks

--- a/ui/admin-frontend/src/portal/components/AppDetailView.js
+++ b/ui/admin-frontend/src/portal/components/AppDetailView.js
@@ -768,6 +768,61 @@ const AppDetailView = () => {
                 </Box>
               </Box>
 
+              {/* Anthropic Messages Endpoint (Bedrock only) */}
+              {llm.attributes.vendor === "bedrock" && (
+                <>
+                  <Typography
+                    variant="subtitle1"
+                    sx={{
+                      fontWeight: "bold",
+                      mt: 2,
+                      mb: 1,
+                    }}
+                  >
+                    Anthropic-Compatible Endpoint
+                  </Typography>
+                  <Typography variant="body2" sx={{ mb: 2 }}>
+                    Use this endpoint with the native Anthropic Messages API. Set it as <code>ANTHROPIC_BASE_URL</code> and pass the app key as <code>ANTHROPIC_AUTH_TOKEN</code> (or <code>ANTHROPIC_API_KEY</code>). Requests are translated to your configured Bedrock model.
+                  </Typography>
+
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <FieldLabel sx={{ minWidth: "100px" }}>Anthropic API:</FieldLabel>
+                    <Box>
+                      <Tooltip title="Native Anthropic Messages API (appends /v1/messages), translated to Bedrock Converse using the default model defined by the admin. Set this as ANTHROPIC_BASE_URL for Claude Code.">
+                        <HelpOutlineIcon sx={{ color: "text.secondary", mr: 1 }} />
+                      </Tooltip>
+                    </Box>
+                    <Box
+                      sx={{ flexGrow: 1, display: "flex", alignItems: "center" }}
+                    >
+                      <Typography
+                        variant="body2"
+                        component="code"
+                        sx={{
+                          fontFamily: "monospace",
+                          bgcolor: "background.paper",
+                          p: 1,
+                          borderRadius: 1,
+                          flexGrow: 1,
+                        }}
+                      >
+                        {generateEndpointUrl("/anthropic/", llm.attributes.name)}
+                      </Typography>
+                      <IconButton
+                        onClick={() =>
+                          copyToClipboard(
+                            generateEndpointUrl("/anthropic/", llm.attributes.name),
+                          )
+                        }
+                        size="small"
+                      >
+                        <ContentCopyIcon />
+                      </IconButton>
+                    </Box>
+                  </Box>
+                </>
+              )}
+
               {/* Legacy Endpoints - Collapsible */}
               <Accordion
                 sx={{

--- a/vendors/bedrock/anthropic_converse.go
+++ b/vendors/bedrock/anthropic_converse.go
@@ -1,0 +1,234 @@
+package bedrockVendor
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/document"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
+)
+
+// This file holds pure converters between a simplified Anthropic Messages shape
+// and the AWS Bedrock Converse API. The simplified types live here (mirroring the
+// existing ChatMessage / ToolDef pattern) so the vendor package stays free of any
+// dependency on the proxy package — the proxy translator maps its wire structs
+// into these before calling in.
+
+// --- Simplified Anthropic input types (proxy maps its wire structs into these) ---
+
+// AnthropicMsg is one conversation turn with already-decoded content blocks.
+type AnthropicMsg struct {
+	Role   string // "user" | "assistant"
+	Blocks []AnthropicBlock
+}
+
+// AnthropicBlock is a single content block. Only the fields relevant to its Type
+// are populated.
+type AnthropicBlock struct {
+	Type string // "text" | "tool_use" | "tool_result"
+
+	Text string // text
+
+	// tool_use
+	ToolUseID string
+	Name      string
+	Input     map[string]any
+
+	// tool_result
+	ResultText string
+	IsError    bool
+
+	// prompt caching: a cache breakpoint sits at (and includes) this block
+	CachePoint bool
+}
+
+// AnthropicSystemBlock is a system-prompt block.
+type AnthropicSystemBlock struct {
+	Text       string
+	CachePoint bool
+}
+
+// AnthropicToolSpec is a tool definition.
+type AnthropicToolSpec struct {
+	Name        string
+	Description string
+	InputSchema map[string]any
+	CachePoint  bool
+}
+
+// AnthropicToolChoiceSpec controls tool selection ("auto" | "any" | "tool").
+type AnthropicToolChoiceSpec struct {
+	Type string
+	Name string
+}
+
+// AnthropicOutBlock is a simplified output block (text or tool_use) the proxy
+// maps back onto the Anthropic response wire format.
+type AnthropicOutBlock struct {
+	Type  string // "text" | "tool_use"
+	Text  string
+	ID    string
+	Name  string
+	Input map[string]any
+}
+
+// --- Converters ---
+
+// AnthropicMessagesToConverse maps Anthropic messages + system blocks to the
+// Converse request shape. cache_control markers become Bedrock cache points
+// inserted immediately after the block they apply to.
+func AnthropicMessagesToConverse(msgs []AnthropicMsg, system []AnthropicSystemBlock) ([]types.Message, []types.SystemContentBlock) {
+	var converseMsgs []types.Message
+	for _, m := range msgs {
+		var content []types.ContentBlock
+		for _, b := range m.Blocks {
+			switch b.Type {
+			case "text":
+				if b.Text == "" {
+					continue // Bedrock rejects empty text blocks
+				}
+				content = append(content, &types.ContentBlockMemberText{Value: b.Text})
+			case "tool_use":
+				content = append(content, &types.ContentBlockMemberToolUse{
+					Value: types.ToolUseBlock{
+						ToolUseId: aws.String(b.ToolUseID),
+						Name:      aws.String(b.Name),
+						Input:     document.NewLazyDocument(b.Input),
+					},
+				})
+			case "tool_result":
+				status := types.ToolResultStatusSuccess
+				if b.IsError {
+					status = types.ToolResultStatusError
+				}
+				content = append(content, &types.ContentBlockMemberToolResult{
+					Value: types.ToolResultBlock{
+						ToolUseId: aws.String(b.ToolUseID),
+						Status:    status,
+						Content: []types.ToolResultContentBlock{
+							&types.ToolResultContentBlockMemberText{Value: b.ResultText},
+						},
+					},
+				})
+			}
+			if b.CachePoint {
+				content = append(content, &types.ContentBlockMemberCachePoint{
+					Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+				})
+			}
+		}
+		if len(content) == 0 {
+			continue
+		}
+		converseMsgs = append(converseMsgs, types.Message{
+			Role:    convertToConverseRole(m.Role),
+			Content: content,
+		})
+	}
+
+	var systemBlocks []types.SystemContentBlock
+	for _, s := range system {
+		if s.Text != "" {
+			systemBlocks = append(systemBlocks, &types.SystemContentBlockMemberText{Value: s.Text})
+		}
+		if s.CachePoint {
+			systemBlocks = append(systemBlocks, &types.SystemContentBlockMemberCachePoint{
+				Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+			})
+		}
+	}
+
+	return converseMsgs, systemBlocks
+}
+
+// AnthropicToolsToToolConfig converts Anthropic tool definitions and tool_choice
+// to a Bedrock ToolConfiguration. Returns nil when there are no tools.
+func AnthropicToolsToToolConfig(tools []AnthropicToolSpec, choice *AnthropicToolChoiceSpec) *types.ToolConfiguration {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	bedrockTools := make([]types.Tool, 0, len(tools))
+	for _, t := range tools {
+		bedrockTools = append(bedrockTools, &types.ToolMemberToolSpec{
+			Value: types.ToolSpecification{
+				Name:        aws.String(t.Name),
+				Description: aws.String(t.Description),
+				InputSchema: &types.ToolInputSchemaMemberJson{
+					Value: document.NewLazyDocument(t.InputSchema),
+				},
+			},
+		})
+		if t.CachePoint {
+			bedrockTools = append(bedrockTools, &types.ToolMemberCachePoint{
+				Value: types.CachePointBlock{Type: types.CachePointTypeDefault},
+			})
+		}
+	}
+
+	cfg := &types.ToolConfiguration{Tools: bedrockTools}
+
+	if choice != nil {
+		switch choice.Type {
+		case "any":
+			cfg.ToolChoice = &types.ToolChoiceMemberAny{Value: types.AnyToolChoice{}}
+		case "tool":
+			if choice.Name != "" {
+				cfg.ToolChoice = &types.ToolChoiceMemberTool{
+					Value: types.SpecificToolChoice{Name: aws.String(choice.Name)},
+				}
+			}
+		case "auto":
+			cfg.ToolChoice = &types.ToolChoiceMemberAuto{Value: types.AutoToolChoice{}}
+		}
+	}
+
+	return cfg
+}
+
+// ConverseOutputToAnthropicBlocks converts a Converse response message into
+// Anthropic output blocks (text and tool_use).
+func ConverseOutputToAnthropicBlocks(output *bedrockruntime.ConverseOutput) []AnthropicOutBlock {
+	var blocks []AnthropicOutBlock
+	if output == nil {
+		return blocks
+	}
+	msgOutput, ok := output.Output.(*types.ConverseOutputMemberMessage)
+	if !ok {
+		return blocks
+	}
+	for _, block := range msgOutput.Value.Content {
+		switch b := block.(type) {
+		case *types.ContentBlockMemberText:
+			blocks = append(blocks, AnthropicOutBlock{Type: "text", Text: b.Value})
+		case *types.ContentBlockMemberToolUse:
+			var input map[string]any
+			if b.Value.Input != nil {
+				_ = b.Value.Input.UnmarshalSmithyDocument(&input)
+			}
+			blocks = append(blocks, AnthropicOutBlock{
+				Type:  "tool_use",
+				ID:    aws.ToString(b.Value.ToolUseId),
+				Name:  aws.ToString(b.Value.Name),
+				Input: input,
+			})
+		}
+	}
+	return blocks
+}
+
+// ConvertConverseStopReasonAnthropic maps Bedrock stop reasons to Anthropic
+// stop_reason values.
+func ConvertConverseStopReasonAnthropic(reason types.StopReason) string {
+	switch reason {
+	case types.StopReasonEndTurn:
+		return "end_turn"
+	case types.StopReasonToolUse:
+		return "tool_use"
+	case types.StopReasonMaxTokens:
+		return "max_tokens"
+	case types.StopReasonStopSequence:
+		return "stop_sequence"
+	default:
+		return "end_turn"
+	}
+}


### PR DESCRIPTION
## Summary

Adds a native **Anthropic Messages API → Amazon Bedrock** bridge so Claude Code (and any Anthropic-SDK client) can drive Claude models hosted in Bedrock **through AI Studio**, with full governance — auth, budget, filters, and analytics — instead of bypassing it via `CLAUDE_CODE_USE_BEDROCK`.

Jira: **TAS-32**

Before this change, AI Studio only exposed Bedrock through an OpenAI-compatible endpoint (`/ai/{routeId}/v1/chat/completions`). Claude Code speaks only the native Anthropic Messages API (`POST /v1/messages`), so pointing it at a Bedrock LLM didn't work. This adds the missing translation layer.

```
ANTHROPIC_BASE_URL=https://<ai-studio-host>/anthropic/<llm-slug>
ANTHROPIC_AUTH_TOKEN=<ai-studio-app-key>   # or ANTHROPIC_API_KEY
claude
```

## How it works

`POST /anthropic/{routeId}/v1/messages` → credential validator (App key) → budget + filters → translate Anthropic Messages ⇄ Bedrock Converse → SigV4-signed call to Bedrock → response translated back → analytics recorded. AWS credentials never leave AI Studio.

It follows the existing **translation-layer pattern** (sibling of the `/ai/` router), not the `/llm/` pass-through: a dedicated `anthropicRouter` outside `/llm/` middleware → `credValidator` → inline model validation → direct Bedrock SDK calls.

## What's covered

- **Text, tool-calling (multi-turn `tool_use` / `tool_result`), and system prompts** — mapped both ways between Anthropic content blocks and Converse content blocks.
- **Streaming** — Bedrock Converse events translated into the Anthropic SSE sequence (`message_start` → `content_block_start`/`delta`/`stop` → `message_delta` → `message_stop`), including `input_json_delta` for streamed tool arguments.
- **Prompt caching** — `cache_control` markers → Converse `cachePoint` blocks (message / system / tools); cache-token usage mapped back on responses + streaming (`cache_creation_input_tokens` / `cache_read_input_tokens`) and into analytics/metrics.
- **Auth** — App key via `x-api-key` **or** `Authorization: Bearer`.
- **Model resolution** — uses the LLM's `default_model` (a real Bedrock ID; Claude Code's own model name isn't one), validated against `allowed_models`.
- **Governance** — budget, response filters, and analytics (proxy log + chat record with token/cache-token counts and cost) applied consistently with the `/ai/` Bedrock path.

## Changes

| Area | File |
|---|---|
| Anthropic wire-format structs | `proxy/anthropic_messages_models.go` (new) |
| Anthropic ⇄ Converse converters | `vendors/bedrock/anthropic_converse.go` (new) |
| HTTP/SSE orchestration + entry handler | `proxy/anthropic_bedrock_translator.go` (new) |
| Routing (`anthropicRouter`, `combinedHandler` dispatch) | `proxy/proxy.go` |
| Auth (`anthropic` path case + `x-api-key` fallback) | `proxy/credential_validator.go` |
| Cache-token usage capture across all Bedrock paths | `proxy/bedrock_translator.go`, `proxy/bedrock_streaming.go` |

**Also included (bug found during testing):**
- **Credential-wipe fix** (`services/llm_service.go`): editing/saving an LLM was persisting the redacted `[redacted]` placeholder over real metadata credentials (broke Bedrock AWS keys). `UpdateLLM` now preserves the stored value for any metadata field submitted as `[redacted]`, mirroring the existing `api_key` handling.
- **UI**: an "Anthropic-Compatible Endpoint" card on an app's LLM Access Details, shown only for Bedrock LLMs (`ui/admin-frontend/src/portal/components/AppDetailView.js`).
 
<img width="2051" height="504" alt="image" src="https://github.com/user-attachments/assets/4caf97bc-705f-4726-8726-6be89c470fad" />


No changes to the LLM/App configuration schema.

## Testing

**Automated** (`go test ./proxy/... ./services/...` — green):
- Converters: text / `tool_use` / `tool_result` / system, cache-point insertion, `tool_choice`, stop-reason mapping, response mapping incl. cache-token usage.
- Streaming: synthetic Converse events → asserted Anthropic SSE sequence, tool-arg reconstruction from `input_json_delta`, cache-token usage on `message_delta`.
- Auth: `x-api-key` and `Bearer` both authenticate on `/anthropic/{routeId}/v1/messages`; invalid/missing → 401 (end-to-end through `createHandler`).
- Handler/governance branches: route-not-found (404), non-Bedrock vendor (400), invalid body (400), empty messages (400), model resolution (400/403).
- Credential-preserve regression test.

**Manual e2e**: ran a real Claude Code session against `/anthropic/<slug>` (streaming, multi-turn tool use — create/edit files, run tests). Verified streamed output, tool execution, and 16/16 requests logged + metered in AI Studio.

## Not covered / follow-ups

- The live AWS `Converse`/`ConverseStream` round-trip is exercised only by the manual e2e — `NewBedrockClient` returns a concrete `*bedrockruntime.Client` with no mockable interface (same limit as the existing `/ai/` Bedrock path).
- Live cache-**hit** behavior (repeat-prompt cache read) is verified manually; the cache-token **mapping** is unit-tested.
- **Out of scope**: image content blocks, `/v1/messages/count_tokens` (neither required for Claude Code).

## Reviewer notes — local test

```
make dev-full
# create a Bedrock LLM (endpoint region + AWS creds + a current default_model,
# e.g. an inference-profile ID) and an App with that LLM
ANTHROPIC_BASE_URL=http://localhost:9090/anthropic/<slug> \
ANTHROPIC_AUTH_TOKEN=<app-secret> \
claude
```

