### PR TITLE
[stack 1/3] fix: secrets decrypt path no longer panics on malformed input (#395)

### DIFF
--- a/secrets/models.go
+++ b/secrets/models.go
@@ -76,20 +76,25 @@ func encrypt(keyString string, stringToEncrypt string) (encryptedString string, 
 	return base64.URLEncoding.EncodeToString(ciphertext), nil
 }
 
-// decrypt from base64 to decrypted string
-func decrypt(keyString string, stringToDecrypt string) string {
+// decrypt from base64 to decrypted string. Malformed input (bad base64,
+// truncated ciphertext) is reported as an error rather than a panic, since
+// stored values can be tampered with or truncated outside our control.
+func decrypt(keyString string, stringToDecrypt string) (string, error) {
 	key := deriveKey(keyString)
-	ciphertext, _ := base64.URLEncoding.DecodeString(stringToDecrypt)
+	ciphertext, err := base64.URLEncoding.DecodeString(stringToDecrypt)
+	if err != nil {
+		return "", fmt.Errorf("failed to base64-decode ciphertext: %w", err)
+	}
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("failed to create cipher: %w", err)
 	}
 
 	// The IV needs to be unique, but not secure. Therefore it's common to
 	// include it at the beginning of the ciphertext.
 	if len(ciphertext) < aes.BlockSize {
-		panic("ciphertext too short")
+		return "", fmt.Errorf("ciphertext too short: %d bytes", len(ciphertext))
 	}
 	iv := ciphertext[:aes.BlockSize]
 	ciphertext = ciphertext[aes.BlockSize:]
@@ -99,7 +104,7 @@ func decrypt(keyString string, stringToDecrypt string) string {
 	// XORKeyStream can work in-place if the two arguments are the same.
 	stream.XORKeyStream(ciphertext, ciphertext)
 
-	return fmt.Sprintf("%s", ciphertext)
+	return string(ciphertext), nil
 }
 
 // EncryptValue encrypts a plaintext string using the application's AES key.
@@ -130,7 +135,12 @@ func DecryptValue(value string) string {
 		return value // No key to decrypt with
 	}
 	encrypted := strings.TrimPrefix(value, "$ENC/")
-	return decrypt(key, encrypted)
+	decrypted, err := decrypt(key, encrypted)
+	if err != nil {
+		log.Errorf("failed to decrypt stored value: %v", err)
+		return value // Return stored value untouched rather than crashing
+	}
+	return decrypted
 }
 
 // GetSecretByID retrieves a Secret record from the database by ID.
@@ -147,7 +157,11 @@ func GetSecretByID(db *gorm.DB, id uint, preserveRef bool) (*Secret, error) {
 	}
 
 	key := os.Getenv(midsommarSecret)
-	settings.Value = decrypt(key, settings.Value)
+	decrypted, err := decrypt(key, settings.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt secret %d: %w", settings.ID, err)
+	}
+	settings.Value = decrypted
 	return &settings, nil
 }
 
@@ -165,7 +179,11 @@ func GetSecretByVarName(db *gorm.DB, name string, preserveRef bool) (*Secret, er
 	}
 
 	key := os.Getenv(midsommarSecret)
-	settings.Value = decrypt(key, settings.Value)
+	decrypted, err := decrypt(key, settings.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt secret %q: %w", settings.VarName, err)
+	}
+	settings.Value = decrypted
 	return &settings, nil
 }
 

--- a/secrets/models_test.go
+++ b/secrets/models_test.go
@@ -100,13 +100,14 @@ func TestEncryptDecrypt(t *testing.T) {
 			assert.NotEqual(t, tt.value, encrypted, "encrypted value should be different from original")
 
 			// Test decryption
-			decrypted := decrypt(tt.key, encrypted)
+			decrypted, err := decrypt(tt.key, encrypted)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.value, decrypted, "decrypted value should match original")
 
 			// Test that different keys produce different results, except for empty values
 			if tt.value != "" {
 				differentKey := tt.key + "-different"
-				differentDecrypted := decrypt(differentKey, encrypted)
+				differentDecrypted, _ := decrypt(differentKey, encrypted)
 				assert.NotEqual(t, tt.value, differentDecrypted, "decryption with wrong key should not match original")
 			}
 		})

--- a/secrets/no_panic_test.go
+++ b/secrets/no_panic_test.go
@@ -1,0 +1,63 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Issue #395: malformed or truncated encrypted values must surface as errors,
+// never as a panic that takes down the process.
+
+func TestDecryptMalformedInputReturnsError(t *testing.T) {
+	tests := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "empty ciphertext", key: "my-key", value: ""},
+		{name: "ciphertext shorter than block size", key: "my-key", value: "YWJj"}, // "abc" base64
+		{name: "invalid base64", key: "my-key", value: "!!!not-base64!!!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				_, err := decrypt(tt.key, tt.value)
+				assert.Error(t, err, "malformed ciphertext should return an error")
+			})
+		})
+	}
+}
+
+func TestDecryptValueMalformedReturnsOriginal(t *testing.T) {
+	t.Setenv(midsommarSecret, "test-key")
+
+	// A "$ENC/" prefixed value whose payload is garbage must not panic and
+	// must fall back to returning the stored value untouched.
+	malformed := "$ENC/YWJj"
+	assert.NotPanics(t, func() {
+		got := DecryptValue(malformed)
+		assert.Equal(t, malformed, got)
+	})
+}
+
+func TestDecryptValueRoundTrip(t *testing.T) {
+	t.Setenv(midsommarSecret, "test-key")
+
+	enc := EncryptValue("super-secret")
+	assert.NotEqual(t, "super-secret", enc)
+	assert.Equal(t, "super-secret", DecryptValue(enc))
+}
+
+func TestFilterSesitiveFieldsArrNonSliceDoesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		got := FilterSesitiveFieldsArr("not-a-slice")
+		assert.Equal(t, "not-a-slice", got)
+	})
+
+	assert.NotPanics(t, func() {
+		got := FilterSesitiveFieldsArr(42)
+		assert.Equal(t, 42, got)
+	})
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -109,7 +109,8 @@ func FilterSensitiveFields(obj interface{}) interface{} {
 func FilterSesitiveFieldsArr(in interface{}) interface{} {
 	s := reflect.ValueOf(in)
 	if s.Kind() != reflect.Slice {
-		panic("given a non-slice type")
+		log.Printf("FilterSesitiveFieldsArr: given a non-slice type %T, returning input unchanged", in)
+		return in
 	}
 
 	if s.Len() == 0 {


### PR DESCRIPTION
## Summary
- Fixes #395 (High)
- `decrypt` now returns `(string, error)` instead of panicking on bad base64, cipher-creation failure, or ciphertext shorter than the AES block size — previously a tampered/truncated stored value could take down the whole process via a normal read request.
- Callers updated: `DecryptValue` logs the failure and returns the stored value untouched; `GetSecretByID`/`GetSecretByVarName` propagate the error to their callers (which already handle errors); `FilterSesitiveFieldsArr` logs and returns its input unchanged instead of panicking on non-slice input.
- Also fixes the previously ignored base64 decode error in `decrypt`.

## Testing
- Test-first: added `secrets/no_panic_test.go` — asserts no panic and proper error/fallback behavior for truncated ciphertext, invalid base64, malformed `$ENC/` values, and non-slice input to `FilterSesitiveFieldsArr`; plus a round-trip regression test for `EncryptValue`/`DecryptValue`.
- Existing `secrets` tests updated for the new signature; `go test ./secrets/` passes and the full module builds.

## Note
Part of a stacked series on the secrets package: #395 (this) → #394 → #393. Merge in that order to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)