### PR TITLE
fix: construct streaming filter-block JSON via encoding/json (#402)

### DIFF
--- a/proxy/filter_blocked_json_test.go
+++ b/proxy/filter_blocked_json_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Issue #402: streaming-filter block payloads must be built with
+// encoding/json — fmt.Sprintf produced malformed JSON when interpolated
+// values contained quotes or non-JSON text.
+
+func TestBuildFilterBlockedErrorChunk(t *testing.T) {
+	cases := []string{
+		"simple reason",
+		`reason with "quotes" and \ backslashes`,
+		"newlines\nand\ttabs",
+		`{"nested":"json"}`,
+	}
+	for _, msg := range cases {
+		chunk := buildFilterBlockedErrorChunk(msg)
+
+		var parsed map[string]string
+		if err := json.Unmarshal(chunk, &parsed); err != nil {
+			t.Fatalf("error chunk is not valid JSON for %q: %v (payload: %s)", msg, err, chunk)
+		}
+		if parsed["error"] == "" {
+			t.Errorf("expected non-empty error field for %q", msg)
+		}
+	}
+}
+
+func TestBuildFilterBlockedAnalyticsBody(t *testing.T) {
+	partials := []string{
+		`data: {"choices":[{"delta":{"content":"hi"}}]}` + "\n\n", // SSE — not JSON
+		`text with "quotes"`,
+		"",
+	}
+	for _, partial := range partials {
+		body := buildFilterBlockedAnalyticsBody(`blocked "reason"`, 3, partial)
+
+		var parsed struct {
+			FilterBlocked   bool   `json:"filter_blocked"`
+			BlockReason     string `json:"block_reason"`
+			ChunkIndex      int    `json:"chunk_index"`
+			PartialResponse string `json:"partial_response"`
+		}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("analytics body is not valid JSON for partial %q: %v (payload: %s)", partial, err, body)
+		}
+		if !parsed.FilterBlocked {
+			t.Error("filter_blocked should be true")
+		}
+		if parsed.BlockReason != `blocked "reason"` {
+			t.Errorf("block_reason mangled: %q", parsed.BlockReason)
+		}
+		if parsed.ChunkIndex != 3 {
+			t.Errorf("chunk_index mangled: %d", parsed.ChunkIndex)
+		}
+		if parsed.PartialResponse != partial {
+			t.Errorf("partial_response mangled: %q != %q", parsed.PartialResponse, partial)
+		}
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1245,15 +1245,14 @@ func (p *Proxy) handleStreamingLLMRequest(w http.ResponseWriter, r *http.Request
 					metrics.RecordPolicyBlock(r.Context(), "response_filter", "filter")
 					// Response blocked mid-stream - send error chunk and stop
 					logger.Warnf("Streaming response blocked by filter at chunk %d: %s", chunkIndex, blockMsg)
-					errorChunk := []byte(fmt.Sprintf(`{"error":"Response blocked by filter: %s"}`, blockMsg))
+					errorChunk := buildFilterBlockedErrorChunk(blockMsg)
 					w.Write(errorChunk)
 					if f, ok := w.(http.Flusher); ok {
 						f.Flush()
 					}
 					isErr = true
 					// Log with 400 status and include both the block reason and partial LLM response for audit trail
-					blockedResponseBody := []byte(fmt.Sprintf(`{"filter_blocked":true,"block_reason":%q,"chunk_index":%d,"partial_response":%s}`,
-						blockMsg, chunkIndex, fullResponse.String()))
+					blockedResponseBody := buildFilterBlockedAnalyticsBody(blockMsg, chunkIndex, fullResponse.String())
 					go p.analyzeStreamingResponse(llm, app, upstreamReq, http.StatusBadRequest, blockedResponseBody, reqBody, responses, time.Now(), "")
 					return
 				}
@@ -1285,6 +1284,35 @@ func (p *Proxy) handleStreamingLLMRequest(w http.ResponseWriter, r *http.Request
 			go p.executeOnStreamComplete(r, resp, llm, app, fullResponse.Bytes(), reqBody, chunkIndex)
 		}
 	}
+}
+
+// buildFilterBlockedErrorChunk builds the JSON error chunk sent to the client
+// when a response filter blocks a stream. Constructed via encoding/json so
+// filter messages containing quotes cannot break the payload.
+func buildFilterBlockedErrorChunk(blockMsg string) []byte {
+	chunk, err := json.Marshal(map[string]string{
+		"error": "Response blocked by filter: " + blockMsg,
+	})
+	if err != nil {
+		return []byte(`{"error":"Response blocked by filter"}`)
+	}
+	return chunk
+}
+
+// buildFilterBlockedAnalyticsBody builds the analytics/audit payload recorded
+// when a streaming response is blocked mid-stream. The partial response is
+// encoded as a JSON string — it is usually raw SSE text, not JSON.
+func buildFilterBlockedAnalyticsBody(blockMsg string, chunkIndex int, partialResponse string) []byte {
+	body, err := json.Marshal(map[string]interface{}{
+		"filter_blocked":   true,
+		"block_reason":     blockMsg,
+		"chunk_index":      chunkIndex,
+		"partial_response": partialResponse,
+	})
+	if err != nil {
+		return []byte(`{"filter_blocked":true}`)
+	}
+	return body
 }
 
 // executeOnStreamComplete calls the OnStreamComplete hook for streaming responses


### PR DESCRIPTION
## Summary
- Fixes #402 (Medium)
- Extracted `buildFilterBlockedErrorChunk` / `buildFilterBlockedAnalyticsBody` and switched both from `fmt.Sprintf` to `json.Marshal`.
- Notably, the old `"partial_response":%s` interpolated the accumulated stream verbatim — since streamed chunks are usually SSE text rather than JSON, the audit payload was malformed in practice. It is now encoded as a proper JSON string.

## Testing
- Test-first: `proxy/filter_blocked_json_test.go` proves both payloads parse as valid JSON for messages with quotes/backslashes/newlines and for SSE-format partial responses, with all fields round-tripping unmangled.
- Full `go test ./proxy/` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)