### PR TITLE
fix: constant-time comparison for microgateway token validation (#404)

### DIFF
--- a/microgateway/internal/auth/secure_compare.go
+++ b/microgateway/internal/auth/secure_compare.go
@@ -1,0 +1,13 @@
+package auth
+
+import "crypto/subtle"
+
+// SecureTokenEquals compares two tokens in constant time to avoid timing
+// side channels. Empty tokens never match — an unset credential must not
+// authenticate anything.
+func SecureTokenEquals(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}

--- a/microgateway/internal/auth/secure_compare_test.go
+++ b/microgateway/internal/auth/secure_compare_test.go
@@ -1,0 +1,29 @@
+package auth
+
+import "testing"
+
+// Issue #404: token comparisons performed in-process must use a
+// constant-time comparison to avoid timing side channels.
+
+func TestSecureTokenEquals(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"equal tokens", "abc123def456", "abc123def456", true},
+		{"different tokens same length", "abc123def456", "abc123def457", false},
+		{"different lengths", "short", "much-longer-token", false},
+		{"empty vs empty", "", "", false}, // empty credentials never authenticate
+		{"empty vs value", "", "token", false},
+		{"value vs empty", "token", "", false},
+		{"case sensitive", "AbC", "abc", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SecureTokenEquals(tc.a, tc.b); got != tc.want {
+				t.Errorf("SecureTokenEquals(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}

--- a/microgateway/internal/auth/token_auth.go
+++ b/microgateway/internal/auth/token_auth.go
@@ -48,6 +48,16 @@ func (p *TokenAuthProvider) ValidateToken(token string) (*AuthResult, error) {
 		return nil, fmt.Errorf("token validation failed: %w", err)
 	}
 
+	// Constant-time re-verification of the DB match. Defends against timing
+	// side channels and lax database collations (e.g. case-insensitive
+	// comparisons) accepting a near-miss token.
+	if !SecureTokenEquals(apiToken.Token, token) {
+		return &AuthResult{
+			Valid: false,
+			Error: "Invalid token",
+		}, nil
+	}
+
 	// Check expiration
 	if apiToken.ExpiresAt != nil && apiToken.ExpiresAt.Before(time.Now()) {
 		return &AuthResult{

--- a/microgateway/internal/auth/token_auth.go
+++ b/microgateway/internal/auth/token_auth.go
@@ -51,6 +51,13 @@ func (p *TokenAuthProvider) ValidateToken(token string) (*AuthResult, error) {
 	// Constant-time re-verification of the DB match. Defends against timing
 	// side channels and lax database collations (e.g. case-insensitive
 	// comparisons) accepting a near-miss token.
+	//
+	// NOTE: this provider queries the api_tokens table directly (see p.db
+	// above) — it does NOT route through providers.DatabaseProvider, so this
+	// is the only verification on this path, not a repeat of one performed
+	// elsewhere. Each of the three independent DB-lookup paths
+	// (TokenAuthProvider, DatabaseGatewayService, DatabaseProvider) verifies
+	// exactly once per request.
 	if !SecureTokenEquals(apiToken.Token, token) {
 		return &AuthResult{
 			Valid: false,

--- a/microgateway/internal/grpc/server.go
+++ b/microgateway/internal/grpc/server.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	internalauth "github.com/TykTechnologies/midsommar/microgateway/internal/auth"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/config"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/database"
 	pb "github.com/TykTechnologies/midsommar/v2/proto"
@@ -217,13 +218,13 @@ func (s *ControlServer) authenticate(ctx context.Context) error {
 
 	token := tokens[0]
 
-	// Check current token
-	if s.config.HubSpoke.AuthToken != "" && token == "Bearer "+s.config.HubSpoke.AuthToken {
+	// Check current token (constant-time comparison to avoid timing side channels)
+	if s.config.HubSpoke.AuthToken != "" && internalauth.SecureTokenEquals(token, "Bearer "+s.config.HubSpoke.AuthToken) {
 		return nil
 	}
 
 	// Check next token (for rotation)
-	if s.config.HubSpoke.NextAuthToken != "" && token == "Bearer "+s.config.HubSpoke.NextAuthToken {
+	if s.config.HubSpoke.NextAuthToken != "" && internalauth.SecureTokenEquals(token, "Bearer "+s.config.HubSpoke.NextAuthToken) {
 		log.Debug().Msg("Edge authenticated with next token (rotation in progress)")
 		return nil
 	}

--- a/microgateway/internal/providers/database_provider.go
+++ b/microgateway/internal/providers/database_provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	internalauth "github.com/TykTechnologies/midsommar/microgateway/internal/auth"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/database"
 	"github.com/TykTechnologies/midsommar/v2/pkg/config"
 	"github.com/rs/zerolog/log"
@@ -186,7 +187,13 @@ func (p *DatabaseProvider) ValidateToken(token string) (*database.APIToken, erro
 	if err != nil {
 		return nil, err
 	}
-	
+
+	// Constant-time re-verification of the DB match. Defends against timing
+	// side channels and lax database collations accepting a near-miss token.
+	if !internalauth.SecureTokenEquals(apiToken.Token, token) {
+		return nil, fmt.Errorf("invalid token")
+	}
+
 	// Check if token is active
 	if !apiToken.IsActive {
 		return nil, fmt.Errorf("token is inactive")

--- a/microgateway/internal/services/gateway_service.go
+++ b/microgateway/internal/services/gateway_service.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	internalauth "github.com/TykTechnologies/midsommar/microgateway/internal/auth"
 	"github.com/TykTechnologies/midsommar/microgateway/internal/database"
 	"github.com/rs/zerolog/log"
 	"gorm.io/gorm"
@@ -203,6 +204,12 @@ func (s *DatabaseGatewayService) ValidateAPIToken(token string) (*TokenValidatio
 			return nil, fmt.Errorf("invalid or expired token")
 		}
 		return nil, fmt.Errorf("token validation failed: %w", err)
+	}
+
+	// Constant-time re-verification of the DB match. Defends against timing
+	// side channels and lax database collations accepting a near-miss token.
+	if !internalauth.SecureTokenEquals(apiToken.Token, token) {
+		return nil, fmt.Errorf("invalid or expired token")
 	}
 
 	// Check expiration

--- a/microgateway/internal/services/gateway_service.go
+++ b/microgateway/internal/services/gateway_service.go
@@ -208,6 +208,11 @@ func (s *DatabaseGatewayService) ValidateAPIToken(token string) (*TokenValidatio
 
 	// Constant-time re-verification of the DB match. Defends against timing
 	// side channels and lax database collations accepting a near-miss token.
+	//
+	// NOTE: this service queries the api_tokens table directly (see s.db
+	// above) — it is an alternative implementation of
+	// GatewayServiceInterface, not a layer over providers.DatabaseProvider.
+	// A request served by this path is verified exactly once, here.
 	if !internalauth.SecureTokenEquals(apiToken.Token, token) {
 		return nil, fmt.Errorf("invalid or expired token")
 	}


### PR DESCRIPTION
## Summary
- Fixes #404 (Medium)
- New `auth.SecureTokenEquals` helper (`crypto/subtle.ConstantTimeCompare`; empty tokens never authenticate), routed through every in-process token comparison entry point in the microgateway:
  - **`ControlServer.authenticate`** — the hub-spoke gRPC bearer tokens (current + rotation) were compared with plain `==`; now constant-time, with the original non-empty guards preserved so an empty configured token can't match a bare `"Bearer "` header.
  - **DB-lookup paths** (`TokenAuthProvider.ValidateToken`, `DatabaseGatewayService.ValidateAPIToken`, `DatabaseProvider.ValidateToken`): after the indexed lookup, the fetched token is re-verified in constant time. Besides the timing layer, this defends against lax DB collations (e.g. case-insensitive) accepting a near-miss token.
- `pkg/middleware/metrics_auth.go` already used `subtle` and is unchanged.

## Testing
- Test-first: `secure_compare_test.go` covers equal/near-miss/length-mismatch/case-sensitivity and the empty-credential rule.
- Existing `internal/auth`, `internal/services`, and `internal/grpc` suites pass; microgateway module builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)