### PR TITLE
Disambiguate catalogues/tags/sso-profiles/users summaries from Developer Portal's (DX-2380)

### DIFF
--- a/api/catalogue_handlers.go
+++ b/api/catalogue_handlers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// @Summary Create a new catalogue
+// @Summary Create a new LLM catalogue
 // @Description Create a new catalogue with the provided information
 // @Tags catalogues
 // @Accept json
@@ -86,7 +86,7 @@ func (a *API) getCatalogue(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeCatalogue(catalogue)})
 }
 
-// @Summary Update a catalogue
+// @Summary Update an LLM catalogue
 // @Description Update an existing catalogue's information
 // @Tags catalogues
 // @Accept json
@@ -135,7 +135,7 @@ func (a *API) updateCatalogue(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeCatalogue(catalogue)})
 }
 
-// @Summary Delete a catalogue
+// @Summary Delete an LLM catalogue
 // @Description Delete a catalogue by its ID
 // @Tags catalogues
 // @Accept json
@@ -184,7 +184,7 @@ func (a *API) deleteCatalogue(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// @Summary List all catalogues
+// @Summary List all LLM catalogues
 // @Description Get a list of all catalogues with their associated LLM names
 // @Tags catalogues
 // @Accept json

--- a/api/profile_handlers_enterprise.go
+++ b/api/profile_handlers_enterprise.go
@@ -148,7 +148,7 @@ func serializeProfiles(profiles models.Profiles) []ProfileListItem {
 	return result
 }
 
-// @Summary Create a new SSO profile
+// @Summary Create a new SSO profile (AI Studio)
 // @Description Create a new SSO profile with the provided information
 // @Tags sso-profiles
 // @Accept json
@@ -237,7 +237,7 @@ func (a *API) getProfile(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeProfile(profile)})
 }
 
-// @Summary Update an SSO profile
+// @Summary Update an SSO profile (AI Studio)
 // @Description Update an existing SSO profile's information
 // @Tags sso-profiles
 // @Accept json
@@ -302,7 +302,7 @@ func (a *API) updateProfile(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeProfile(profile)})
 }
 
-// @Summary Delete an SSO profile
+// @Summary Delete an SSO profile (AI Studio)
 // @Description Delete an SSO profile by its ID
 // @Tags sso-profiles
 // @Accept json
@@ -329,7 +329,7 @@ func (a *API) deleteProfile(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// @Summary List all SSO profiles
+// @Summary List all SSO profiles (AI Studio)
 // @Description Get a list of all SSO profiles with pagination
 // @Tags sso-profiles
 // @Accept json

--- a/api/tag_handlers.go
+++ b/api/tag_handlers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// @Summary Create a new tag
+// @Summary Create a new tag (AI Studio)
 // @Description Create a new tag with the provided information
 // @Tags tags
 // @Accept json
@@ -82,7 +82,7 @@ func (a *API) getTag(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeTag(tag)})
 }
 
-// @Summary Update a tag
+// @Summary Update a tag (AI Studio)
 // @Description Update an existing tag's information
 // @Tags tags
 // @Accept json
@@ -131,7 +131,7 @@ func (a *API) updateTag(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeTag(tag)})
 }
 
-// @Summary Delete a tag
+// @Summary Delete a tag (AI Studio)
 // @Description Delete a tag by its ID
 // @Tags tags
 // @Accept json
@@ -168,7 +168,7 @@ func (a *API) deleteTag(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// @Summary List all tags
+// @Summary List all tags (AI Studio)
 // @Description Get a list of all tags
 // @Tags tags
 // @Accept json

--- a/api/user_handlers.go
+++ b/api/user_handlers.go
@@ -41,7 +41,7 @@ func (a *API) validateUserInput(userInput UserInput, userId uint) error {
 	return nil
 }
 
-// @Summary Create a new user
+// @Summary Create a new user (AI Studio)
 // @Description Create a new user with the provided information
 // @Tags users
 // @Accept json
@@ -128,7 +128,7 @@ func (a *API) getUser(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeUser(user)})
 }
 
-// @Summary Update a user
+// @Summary Update a user (AI Studio)
 // @Description Update an existing user's information
 // @Tags users
 // @Accept json
@@ -193,7 +193,7 @@ func (a *API) updateUser(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeUser(updatedUser)})
 }
 
-// @Summary Delete a user
+// @Summary Delete a user (AI Studio)
 // @Description Delete a user by their ID
 // @Tags users
 // @Accept json

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -5378,7 +5378,7 @@ const docTemplate = `{
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "List all SSO profiles",
+                "summary": "List all SSO profiles (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -5436,7 +5436,7 @@ const docTemplate = `{
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Create a new SSO profile",
+                "summary": "Create a new SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "description": "Profile information",
@@ -5534,7 +5534,7 @@ const docTemplate = `{
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Update an SSO profile",
+                "summary": "Update an SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "type": "string",
@@ -5596,7 +5596,7 @@ const docTemplate = `{
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Delete an SSO profile",
+                "summary": "Delete an SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "type": "string",
@@ -7700,7 +7700,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "List all catalogues",
+                "summary": "List all LLM catalogues",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -7735,7 +7735,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Create a new catalogue",
+                "summary": "Create a new LLM catalogue",
                 "parameters": [
                     {
                         "description": "Catalogue information",
@@ -7937,7 +7937,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Delete a catalogue",
+                "summary": "Delete an LLM catalogue",
                 "parameters": [
                     {
                         "type": "integer",
@@ -7981,7 +7981,7 @@ const docTemplate = `{
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Update a catalogue",
+                "summary": "Update an LLM catalogue",
                 "parameters": [
                     {
                         "type": "integer",
@@ -15678,7 +15678,7 @@ const docTemplate = `{
                 "tags": [
                     "tags"
                 ],
-                "summary": "List all tags",
+                "summary": "List all tags (AI Studio)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -15713,7 +15713,7 @@ const docTemplate = `{
                 "tags": [
                     "tags"
                 ],
-                "summary": "Create a new tag",
+                "summary": "Create a new tag (AI Studio)",
                 "parameters": [
                     {
                         "description": "Tag information",
@@ -15863,7 +15863,7 @@ const docTemplate = `{
                 "tags": [
                     "tags"
                 ],
-                "summary": "Delete a tag",
+                "summary": "Delete a tag (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -15907,7 +15907,7 @@ const docTemplate = `{
                 "tags": [
                     "tags"
                 ],
-                "summary": "Update a tag",
+                "summary": "Update a tag (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -18032,7 +18032,7 @@ const docTemplate = `{
                 "tags": [
                     "users"
                 ],
-                "summary": "Create a new user",
+                "summary": "Create a new user (AI Studio)",
                 "parameters": [
                     {
                         "description": "User information",
@@ -18130,7 +18130,7 @@ const docTemplate = `{
                 "tags": [
                     "users"
                 ],
-                "summary": "Delete a user",
+                "summary": "Delete a user (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -18174,7 +18174,7 @@ const docTemplate = `{
                 "tags": [
                     "users"
                 ],
-                "summary": "Update a user",
+                "summary": "Update a user (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -19782,6 +19782,7 @@ const docTemplate = `{
                             "additionalProperties": true
                         },
                         "namespace": {
+                            "description": "Always \"default\" in CE",
                             "type": "string"
                         },
                         "session_id": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -5372,7 +5372,7 @@
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "List all SSO profiles",
+                "summary": "List all SSO profiles (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -5430,7 +5430,7 @@
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Create a new SSO profile",
+                "summary": "Create a new SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "description": "Profile information",
@@ -5528,7 +5528,7 @@
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Update an SSO profile",
+                "summary": "Update an SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "type": "string",
@@ -5590,7 +5590,7 @@
                 "tags": [
                     "sso-profiles"
                 ],
-                "summary": "Delete an SSO profile",
+                "summary": "Delete an SSO profile (AI Studio)",
                 "parameters": [
                     {
                         "type": "string",
@@ -7694,7 +7694,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "List all catalogues",
+                "summary": "List all LLM catalogues",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -7729,7 +7729,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Create a new catalogue",
+                "summary": "Create a new LLM catalogue",
                 "parameters": [
                     {
                         "description": "Catalogue information",
@@ -7931,7 +7931,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Delete a catalogue",
+                "summary": "Delete an LLM catalogue",
                 "parameters": [
                     {
                         "type": "integer",
@@ -7975,7 +7975,7 @@
                 "tags": [
                     "catalogues"
                 ],
-                "summary": "Update a catalogue",
+                "summary": "Update an LLM catalogue",
                 "parameters": [
                     {
                         "type": "integer",
@@ -15672,7 +15672,7 @@
                 "tags": [
                     "tags"
                 ],
-                "summary": "List all tags",
+                "summary": "List all tags (AI Studio)",
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -15707,7 +15707,7 @@
                 "tags": [
                     "tags"
                 ],
-                "summary": "Create a new tag",
+                "summary": "Create a new tag (AI Studio)",
                 "parameters": [
                     {
                         "description": "Tag information",
@@ -15857,7 +15857,7 @@
                 "tags": [
                     "tags"
                 ],
-                "summary": "Delete a tag",
+                "summary": "Delete a tag (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -15901,7 +15901,7 @@
                 "tags": [
                     "tags"
                 ],
-                "summary": "Update a tag",
+                "summary": "Update a tag (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -18026,7 +18026,7 @@
                 "tags": [
                     "users"
                 ],
-                "summary": "Create a new user",
+                "summary": "Create a new user (AI Studio)",
                 "parameters": [
                     {
                         "description": "User information",
@@ -18124,7 +18124,7 @@
                 "tags": [
                     "users"
                 ],
-                "summary": "Delete a user",
+                "summary": "Delete a user (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -18168,7 +18168,7 @@
                 "tags": [
                     "users"
                 ],
-                "summary": "Update a user",
+                "summary": "Update a user (AI Studio)",
                 "parameters": [
                     {
                         "type": "integer",
@@ -19776,6 +19776,7 @@
                             "additionalProperties": true
                         },
                         "namespace": {
+                            "description": "Always \"default\" in CE",
                             "type": "string"
                         },
                         "session_id": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -759,6 +759,7 @@ definitions:
             additionalProperties: true
             type: object
           namespace:
+            description: Always "default" in CE
             type: string
           session_id:
             type: string
@@ -6744,7 +6745,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: List all SSO profiles
+      summary: List all SSO profiles (AI Studio)
       tags:
       - sso-profiles
     post:
@@ -6775,7 +6776,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new SSO profile
+      summary: Create a new SSO profile (AI Studio)
       tags:
       - sso-profiles
   /api/v1/sso-profiles/{id}:
@@ -6808,7 +6809,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Delete an SSO profile
+      summary: Delete an SSO profile (AI Studio)
       tags:
       - sso-profiles
     get:
@@ -6878,7 +6879,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update an SSO profile
+      summary: Update an SSO profile (AI Studio)
       tags:
       - sso-profiles
   /api/v1/sso-profiles/{profile_id}/use-in-login-page:
@@ -8224,7 +8225,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: List all catalogues
+      summary: List all LLM catalogues
       tags:
       - catalogues
     post:
@@ -8255,7 +8256,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new catalogue
+      summary: Create a new LLM catalogue
       tags:
       - catalogues
   /catalogues/{id}:
@@ -8284,7 +8285,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Delete a catalogue
+      summary: Delete an LLM catalogue
       tags:
       - catalogues
     get:
@@ -8350,7 +8351,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update a catalogue
+      summary: Update an LLM catalogue
       tags:
       - catalogues
   /catalogues/{id}/llms:
@@ -13390,7 +13391,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: List all tags
+      summary: List all tags (AI Studio)
       tags:
       - tags
     post:
@@ -13421,7 +13422,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new tag
+      summary: Create a new tag (AI Studio)
       tags:
       - tags
   /tags/{id}:
@@ -13450,7 +13451,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Delete a tag
+      summary: Delete a tag (AI Studio)
       tags:
       - tags
     get:
@@ -13516,7 +13517,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update a tag
+      summary: Update a tag (AI Studio)
       tags:
       - tags
   /tags/search:
@@ -14922,7 +14923,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Create a new user
+      summary: Create a new user (AI Studio)
       tags:
       - users
   /users/{id}:
@@ -14951,7 +14952,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Delete a user
+      summary: Delete a user (AI Studio)
       tags:
       - users
     get:
@@ -15017,7 +15018,7 @@ paths:
             $ref: '#/definitions/api.ErrorResponse'
       security:
       - BearerAuth: []
-      summary: Update a user
+      summary: Update a user (AI Studio)
       tags:
       - users
   /users/{id}/catalogues:


### PR DESCRIPTION
## Summary

tyk-docs' OpenAPI page-slug collision check (DX-2380) flags 15 operations in this repo sharing an identical tag+summary with a Developer Portal (EDP) operation of the same generic CRUD name. Companion to [tyk-analytics#5976](https://github.com/TykTechnologies/tyk-analytics/pull/5976)/[#5977](https://github.com/TykTechnologies/tyk-analytics/pull/5977), [tyk#8492](https://github.com/TykTechnologies/tyk/pull/8492), [portal#1946](https://github.com/TykTechnologies/portal/pull/1946), and this repo's own [#385](https://github.com/TykTechnologies/ai-studio/pull/385) (which fixed 12 *within-ai-studio* CE/EE collisions - a different problem from the cross-product ones fixed here).

## Investigation

Read the actual Go implementations and response schemas for every pair, not just the summary text, before deciding what to do - three different outcomes fell out of that:

**catalogues (4 ops) - different domain objects, matched an existing internal convention instead of adding a suffix.** ai-studio's `Catalogue` is a named grouping of LLMs (`api.CatalogueResponse.attributes.llm_names`); EDP's is a curated grouping of API products/plans for portal consumers (`VisibilityStatus`, `OrgCatalogues`). ai-studio's own spec already disambiguates its two other catalogue-shaped tags this same way - `data-catalogues` says "data catalogue", `tool-catalogues` says "tool catalogue" - and this tag's own CE-stub description (`catalogue_handlers_community.go`) already says "LLM catalogue". Renamed to match: `Create/Update/Delete/List a(n) (new) catalogue` → `... LLM catalogue`.

**tags (4 ops) - different domain objects, no existing narrower term.** ai-studio's `Tag` labels AI resources (data/tool catalogues); EDP's labels portal blog posts and API products. No existing ai-studio vocabulary to borrow, so suffixed `(AI Studio)`.

**sso-profiles (4 ops) - confirmed the SAME underlying concept.** Both sides operate on Tyk Identity Broker profiles: `api/sso_handlers_enterprise.go` imports `tyk-identity-broker/error` directly, and EDP's `app/api/sso-profile.go` operates on `model/tib.Profile`. Response schemas match field-for-field (`ProviderName`, `IdentityHandlerConfig`, `UserGroupMapping`, etc., appear in both `api.ProfileResponse` and EDP's `SSOProfile-response`). Same capability just exposed per-product - suffixed `(AI Studio)`, no rewording needed since there's nothing to distinguish semantically.

**users (3 of the 4 grouped ops, ai-studio-vs-EDP leg only) - different domain objects.** ai-studio's `User` is an AI Studio platform account (`is_admin`, `show_chat`, `api_key`, `role`); EDP's is an organisation/team-scoped portal identity. No existing narrower term, suffixed `(AI Studio)`. `users/delete-a-user` is a 3-way collision (ai-studio + Dashboard + Developer Portal) - only this repo's leg is fixed here; the EDP leg is a separate fix in the Developer Portal repo, and Dashboard's leg is intentionally left bare per the same foundational/specialized ordering used throughout this effort.

## Fix

| Tag/slug | Old summary | New summary |
|---|---|---|
| catalogues/create-a-new-catalogue | Create a new catalogue | Create a new LLM catalogue |
| catalogues/update-a-catalogue | Update a catalogue | Update an LLM catalogue |
| catalogues/delete-a-catalogue | Delete a catalogue | Delete an LLM catalogue |
| catalogues/list-all-catalogues | List all catalogues | List all LLM catalogues |
| tags/create-a-new-tag | Create a new tag | Create a new tag (AI Studio) |
| tags/update-a-tag | Update a tag | Update a tag (AI Studio) |
| tags/delete-a-tag | Delete a tag | Delete a tag (AI Studio) |
| tags/list-all-tags | List all tags | List all tags (AI Studio) |
| sso-profiles/create-a-new-sso-profile | Create a new SSO profile | Create a new SSO profile (AI Studio) |
| sso-profiles/update-an-sso-profile | Update an SSO profile | Update an SSO profile (AI Studio) |
| sso-profiles/delete-an-sso-profile | Delete an SSO profile | Delete an SSO profile (AI Studio) |
| sso-profiles/list-all-sso-profiles | List all SSO profiles | List all SSO profiles (AI Studio) |
| users/create-a-new-user | Create a new user | Create a new user (AI Studio) |
| users/update-a-user | Update a user | Update a user (AI Studio) |
| users/delete-a-user | Delete a user | Delete a user (AI Studio) |

## Regeneration

Ran `swag init -g api/api.go -o docs/swagger` per the process established in #385. The diff also picked up one unrelated line (a struct field description added elsewhere in the codebase since the spec was last regenerated) and the usual non-deterministic `definitions:` key reordering - confirmed both are pre-existing drift, not caused by this change, same class of harmless regeneration noise #385 already documented. Also saw the same pre-existing `/common/tool-catalogues/{id}/tools declared multiple times` warning #385 noted as untouched/unrelated.

## Test plan

- [x] `gofmt -l` on all 4 changed Go files - no output (one pre-existing, unrelated formatting issue elsewhere in `catalogue_handlers.go` left untouched, not introduced by this change)
- [x] `swag init` completed without new errors
- [x] Confirmed all 15 target summaries now unique against both EDP's spec and this repo's other tags
- [ ] CI / swagger lint on this PR