### PR TITLE
fix: set ReadHeaderTimeout on API server (#401)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -254,12 +254,23 @@ func NewAPI(service *services.Service, disableCORS bool, authService *auth.AuthS
 	return api
 }
 
+// newHTTPServer builds the API http.Server with hardening timeouts.
+// ReadHeaderTimeout bounds slow-header (Slowloris) attacks and IdleTimeout
+// reaps idle keep-alive connections. ReadTimeout/WriteTimeout are left unset
+// deliberately: the API serves long-lived streaming responses (chat/SSE)
+// that a global write deadline would sever.
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+}
+
 func (a *API) Run(addr string, certFile string, keyFile string) error {
 	// Create http.Server for graceful shutdown support
-	a.server = &http.Server{
-		Addr:    addr,
-		Handler: a.router,
-	}
+	a.server = newHTTPServer(addr, a.router)
 
 	if certFile != "" && keyFile != "" {
 		return a.server.ListenAndServeTLS(certFile, keyFile)

--- a/api/server_timeouts_test.go
+++ b/api/server_timeouts_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+// Issue #401: the API server must set ReadHeaderTimeout to defend against
+// slow-header (Slowloris) resource exhaustion.
+
+func TestNewHTTPServerTimeouts(t *testing.T) {
+	srv := newHTTPServer(":0", nil)
+
+	if srv.ReadHeaderTimeout <= 0 {
+		t.Error("ReadHeaderTimeout must be set to a positive duration")
+	}
+	if srv.ReadHeaderTimeout > 60*time.Second {
+		t.Errorf("ReadHeaderTimeout should be at most 60s, got %v", srv.ReadHeaderTimeout)
+	}
+
+	if srv.IdleTimeout <= 0 {
+		t.Error("IdleTimeout must be set to a positive duration")
+	}
+
+	// The API serves long-lived streaming responses (chat/SSE), so global
+	// read/write timeouts must remain unset to avoid severing active streams.
+	if srv.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout must stay 0 to keep streaming endpoints working, got %v", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout must stay 0 to keep streaming endpoints working, got %v", srv.WriteTimeout)
+	}
+
+	if srv.Addr != ":0" {
+		t.Errorf("Addr not propagated, got %q", srv.Addr)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #401 (Medium)
- Extracted `newHTTPServer` and set `ReadHeaderTimeout: 30s` (Slowloris defense) and `IdleTimeout: 120s` on the API server.
- `ReadTimeout`/`WriteTimeout` are deliberately left unset — the API serves long-lived streaming (chat/SSE) responses that a global write deadline would sever; a test locks this in so it isn't 'fixed' later by accident.
- The proxy server already configures its own timeouts (`serverReadTimeout` etc.), so no change needed there.

## Testing
- Test-first: `api/server_timeouts_test.go` asserts ReadHeaderTimeout ∈ (0, 60s], IdleTimeout > 0, and that Read/Write timeouts stay 0 for streaming safety.
- Full `go test ./api/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)