### PR TITLE
fix: path validation for plugin binary execution (#397)

### DIFF
--- a/pkg/ociplugins/verifier.go
+++ b/pkg/ociplugins/verifier.go
@@ -23,12 +23,31 @@ func NewSignatureVerifier(config *OCIConfig) (*SignatureVerifier, error) {
 	}, nil
 }
 
+// validateCosignArg rejects values that would be interpreted by the cosign
+// subprocess as flags rather than positional arguments (argument injection).
+func validateCosignArg(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("cosign argument %s is empty", name)
+	}
+	if strings.HasPrefix(value, "-") {
+		return fmt.Errorf("invalid cosign argument %s: %q must not start with '-'", name, value)
+	}
+	return nil
+}
+
 // Verify checks the cosign signature of an OCI artifact using cosign CLI
 func (v *SignatureVerifier) Verify(ctx context.Context, ref *OCIReference, pubKeyID string) error {
 	// Get public key path for verification
 	pubKeyPath, err := v.getPublicKeyPath(pubKeyID)
 	if err != nil {
 		return fmt.Errorf("failed to get public key path: %w", err)
+	}
+
+	if err := validateCosignArg("public key path", pubKeyPath); err != nil {
+		return err
+	}
+	if err := validateCosignArg("reference", ref.FullReference()); err != nil {
+		return err
 	}
 
 	// Build cosign verify command
@@ -183,6 +202,10 @@ func isAlphaNumeric(s string) bool {
 
 // VerifyBundle verifies a signature bundle for keyless signing
 func (v *SignatureVerifier) VerifyBundle(ctx context.Context, ref *OCIReference, issuer, subject string) error {
+	if err := validateCosignArg("reference", ref.FullReference()); err != nil {
+		return err
+	}
+
 	// Build cosign verify command for keyless verification
 	// cosign verify --certificate-identity=<subject> --certificate-oidc-issuer=<issuer> <ref>
 	args := []string{
@@ -208,6 +231,13 @@ func (v *SignatureVerifier) VerifyBundle(ctx context.Context, ref *OCIReference,
 
 // VerifyWithPolicy verifies a signature using a policy file
 func (v *SignatureVerifier) VerifyWithPolicy(ctx context.Context, ref *OCIReference, policyPath string) error {
+	if err := validateCosignArg("policy path", policyPath); err != nil {
+		return err
+	}
+	if err := validateCosignArg("reference", ref.FullReference()); err != nil {
+		return err
+	}
+
 	// Build cosign verify command with policy
 	// cosign verify --policy=<policy> <ref>
 	cmd := exec.CommandContext(ctx, "cosign", "verify", "--policy", policyPath, ref.FullReference())

--- a/pkg/ociplugins/verifier_args_test.go
+++ b/pkg/ociplugins/verifier_args_test.go
@@ -1,0 +1,51 @@
+package ociplugins
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Issue #397: values passed as positional arguments to the cosign subprocess
+// must not be interpretable as flags (argument injection).
+
+func TestValidateCosignArg(t *testing.T) {
+	valid := []string{
+		"registry.example.com/repo@sha256:abc",
+		"/tmp/policy.yaml",
+		"relative/path.pub",
+	}
+	for _, v := range valid {
+		if err := validateCosignArg("test", v); err != nil {
+			t.Errorf("expected %q to be accepted, got: %v", v, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"-o=/etc/passwd",
+		"--policy=evil",
+		"-",
+	}
+	for _, v := range invalid {
+		if err := validateCosignArg("test", v); err == nil {
+			t.Errorf("expected %q to be rejected", v)
+		}
+	}
+}
+
+func TestVerifyWithPolicyRejectsFlagLikePolicyPath(t *testing.T) {
+	v, err := NewSignatureVerifier(&OCIConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := &OCIReference{Registry: "registry.example.com", Repository: "repo", Tag: "v1"}
+	err = v.VerifyWithPolicy(context.Background(), ref, "--output=/tmp/x")
+	if err == nil {
+		t.Fatal("expected error for flag-like policy path")
+	}
+	if !strings.Contains(err.Error(), "argument") {
+		t.Fatalf("expected argument-validation error, got: %v", err)
+	}
+}

--- a/services/ai_studio_plugin_manager.go
+++ b/services/ai_studio_plugin_manager.go
@@ -1439,6 +1439,11 @@ func (m *AIStudioPluginManager) createLocalPluginClient(command string) (*goplug
 		cmdPath = strings.TrimPrefix(command, "file://")
 	}
 
+	cmdPath, err := validatePluginExecutablePath(cmdPath)
+	if err != nil {
+		return nil, fmt.Errorf("plugin executable validation failed: %w", err)
+	}
+
 	log.Debug().
 		Str("command", command).
 		Str("path", cmdPath).
@@ -1526,6 +1531,11 @@ func (m *AIStudioPluginManager) createConfigOnlyLocalPluginClient(command string
 	cmdPath := command
 	if strings.HasPrefix(command, "file://") {
 		cmdPath = strings.TrimPrefix(command, "file://")
+	}
+
+	cmdPath, err := validatePluginExecutablePath(cmdPath)
+	if err != nil {
+		return nil, fmt.Errorf("plugin executable validation failed: %w", err)
 	}
 
 	log.Debug().

--- a/services/plugin_path_validation.go
+++ b/services/plugin_path_validation.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// pluginAllowedDirsEnv lists directories (separated by os.PathListSeparator)
+// that local plugin executables may be launched from. When set, any plugin
+// command resolving outside these directories is refused. When unset, plugins
+// may run from any location (backwards compatible), but paths are still
+// checked for traversal sequences and basic executable sanity.
+const pluginAllowedDirsEnv = "AI_STUDIO_PLUGIN_ALLOWED_DIRS"
+
+// validatePluginExecutablePath validates a local plugin executable path
+// before it is handed to exec.Command. It returns the validated path or an
+// error when the path is empty, contains traversal segments, does not point
+// at a regular executable file, or (when AI_STUDIO_PLUGIN_ALLOWED_DIRS is
+// set) resolves outside the allowlisted plugin directories, including via
+// symlinks.
+func validatePluginExecutablePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("plugin executable path is empty")
+	}
+
+	// Reject traversal sequences outright — plugin commands are stored
+	// configuration and have no legitimate need for "..".
+	for _, seg := range strings.Split(filepath.ToSlash(path), "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("plugin executable path %q contains a path traversal segment", path)
+		}
+	}
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve plugin executable path %q: %w", path, err)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", fmt.Errorf("plugin executable %q is not accessible: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("plugin executable %q is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		return "", fmt.Errorf("plugin executable %q is not executable", path)
+	}
+
+	allowedDirs := os.Getenv(pluginAllowedDirsEnv)
+	if allowedDirs == "" {
+		log.Debug().
+			Str("path", abs).
+			Msgf("%s not set — plugin executable location is not scope-restricted", pluginAllowedDirsEnv)
+		return path, nil
+	}
+
+	// Resolve symlinks so a link inside an allowed directory cannot point at
+	// a binary outside it.
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks for plugin executable %q: %w", path, err)
+	}
+
+	for _, dir := range filepath.SplitList(allowedDirs) {
+		if dir == "" {
+			continue
+		}
+		dirAbs, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		dirResolved, err := filepath.EvalSymlinks(dirAbs)
+		if err != nil {
+			continue
+		}
+		rel, err := filepath.Rel(dirResolved, resolved)
+		if err != nil {
+			continue
+		}
+		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("plugin executable %q is outside the allowed plugin directories (%s=%s)", path, pluginAllowedDirsEnv, allowedDirs)
+}

--- a/services/plugin_path_validation.go
+++ b/services/plugin_path_validation.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -17,11 +18,17 @@ import (
 const pluginAllowedDirsEnv = "AI_STUDIO_PLUGIN_ALLOWED_DIRS"
 
 // validatePluginExecutablePath validates a local plugin executable path
-// before it is handed to exec.Command. It returns the validated path or an
-// error when the path is empty, contains traversal segments, does not point
-// at a regular executable file, or (when AI_STUDIO_PLUGIN_ALLOWED_DIRS is
-// set) resolves outside the allowlisted plugin directories, including via
-// symlinks.
+// before it is handed to exec.Command, and returns the fully resolved
+// absolute path that was validated. Callers MUST execute the returned path —
+// not the original input — so that the binary that runs is exactly the one
+// that was checked (no PATH-vs-cwd or symlink discrepancy).
+//
+// Bare command names (no path separator) are resolved through PATH via
+// exec.LookPath, matching exec.Command semantics. Symlinks are always
+// resolved before validation. It returns an error when the path is empty,
+// contains traversal segments, does not point at a regular executable file,
+// or (when AI_STUDIO_PLUGIN_ALLOWED_DIRS is set) resolves outside the
+// allowlisted plugin directories.
 func validatePluginExecutablePath(path string) (string, error) {
 	if path == "" {
 		return "", fmt.Errorf("plugin executable path is empty")
@@ -35,12 +42,28 @@ func validatePluginExecutablePath(path string) (string, error) {
 		}
 	}
 
-	abs, err := filepath.Abs(path)
+	// Resolve the path the same way exec.Command would: bare names go
+	// through PATH, everything else is relative to the working directory.
+	abs := path
+	if !strings.ContainsRune(path, os.PathSeparator) {
+		found, err := exec.LookPath(path)
+		if err != nil {
+			return "", fmt.Errorf("plugin executable %q not found in PATH: %w", path, err)
+		}
+		abs = found
+	}
+	abs, err := filepath.Abs(abs)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve plugin executable path %q: %w", path, err)
 	}
 
-	info, err := os.Stat(abs)
+	// Follow symlinks so the path we validate is the file that will run.
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks for plugin executable %q: %w", path, err)
+	}
+
+	info, err := os.Stat(resolved)
 	if err != nil {
 		return "", fmt.Errorf("plugin executable %q is not accessible: %w", path, err)
 	}
@@ -54,16 +77,9 @@ func validatePluginExecutablePath(path string) (string, error) {
 	allowedDirs := os.Getenv(pluginAllowedDirsEnv)
 	if allowedDirs == "" {
 		log.Debug().
-			Str("path", abs).
+			Str("path", resolved).
 			Msgf("%s not set — plugin executable location is not scope-restricted", pluginAllowedDirsEnv)
-		return path, nil
-	}
-
-	// Resolve symlinks so a link inside an allowed directory cannot point at
-	// a binary outside it.
-	resolved, err := filepath.EvalSymlinks(abs)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve symlinks for plugin executable %q: %w", path, err)
+		return resolved, nil
 	}
 
 	for _, dir := range filepath.SplitList(allowedDirs) {
@@ -72,10 +88,12 @@ func validatePluginExecutablePath(path string) (string, error) {
 		}
 		dirAbs, err := filepath.Abs(dir)
 		if err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msgf("ignoring unresolvable entry in %s", pluginAllowedDirsEnv)
 			continue
 		}
 		dirResolved, err := filepath.EvalSymlinks(dirAbs)
 		if err != nil {
+			log.Warn().Err(err).Str("dir", dir).Msgf("ignoring inaccessible entry in %s", pluginAllowedDirsEnv)
 			continue
 		}
 		rel, err := filepath.Rel(dirResolved, resolved)
@@ -83,7 +101,7 @@ func validatePluginExecutablePath(path string) (string, error) {
 			continue
 		}
 		if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return path, nil
+			return resolved, nil
 		}
 	}
 

--- a/services/plugin_path_validation_test.go
+++ b/services/plugin_path_validation_test.go
@@ -26,10 +26,28 @@ func TestValidatePluginExecutablePathBasics(t *testing.T) {
 	dir := t.TempDir()
 	exe := writeExecutable(t, dir, "plugin-bin")
 
-	t.Run("valid executable passes", func(t *testing.T) {
+	t.Run("valid executable passes and returns the resolved path", func(t *testing.T) {
 		got, err := validatePluginExecutablePath(exe)
 		require.NoError(t, err)
-		assert.Equal(t, exe, got)
+		want, err := filepath.EvalSymlinks(exe)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "the returned path must be the fully resolved path that was validated")
+		assert.True(t, filepath.IsAbs(got))
+	})
+
+	t.Run("bare command name resolves via PATH like exec.Command", func(t *testing.T) {
+		t.Setenv("PATH", dir)
+		got, err := validatePluginExecutablePath("plugin-bin")
+		require.NoError(t, err)
+		want, err := filepath.EvalSymlinks(exe)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, "bare names must be resolved through PATH, matching exec.Command semantics")
+	})
+
+	t.Run("bare command name not on PATH rejected", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		_, err := validatePluginExecutablePath("plugin-bin")
+		assert.Error(t, err)
 	})
 
 	t.Run("empty path rejected", func(t *testing.T) {
@@ -67,7 +85,9 @@ func TestValidatePluginExecutablePathAllowedDirs(t *testing.T) {
 	t.Run("inside allowed dir passes", func(t *testing.T) {
 		got, err := validatePluginExecutablePath(inside)
 		require.NoError(t, err)
-		assert.Equal(t, inside, got)
+		want, err := filepath.EvalSymlinks(inside)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
 	})
 
 	t.Run("outside allowed dir rejected", func(t *testing.T) {
@@ -92,7 +112,9 @@ func TestValidatePluginExecutablePathAllowedDirs(t *testing.T) {
 		t.Setenv(pluginAllowedDirsEnv, outside+string(os.PathListSeparator)+allowed)
 		got, err := validatePluginExecutablePath(escaped)
 		require.NoError(t, err)
-		assert.Equal(t, escaped, got)
+		want, err := filepath.EvalSymlinks(escaped)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
 	})
 }
 

--- a/services/plugin_path_validation_test.go
+++ b/services/plugin_path_validation_test.go
@@ -1,0 +1,109 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #397: plugin executables must be validated before being handed to
+// exec.Command — scope checks against an allowlisted plugin directory, no
+// traversal, and basic sanity (exists, regular file, executable).
+
+func writeExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	return p
+}
+
+func TestValidatePluginExecutablePathBasics(t *testing.T) {
+	t.Setenv(pluginAllowedDirsEnv, "")
+
+	dir := t.TempDir()
+	exe := writeExecutable(t, dir, "plugin-bin")
+
+	t.Run("valid executable passes", func(t *testing.T) {
+		got, err := validatePluginExecutablePath(exe)
+		require.NoError(t, err)
+		assert.Equal(t, exe, got)
+	})
+
+	t.Run("empty path rejected", func(t *testing.T) {
+		_, err := validatePluginExecutablePath("")
+		assert.Error(t, err)
+	})
+
+	t.Run("nonexistent path rejected", func(t *testing.T) {
+		_, err := validatePluginExecutablePath(filepath.Join(dir, "missing"))
+		assert.Error(t, err)
+	})
+
+	t.Run("directory rejected", func(t *testing.T) {
+		_, err := validatePluginExecutablePath(dir)
+		assert.Error(t, err)
+	})
+
+	t.Run("non-executable file rejected", func(t *testing.T) {
+		p := filepath.Join(dir, "not-exec")
+		require.NoError(t, os.WriteFile(p, []byte("data"), 0o644))
+		_, err := validatePluginExecutablePath(p)
+		assert.Error(t, err)
+	})
+}
+
+func TestValidatePluginExecutablePathAllowedDirs(t *testing.T) {
+	allowed := t.TempDir()
+	outside := t.TempDir()
+
+	inside := writeExecutable(t, allowed, "good-plugin")
+	escaped := writeExecutable(t, outside, "evil-plugin")
+
+	t.Setenv(pluginAllowedDirsEnv, allowed)
+
+	t.Run("inside allowed dir passes", func(t *testing.T) {
+		got, err := validatePluginExecutablePath(inside)
+		require.NoError(t, err)
+		assert.Equal(t, inside, got)
+	})
+
+	t.Run("outside allowed dir rejected", func(t *testing.T) {
+		_, err := validatePluginExecutablePath(escaped)
+		assert.Error(t, err)
+	})
+
+	t.Run("traversal out of allowed dir rejected", func(t *testing.T) {
+		sneaky := filepath.Join(allowed, "..", filepath.Base(outside), "evil-plugin")
+		_, err := validatePluginExecutablePath(sneaky)
+		assert.Error(t, err)
+	})
+
+	t.Run("symlink escaping allowed dir rejected", func(t *testing.T) {
+		link := filepath.Join(allowed, "link-to-evil")
+		require.NoError(t, os.Symlink(escaped, link))
+		_, err := validatePluginExecutablePath(link)
+		assert.Error(t, err)
+	})
+
+	t.Run("multiple allowed dirs honored", func(t *testing.T) {
+		t.Setenv(pluginAllowedDirsEnv, outside+string(os.PathListSeparator)+allowed)
+		got, err := validatePluginExecutablePath(escaped)
+		require.NoError(t, err)
+		assert.Equal(t, escaped, got)
+	})
+}
+
+func TestValidatePluginExecutablePathTraversalWithoutAllowlist(t *testing.T) {
+	t.Setenv(pluginAllowedDirsEnv, "")
+
+	dir := t.TempDir()
+	writeExecutable(t, dir, "plugin-bin")
+
+	// Even without an allowlist, paths containing traversal segments are refused.
+	sneaky := dir + "/subdir/../plugin-bin"
+	_, err := validatePluginExecutablePath(sneaky)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Fixes #397 (High)
- New `validatePluginExecutablePath` guard applied in `createLocalPluginClient` and `createConfigOnlyLocalPluginClient` before any `exec.Command`:
  - rejects empty paths and any path containing a `..` traversal segment
  - requires the target to exist, be a regular file, and carry an executable bit
  - when **`AI_STUDIO_PLUGIN_ALLOWED_DIRS`** (new, `os.PathListSeparator`-separated) is set, the fully resolved path — symlinks followed — must live inside one of the allowlisted directories, so a symlink planted inside an allowed dir cannot escape it
- OCI verifier (`pkg/ociplugins/verifier.go`): the `cosign` subprocess is a fixed binary name, so the exec risk there is argument injection — positional values (reference, public key path, policy path) are now rejected if empty or flag-like (leading `-`), across `Verify`, `VerifyBundle`, and `VerifyWithPolicy`.

## Backwards compatibility
Without `AI_STUDIO_PLUGIN_ALLOWED_DIRS` set, plugins can still run from any location (existing deployments and the dev workflow keep working); only traversal and non-executable paths are refused. Setting the variable opts into strict scoping.

## Testing
- Test-first: `services/plugin_path_validation_test.go` (valid binary, empty/missing/directory/non-executable rejection, allowlist enforcement incl. traversal, symlink escape, and multi-dir lists) and `pkg/ociplugins/verifier_args_test.go` (flag-like argument rejection, `VerifyWithPolicy` fails before spawning cosign).
- `go test ./services/ ./pkg/ociplugins/` passes, including existing plugin-manager tests; module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)