### PR TITLE
fix: prominent startup warning for EDGE_SKIP_TLS_VERIFY (#400)

### DIFF
--- a/microgateway/internal/config/config.go
+++ b/microgateway/internal/config/config.go
@@ -135,6 +135,13 @@ type HubSpokeConfig struct {
 	MaxMessageSize int `env:"GRPC_MAX_MESSAGE_SIZE" envDefault:"16777216"` // 16MB
 }
 
+// IsTLSVerificationDisabled reports whether the hub-spoke client will use TLS
+// with certificate verification disabled (EDGE_SKIP_TLS_VERIFY=true while TLS
+// is enabled). Plaintext connections are covered by a separate warning path.
+func (h HubSpokeConfig) IsTLSVerificationDisabled() bool {
+	return h.ClientTLSEnabled && h.SkipTLSVerify
+}
+
 // ControlPayloadConfig holds configuration for edge-to-control plugin data transmission
 type ControlPayloadConfig struct {
 	// Enabled controls whether plugin control payloads are sent to control
@@ -268,6 +275,15 @@ func (c *Config) Validate() error {
 
 	if c.Security.EncryptionKey == "change-me-in-production" {
 		fmt.Println("Warning: Using default encryption key. Change this in production!")
+	}
+
+	// Warn prominently at startup when TLS certificate verification is
+	// disabled on the hub-spoke client — operator-controlled, but must never
+	// be enabled accidentally in production.
+	if c.HubSpoke.IsTLSVerificationDisabled() {
+		fmt.Println("⚠️  SECURITY WARNING: EDGE_SKIP_TLS_VERIFY=true — TLS certificate verification is DISABLED for the hub-spoke gRPC connection.")
+		fmt.Println("⚠️  The control-plane connection is vulnerable to man-in-the-middle attacks in this mode.")
+		fmt.Println("⚠️  This setting is intended for development only. Remove EDGE_SKIP_TLS_VERIFY (default: false) for production.")
 	}
 
 	// Validate gRPC TLS configuration (security warning)

--- a/microgateway/internal/config/tls_verify_test.go
+++ b/microgateway/internal/config/tls_verify_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #400: EDGE_SKIP_TLS_VERIFY must default to false, and enabling it
+// must produce a prominent startup warning rather than being silent.
+
+func TestSkipTLSVerifyDefaultsToFalse(t *testing.T) {
+	t.Setenv("ENCRYPTION_KEY", "12345678901234567890123456789012")
+
+	cfg, err := Load("")
+	require.NoError(t, err)
+
+	assert.False(t, cfg.HubSpoke.SkipTLSVerify, "EDGE_SKIP_TLS_VERIFY must default to false")
+	assert.False(t, cfg.HubSpoke.AllowInsecure, "EDGE_ALLOW_INSECURE must default to false")
+	assert.True(t, cfg.HubSpoke.ClientTLSEnabled, "EDGE_TLS_ENABLED must default to true")
+}
+
+func TestSkipTLSVerifyEnabledStillValidatesButWarns(t *testing.T) {
+	t.Setenv("ENCRYPTION_KEY", "12345678901234567890123456789012")
+	t.Setenv("EDGE_SKIP_TLS_VERIFY", "true")
+
+	cfg, err := Load("")
+	require.NoError(t, err, "enabling skip-verify remains operator-controlled and must not hard-fail")
+	assert.True(t, cfg.HubSpoke.SkipTLSVerify)
+
+	// The warning is emitted during Validate; assert the helper reports the
+	// insecure state so callers surface it prominently.
+	assert.True(t, cfg.HubSpoke.IsTLSVerificationDisabled())
+}
+
+func TestIsTLSVerificationDisabled(t *testing.T) {
+	c := HubSpokeConfig{ClientTLSEnabled: true, SkipTLSVerify: true}
+	assert.True(t, c.IsTLSVerificationDisabled())
+
+	c = HubSpokeConfig{ClientTLSEnabled: true, SkipTLSVerify: false}
+	assert.False(t, c.IsTLSVerificationDisabled())
+
+	// With TLS disabled entirely, skip-verify is irrelevant (a separate
+	// warning path covers plaintext connections).
+	c = HubSpokeConfig{ClientTLSEnabled: false, SkipTLSVerify: true}
+	assert.False(t, c.IsTLSVerificationDisabled())
+}


### PR DESCRIPTION
## Summary
- Fixes #400 (Medium)
- Reviewed as requested: **the default is already `false`** (`envDefault:"false"` on `EDGE_SKIP_TLS_VERIFY`) — now locked in by a regression test so it can't drift.
- Added a prominent multi-line SECURITY WARNING at config-validation (startup) time when skip-verify is enabled, matching the existing plaintext-gRPC warning pattern — previously the only warning was a single log line at dial time.
- New `HubSpokeConfig.IsTLSVerificationDisabled()` helper distinguishes 'TLS on but unverified' from the plaintext case (which has its own opt-in gate `EDGE_ALLOW_INSECURE` and warning).
- Deliberately did **not** hard-fail or add a second opt-in gate: the flag is operator-controlled and existing dev/self-signed-cert deployments would break.

## Testing
- Test-first: `microgateway/internal/config/tls_verify_test.go` asserts the false defaults (skip-verify, allow-insecure, TLS-enabled=true), that enabling skip-verify still validates (no hard failure), and the helper's truth table.
- Full `microgateway` module builds; `internal/config` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)