### PR TITLE
fix: /ai/ shim sends the requested model upstream instead of always forcing DefaultModel

### DIFF
--- a/proxy/translator_model_selection_test.go
+++ b/proxy/translator_model_selection_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+// Tests for model selection on the OpenAI-compatible shim (/ai/{slug}/v1/chat/completions).
+//
+// Contract under test: the client-supplied "model" field (already validated against the
+// LLM config's AllowedModels before this point) must be the model sent upstream, with
+// the config's DefaultModel used only as a fallback when the request omits the field.
+//
+// The current implementation of ChatCompletionRequest.ToLangchainOptions discards the
+// request model on every non-Bedrock vendor (translator_models.go:83-98), so the
+// request-model-wins tests below fail until that is fixed. Both the streaming and
+// non-streaming shim handlers route through ToLangchainOptions, so this seam covers both.
+
+import (
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/tmc/langchaingo/llms"
+)
+
+// resolveModelOption applies the produced call options and returns the model that
+// would actually be sent to the upstream driver.
+func resolveModelOption(opts []llms.CallOption) string {
+	resolved := &llms.CallOptions{}
+	for _, opt := range opts {
+		opt(resolved)
+	}
+	return resolved.Model
+}
+
+func TestToLangchainOptions_RequestModelWins(t *testing.T) {
+	// The request model must win over DefaultModel for every vendor served by the
+	// shim's langchaingo path. (Bedrock branches off before ToLangchainOptions and
+	// already honors the request model — see bedrock_translator.go.)
+	tests := []struct {
+		name         string
+		vendor       models.Vendor
+		defaultModel string
+		requestModel string
+	}{
+		{"openai", models.OPENAI, "gpt-4", "gpt-4o-mini"},
+		{"anthropic", models.ANTHROPIC, "claude-3-opus-20240229", "claude-3-5-haiku-20241022"},
+		{"google_ai", models.GOOGLEAI, "gemini-1.5-pro", "gemini-1.5-flash"},
+		{"ollama", models.OLLAMA, "llama3", "mistral"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &models.LLM{
+				Vendor:       tt.vendor,
+				DefaultModel: tt.defaultModel,
+			}
+			req := &ChatCompletionRequest{Model: tt.requestModel}
+
+			model := resolveModelOption(req.ToLangchainOptions(conf))
+
+			assert.Equal(t, tt.requestModel, model,
+				"the model requested by the client must be sent upstream, not the config's DefaultModel")
+		})
+	}
+}
+
+func TestToLangchainOptions_DefaultModelIsFallbackOnly(t *testing.T) {
+	// When the request omits the model, DefaultModel applies.
+	tests := []struct {
+		name   string
+		vendor models.Vendor
+	}{
+		{"openai", models.OPENAI},
+		{"anthropic", models.ANTHROPIC},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &models.LLM{
+				Vendor:       tt.vendor,
+				DefaultModel: "configured-default",
+			}
+			req := &ChatCompletionRequest{Model: ""}
+
+			model := resolveModelOption(req.ToLangchainOptions(conf))
+
+			assert.Equal(t, "configured-default", model,
+				"DefaultModel must apply when the request does not name a model")
+		})
+	}
+}
+
+func TestToLangchainOptions_RequestModelUsedWhenNoDefault(t *testing.T) {
+	// A config with no DefaultModel must still pass the requested model upstream
+	// rather than sending no model option at all.
+	for _, vendor := range []models.Vendor{models.OPENAI, models.ANTHROPIC} {
+		t.Run(string(vendor), func(t *testing.T) {
+			conf := &models.LLM{Vendor: vendor, DefaultModel: ""}
+			req := &ChatCompletionRequest{Model: "requested-model"}
+
+			model := resolveModelOption(req.ToLangchainOptions(conf))
+
+			assert.Equal(t, "requested-model", model)
+		})
+	}
+}
+
+func TestToLangchainOptions_DoesNotMutateRequest(t *testing.T) {
+	// ToLangchainOptions must not overwrite req.Model: the handler later echoes
+	// req.Model back in the response body (translator.go NewChatCompletionResponse),
+	// so mutating it makes the response misreport which model served the request.
+	conf := &models.LLM{
+		Vendor:       models.OPENAI,
+		DefaultModel: "gpt-4",
+	}
+	req := &ChatCompletionRequest{Model: "gpt-4o-mini"}
+
+	req.ToLangchainOptions(conf)
+
+	assert.Equal(t, "gpt-4o-mini", req.Model,
+		"ToLangchainOptions must not mutate the request's model field")
+}
+
+func TestHandleOptions_LegacyCompletionsRespectsRequestModel(t *testing.T) {
+	// Regression guard: the legacy /ai/{slug}/v1/completions path already honors the
+	// request model (translator.go handleOptions). The chat completions path must
+	// behave the same way.
+	req := &CreateCompletionRequest{Model: "requested-model"}
+
+	model := resolveModelOption(handleOptions(req))
+
+	assert.Equal(t, "requested-model", model)
+}

--- a/proxy/translator_models.go
+++ b/proxy/translator_models.go
@@ -83,18 +83,16 @@ func (t Tool) ToLangchainTool() llms.Tool {
 func (r *ChatCompletionRequest) ToLangchainOptions(conf *models.LLM) []llms.CallOption {
 	options := make([]llms.CallOption, 0)
 
-	// OpenAI interface can state model, but upstream might be different
-	if conf.Vendor != models.OPENAI {
-		// force model if not OpenAI upstream
-		if conf.DefaultModel != "" {
-			options = append(options, llms.WithModel(conf.DefaultModel))
-		}
-	} else {
-		// it's OpenAI, so we can use the model from the request
-		r.Model = conf.DefaultModel
-		if r.Model != "" {
-			options = append(options, llms.WithModel(r.Model))
-		}
+	// The request model has already been validated against the config's
+	// AllowedModels by the shim handler, so it wins; DefaultModel is only a
+	// fallback when the request omits the field. Do not mutate r.Model - the
+	// handler echoes it back in the response body.
+	model := r.Model
+	if model == "" {
+		model = conf.DefaultModel
+	}
+	if model != "" {
+		options = append(options, llms.WithModel(model))
 	}
 
 	if r.MaxCompletionTokens != nil {

--- a/proxy/translator_models_test.go
+++ b/proxy/translator_models_test.go
@@ -207,18 +207,18 @@ func TestChatCompletionRequest_ToLangchainOptions(t *testing.T) {
 		assert.NotNil(t, opts)
 	})
 
-	t.Run("Non-OpenAI vendor uses default model", func(t *testing.T) {
+	t.Run("Non-OpenAI vendor respects request model", func(t *testing.T) {
 		anthropicConfig := &models.LLM{
 			Vendor:       models.ANTHROPIC,
 			DefaultModel: "claude-3",
 		}
 
 		req := &ChatCompletionRequest{
-			Model: "gpt-4", // This should be ignored for non-OpenAI
+			Model: "claude-3-5-haiku-20241022",
 		}
 
 		opts := req.ToLangchainOptions(anthropicConfig)
-		assert.NotNil(t, opts)
+		assert.Equal(t, "claude-3-5-haiku-20241022", resolveModelOption(opts))
 	})
 }
 


### PR DESCRIPTION
## Problem

The OpenAI-compatible shim (`POST /ai/{slug}/v1/chat/completions`) validates the request's `model` field against the LLM config's `AllowedModels` — then silently discards it:

- **Non-OpenAI vendors** (Anthropic, Gemini, Ollama, …): `DefaultModel` was always forced; the request model was never read. With no `DefaultModel` set, no model option was sent at all.
- **OpenAI vendor**: `req.Model` was overwritten with `DefaultModel` outright — despite the code comment saying the request model would be used.
- Because the handler echoes `req.Model` back in the response body, and that field was mutated, **the response misreported which model actually served the request** — clients had no way to detect the substitution.
- Both streaming and non-streaming paths were affected (both route through `ToLangchainOptions`).
- Side effect: the Model Router's per-vendor model mappings were a no-op for any non-Bedrock target LLM with a `DefaultModel` set, since the mapped model got clobbered on the `/ai/` hop.

Bedrock branches off before this code and already honored the request model; the legacy `/v1/completions` path was also already correct.

## Fix

Collapse the vendor split in `ToLangchainOptions` into a single rule: **the request model wins** (it is already allow-list-validated by the handler), `DefaultModel` applies only when the request omits the field, and `req.Model` is never mutated — so the response now truthfully reports the serving model.

## Tests

- New suite `proxy/translator_model_selection_test.go` committed first (red) to document the bug, then made green by the fix: request-model-wins across `openai`/`anthropic`/`google_ai`/`ollama`, default-as-fallback-only, model used when no default is configured, no request mutation, and a regression guard on the legacy completions path.
- Tightened the stale test "Non-OpenAI vendor uses default model" (only asserted `opts != nil`) into "Non-OpenAI vendor respects request model" with a real assertion.
- Full `proxy` package suite and microgateway `internal/services` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)