### PR TITLE
fix: prevent SQL injection via PGVector metadata filter keys (#392)

### DIFF
--- a/data_session/metadata_operations.go
+++ b/data_session/metadata_operations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"regexp"
 	"strings"
 
 	chromago "github.com/amikos-tech/chroma-go/pkg/api/v2"
@@ -657,9 +658,15 @@ func (ds *DataSession) deletePGVectorByMetadata(ctx context.Context, d *models.D
 	}
 
 	tableName := d.DBName
+	if err := validatePGTableName(tableName); err != nil {
+		return 0, err
+	}
 
 	// Build WHERE clause from metadata filter
-	whereClause, args := ds.buildPGVectorWhereClause(filter, filterMode)
+	whereClause, args, err := ds.buildPGVectorWhereClause(filter, filterMode)
+	if err != nil {
+		return 0, err
+	}
 
 	if dryRun {
 		// Count matching documents
@@ -699,9 +706,15 @@ func (ds *DataSession) queryPGVectorByMetadata(ctx context.Context, d *models.Da
 	}
 
 	tableName := d.DBName
+	if err := validatePGTableName(tableName); err != nil {
+		return nil, 0, err
+	}
 
 	// Build WHERE clause
-	whereClause, args := ds.buildPGVectorWhereClause(filter, filterMode)
+	whereClause, args, err := ds.buildPGVectorWhereClause(filter, filterMode)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	// Get total count
 	var totalCount int64
@@ -820,6 +833,10 @@ func (ds *DataSession) deletePGVectorTable(ctx context.Context, d *models.Dataso
 		return fmt.Errorf("failed to connect to postgres: %w", err)
 	}
 
+	if err := validatePGTableName(namespace); err != nil {
+		return err
+	}
+
 	// Drop the table (with CASCADE to remove dependencies)
 	query := fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", namespace)
 	err = db.Exec(query).Error
@@ -831,10 +848,49 @@ func (ds *DataSession) deletePGVectorTable(ctx context.Context, d *models.Dataso
 	return nil
 }
 
+// metadataFilterKeyPattern restricts metadata filter keys to a safe identifier
+// character set so they can be interpolated into a quoted SQL literal without
+// risk of injection (no quotes, backslashes, or SQL metacharacters).
+var metadataFilterKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,128}$`)
+
+// pgIdentifierPattern matches a single unquoted PostgreSQL identifier
+// (letters, digits, underscore; must not start with a digit; max 63 bytes).
+var pgIdentifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`)
+
+// validateMetadataFilterKey rejects metadata filter keys that contain
+// characters outside a safe allowlist. Filter keys arrive from gRPC clients
+// and are interpolated into SQL, so anything beyond alphanumerics,
+// underscore, dot, and dash is refused.
+func validateMetadataFilterKey(key string) error {
+	if !metadataFilterKeyPattern.MatchString(key) {
+		return fmt.Errorf("invalid metadata filter key %q: keys must match %s", key, metadataFilterKeyPattern.String())
+	}
+	return nil
+}
+
+// validatePGTableName rejects table names that are not plain (optionally
+// schema-qualified) PostgreSQL identifiers, preventing SQL injection via the
+// datasource table name.
+func validatePGTableName(name string) error {
+	if name == "" {
+		return fmt.Errorf("table name cannot be empty")
+	}
+	parts := strings.Split(name, ".")
+	if len(parts) > 2 {
+		return fmt.Errorf("invalid table name %q: expected [schema.]table", name)
+	}
+	for _, part := range parts {
+		if !pgIdentifierPattern.MatchString(part) {
+			return fmt.Errorf("invalid table name %q: identifiers must match %s", name, pgIdentifierPattern.String())
+		}
+	}
+	return nil
+}
+
 // buildPGVectorWhereClause builds a PostgreSQL WHERE clause for JSON metadata filtering
-func (ds *DataSession) buildPGVectorWhereClause(filter map[string]string, filterMode string) (string, []interface{}) {
+func (ds *DataSession) buildPGVectorWhereClause(filter map[string]string, filterMode string) (string, []interface{}, error) {
 	if len(filter) == 0 {
-		return "1=1", []interface{}{}
+		return "1=1", []interface{}{}, nil
 	}
 
 	var clauses []string
@@ -842,6 +898,9 @@ func (ds *DataSession) buildPGVectorWhereClause(filter map[string]string, filter
 	argIndex := 1
 
 	for key, value := range filter {
+		if err := validateMetadataFilterKey(key); err != nil {
+			return "", nil, err
+		}
 		// Use JSON operators to query metadata column
 		// metadata->>'key' = value
 		clause := fmt.Sprintf("metadata->>'%s' = $%d", key, argIndex)
@@ -856,7 +915,7 @@ func (ds *DataSession) buildPGVectorWhereClause(filter map[string]string, filter
 		operator = " OR "
 	}
 
-	return strings.Join(clauses, operator), args
+	return strings.Join(clauses, operator), args, nil
 }
 
 // Weaviate implementations

--- a/data_session/metadata_operations_test.go
+++ b/data_session/metadata_operations_test.go
@@ -1,0 +1,136 @@
+package data_session
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateMetadataFilterKey(t *testing.T) {
+	valid := []string{
+		"source",
+		"file_name",
+		"chunk-id",
+		"doc.section",
+		"Key123",
+		"_internal",
+	}
+	for _, key := range valid {
+		if err := validateMetadataFilterKey(key); err != nil {
+			t.Errorf("expected key %q to be valid, got error: %v", key, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"a' = '' OR '1'='1",
+		"key'; DROP TABLE users; --",
+		"key\\",
+		"key with spaces",
+		"key\"quoted",
+		"key$1",
+		"key;",
+		"key(",
+		strings.Repeat("a", 129), // too long
+	}
+	for _, key := range invalid {
+		if err := validateMetadataFilterKey(key); err == nil {
+			t.Errorf("expected key %q to be rejected", key)
+		}
+	}
+}
+
+func TestValidatePGTableName(t *testing.T) {
+	valid := []string{
+		"documents",
+		"my_table",
+		"MyTable2",
+		"_private",
+		"public.documents",
+		"myschema.my_table",
+	}
+	for _, name := range valid {
+		if err := validatePGTableName(name); err != nil {
+			t.Errorf("expected table name %q to be valid, got error: %v", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"1table",              // cannot start with digit
+		"table; DROP TABLE x", // injection
+		"table name",          // space
+		"table\"name",         // quote
+		"table'name",          // quote
+		"a.b.c",               // too many qualifiers
+		"schema.",             // empty part
+		".table",              // empty part
+		strings.Repeat("a", 64), // exceeds postgres identifier limit
+	}
+	for _, name := range invalid {
+		if err := validatePGTableName(name); err == nil {
+			t.Errorf("expected table name %q to be rejected", name)
+		}
+	}
+}
+
+func TestBuildPGVectorWhereClause(t *testing.T) {
+	ds := &DataSession{}
+
+	t.Run("empty filter", func(t *testing.T) {
+		clause, args, err := ds.buildPGVectorWhereClause(map[string]string{}, "AND")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if clause != "1=1" {
+			t.Errorf("expected clause '1=1', got %q", clause)
+		}
+		if len(args) != 0 {
+			t.Errorf("expected no args, got %v", args)
+		}
+	})
+
+	t.Run("single key", func(t *testing.T) {
+		clause, args, err := ds.buildPGVectorWhereClause(map[string]string{"source": "doc.pdf"}, "AND")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if clause != "metadata->>'source' = $1" {
+			t.Errorf("unexpected clause: %q", clause)
+		}
+		if len(args) != 1 || args[0] != "doc.pdf" {
+			t.Errorf("unexpected args: %v", args)
+		}
+	})
+
+	t.Run("multiple keys OR", func(t *testing.T) {
+		clause, args, err := ds.buildPGVectorWhereClause(map[string]string{"a": "1", "b": "2"}, "OR")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(clause, " OR ") {
+			t.Errorf("expected OR operator in clause: %q", clause)
+		}
+		if len(args) != 2 {
+			t.Errorf("expected 2 args, got %v", args)
+		}
+	})
+
+	t.Run("malicious key is rejected", func(t *testing.T) {
+		mal := "x' = '' OR '1'='1"
+		_, _, err := ds.buildPGVectorWhereClause(map[string]string{mal: "v"}, "AND")
+		if err == nil {
+			t.Fatal("expected error for malicious filter key, got nil")
+		}
+	})
+
+	t.Run("malicious key never reaches SQL", func(t *testing.T) {
+		mal := "x'; DELETE FROM t; --"
+		clause, _, err := ds.buildPGVectorWhereClause(map[string]string{"ok": "v", mal: "v"}, "AND")
+		if err == nil && strings.Contains(clause, "DELETE") {
+			t.Fatalf("malicious key was interpolated into SQL: %q", clause)
+		}
+		if err == nil {
+			t.Fatal("expected error for malicious filter key, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes #392 (Critical)
- Metadata filter **keys** from gRPC clients (`MetadataFilter` → `services/grpc/datasources_server.go` → `deletePGVectorByMetadata` / `queryPGVectorByMetadata`) were interpolated directly into SQL; only values were parameterized.
- `buildPGVectorWhereClause` now validates every filter key against a strict allowlist (`^[a-zA-Z0-9_.-]{1,128}$`) and returns an error on violation — malicious keys never reach the SQL string.
- Table names (`d.DBName` in COUNT/DELETE/SELECT, and `namespace` in `deletePGVectorTable`'s DROP TABLE) are now validated as plain, optionally schema-qualified PostgreSQL identifiers (`^[a-zA-Z_][a-zA-Z0-9_]{0,62}$`).

## Testing
- Test-first: added `data_session/metadata_operations_test.go` covering valid/invalid keys, valid/invalid table names, clause construction (AND/OR, parameter ordering), and injection payloads being rejected before SQL construction.
- `go test ./data_session/` passes; `go build` on all dependent packages (`services/...`, `api/...`, `proxy/...`) passes.
- Public API signatures (`DeleteDocumentsByMetadata`, `QueryByMetadataOnly`, `DeleteNamespace`) are unchanged; invalid input now returns an error instead of reaching the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)