### PR TITLE
feat: configurable CORS policy on proxy and OAuth endpoints (#399)

### DIFF
--- a/api/auth_handlers.go
+++ b/api/auth_handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/TykTechnologies/midsommar/v2/config"
+	"github.com/TykTechnologies/midsommar/v2/pkg/corsutil"
 	"github.com/TykTechnologies/midsommar/v2/helpers"
 	"github.com/TykTechnologies/midsommar/v2/models"
 	"github.com/TykTechnologies/midsommar/v2/services"
@@ -611,11 +612,8 @@ func (a *API) handleRegisterOAuthClient(c *gin.Context) {
 // @Failure 404 {object} ErrorResponse "Client not found"
 // @Router /oauth/authorize [get]
 func (a *API) handleOAuthAuthorize(c *gin.Context) {
-	// Set explicit CORS headers to allow * origins
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
-	c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	c.Header("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(c.Writer.Header(), c.GetHeader("Origin"), "GET, OPTIONS")
 
 	// Handle preflight requests
 	if c.Request.Method == "OPTIONS" {
@@ -742,11 +740,8 @@ func (a *API) handleOAuthAuthorize(c *gin.Context) {
 // @Router /oauth/consent_details [get]
 // @Security BearerAuth
 func (a *API) handleGetConsentDetails(c *gin.Context) {
-	// Set explicit CORS headers to allow * origins
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
-	c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	c.Header("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(c.Writer.Header(), c.GetHeader("Origin"), "GET, OPTIONS")
 
 	// Handle preflight requests
 	if c.Request.Method == "OPTIONS" {
@@ -888,11 +883,8 @@ type SubmitConsentInput struct {
 // @Router /oauth/submit_consent [post]
 // @Security BearerAuth
 func (a *API) handleSubmitConsent(c *gin.Context) {
-	// Set explicit CORS headers to allow * origins
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "POST, OPTIONS")
-	c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	c.Header("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(c.Writer.Header(), c.GetHeader("Origin"), "POST, OPTIONS")
 
 	// Handle preflight requests
 	if c.Request.Method == "OPTIONS" {
@@ -1053,11 +1045,8 @@ func (a *API) handleSubmitConsent(c *gin.Context) {
 // @Failure 401 {object} OAuthErrorResponse "e.g., invalid_client"
 // @Router /oauth/token [post]
 func (a *API) handleOAuthToken(c *gin.Context) {
-	// Set explicit CORS headers to allow * origins
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "POST, OPTIONS")
-	c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	c.Header("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(c.Writer.Header(), c.GetHeader("Origin"), "POST, OPTIONS")
 
 	// Handle preflight requests
 	if c.Request.Method == "OPTIONS" {
@@ -1241,11 +1230,8 @@ type OAuthServerMetadata struct {
 // @Success 200 {object} OAuthServerMetadata
 // @Router /.well-known/oauth-authorization-server [get]
 func (a *API) handleOAuthMetadata(c *gin.Context) {
-	// Set explicit CORS headers to allow * origins
-	c.Header("Access-Control-Allow-Origin", "*")
-	c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
-	c.Header("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	c.Header("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(c.Writer.Header(), c.GetHeader("Origin"), "GET, OPTIONS")
 
 	// Handle preflight requests
 	if c.Request.Method == "OPTIONS" {

--- a/api/plugin_handlers.go
+++ b/api/plugin_handlers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/pkg/corsutil"
 	pb "github.com/TykTechnologies/midsommar/v2/proto"
 	"github.com/TykTechnologies/midsommar/v2/services"
 	"github.com/gin-gonic/gin"
@@ -1774,7 +1775,12 @@ func (a *API) servePluginAsset(c *gin.Context) {
 	// Serve the asset content with proper MIME type and CORS headers for dynamic import
 	c.Header("Content-Type", mimeType)
 	c.Header("Content-Length", fmt.Sprintf("%d", len(content)))
-	c.Header("Access-Control-Allow-Origin", "*")
+	if origin, configured := corsutil.AllowOrigin(c.GetHeader("Origin")); origin != "" {
+		c.Header("Access-Control-Allow-Origin", origin)
+		if configured {
+			c.Writer.Header().Add("Vary", "Origin")
+		}
+	}
 	c.Header("Access-Control-Allow-Methods", "GET, OPTIONS")
 	c.Header("Access-Control-Allow-Headers", "Content-Type, Authorization")
 	c.Header("Cross-Origin-Resource-Policy", "cross-origin")

--- a/pkg/corsutil/corsutil.go
+++ b/pkg/corsutil/corsutil.go
@@ -1,0 +1,57 @@
+// Package corsutil centralizes the CORS policy for endpoints that
+// historically sent `Access-Control-Allow-Origin: *` (OAuth, proxy metadata,
+// plugin assets). The policy is configured via CORS_ALLOWED_ORIGINS:
+//
+//   - unset (default) or "*": wildcard, preserving existing behavior
+//   - comma-separated origins: the request Origin is echoed back only when it
+//     matches an entry (case-insensitive); otherwise no CORS header is sent
+//
+// Credentials are never enabled by this package.
+package corsutil
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// EnvAllowedOrigins configures the allowed origins for the endpoints that
+// previously used a wildcard CORS policy.
+const EnvAllowedOrigins = "CORS_ALLOWED_ORIGINS"
+
+// AllowOrigin returns the value to send as Access-Control-Allow-Origin for a
+// request with the given Origin header, and whether an explicit origin list
+// is configured (callers should send `Vary: Origin` when it is). An empty
+// returned origin means the header must be omitted.
+func AllowOrigin(requestOrigin string) (string, bool) {
+	configured := os.Getenv(EnvAllowedOrigins)
+	if configured == "" {
+		return "*", false
+	}
+
+	for _, entry := range strings.Split(configured, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "*" {
+			return "*", false
+		}
+		if entry != "" && requestOrigin != "" && strings.EqualFold(entry, requestOrigin) {
+			return requestOrigin, true
+		}
+	}
+	return "", true
+}
+
+// SetCORSHeaders applies the CORS policy to a response header set.
+// methods is the value for Access-Control-Allow-Methods.
+func SetCORSHeaders(h http.Header, requestOrigin, methods string) {
+	origin, configured := AllowOrigin(requestOrigin)
+	if origin != "" {
+		h.Set("Access-Control-Allow-Origin", origin)
+	}
+	if configured {
+		h.Add("Vary", "Origin")
+	}
+	h.Set("Access-Control-Allow-Methods", methods)
+	h.Set("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
+	h.Set("Access-Control-Max-Age", "43200") // 12 hours
+}

--- a/pkg/corsutil/corsutil_test.go
+++ b/pkg/corsutil/corsutil_test.go
@@ -1,0 +1,83 @@
+package corsutil
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAllowOriginUnconfiguredKeepsWildcard(t *testing.T) {
+	t.Setenv(EnvAllowedOrigins, "")
+
+	origin, configured := AllowOrigin("https://anything.example.com")
+	if origin != "*" || configured {
+		t.Errorf("unconfigured must preserve wildcard behavior, got (%q, %v)", origin, configured)
+	}
+}
+
+func TestAllowOriginExplicitWildcard(t *testing.T) {
+	t.Setenv(EnvAllowedOrigins, "*")
+
+	origin, configured := AllowOrigin("https://anything.example.com")
+	if origin != "*" || configured {
+		t.Errorf("explicit wildcard must behave as wildcard, got (%q, %v)", origin, configured)
+	}
+}
+
+func TestAllowOriginConfiguredList(t *testing.T) {
+	t.Setenv(EnvAllowedOrigins, "https://app.example.com, https://admin.example.com")
+
+	origin, configured := AllowOrigin("https://app.example.com")
+	if origin != "https://app.example.com" || !configured {
+		t.Errorf("allowlisted origin must be echoed, got (%q, %v)", origin, configured)
+	}
+
+	origin, configured = AllowOrigin("HTTPS://APP.EXAMPLE.COM")
+	if origin == "" || !configured {
+		t.Errorf("origin matching must be case-insensitive, got (%q, %v)", origin, configured)
+	}
+
+	origin, _ = AllowOrigin("https://evil.example.com")
+	if origin != "" {
+		t.Errorf("non-allowlisted origin must get no CORS header, got %q", origin)
+	}
+
+	origin, _ = AllowOrigin("")
+	if origin != "" {
+		t.Errorf("requests without an Origin header get no CORS header, got %q", origin)
+	}
+}
+
+func TestSetCORSHeaders(t *testing.T) {
+	t.Run("unconfigured wildcard", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "")
+		w := httptest.NewRecorder()
+		SetCORSHeaders(w.Header(), "https://x.example.com", "GET, OPTIONS")
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("expected wildcard, got %q", got)
+		}
+		if w.Header().Get("Access-Control-Allow-Methods") != "GET, OPTIONS" {
+			t.Error("methods header missing")
+		}
+	})
+
+	t.Run("configured match echoes origin and varies", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "https://app.example.com")
+		w := httptest.NewRecorder()
+		SetCORSHeaders(w.Header(), "https://app.example.com", "POST, OPTIONS")
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+			t.Errorf("expected echoed origin, got %q", got)
+		}
+		if got := w.Header().Get("Vary"); got != "Origin" {
+			t.Errorf("expected Vary: Origin, got %q", got)
+		}
+	})
+
+	t.Run("configured mismatch omits allow-origin", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "https://app.example.com")
+		w := httptest.NewRecorder()
+		SetCORSHeaders(w.Header(), "https://evil.example.com", "GET, OPTIONS")
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no allow-origin header, got %q", got)
+		}
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/TykTechnologies/midsommar/v2/helpers"
 	"github.com/TykTechnologies/midsommar/v2/logger"
 	"github.com/TykTechnologies/midsommar/v2/models"
+	"github.com/TykTechnologies/midsommar/v2/pkg/corsutil"
 	"github.com/TykTechnologies/midsommar/v2/scripting"
 	"github.com/TykTechnologies/midsommar/v2/services"
 	"github.com/TykTechnologies/midsommar/v2/switches"
@@ -414,11 +415,8 @@ func (p *Proxy) createHandler() http.Handler {
 }
 
 func (p *Proxy) handleOAuthProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
-	// Set CORS headers to allow * origins
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
-	w.Header().Set("Access-Control-Max-Age", "43200") // 12 hours
+	// Apply CORS policy (wildcard unless CORS_ALLOWED_ORIGINS is configured)
+	corsutil.SetCORSHeaders(w.Header(), r.Header.Get("Origin"), "GET, OPTIONS")
 
 	// Handle preflight requests
 	if r.Method == "OPTIONS" {

--- a/proxy/response_hooks_example.go
+++ b/proxy/response_hooks_example.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/TykTechnologies/midsommar/v2/pkg/corsutil"
 )
 
 // ExampleResponseHook demonstrates how to create a custom response hook
@@ -108,8 +110,13 @@ func (h *CORSResponseHook) OnBeforeWriteHeaders(ctx context.Context, req *Header
 		modifiedHeaders[key] = value
 	}
 	
-	// Add CORS headers
-	modifiedHeaders["Access-Control-Allow-Origin"] = "*"
+	// Add CORS headers, honoring the configured CORS_ALLOWED_ORIGINS policy.
+	// The hook has no access to the request Origin, so it only emits a
+	// wildcard when the policy is wildcard; with a configured origin list it
+	// leaves CORS to the endpoint handlers.
+	if origin, configured := corsutil.AllowOrigin(""); origin != "" && !configured {
+		modifiedHeaders["Access-Control-Allow-Origin"] = origin
+	}
 	modifiedHeaders["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, OPTIONS"
 	modifiedHeaders["Access-Control-Allow-Headers"] = "Origin, Content-Type, Accept, Authorization"
 	


### PR DESCRIPTION
## Summary
- Fixes #399 (Medium)
- New `pkg/corsutil` package centralizes CORS for all sites the issue lists: the 5 OAuth handlers in `api/auth_handlers.go`, `proxy.handleOAuthProtectedResourceMetadata`, the plugin UI-asset endpoint in `api/plugin_handlers.go`, and the example CORS response hook.
- Policy via new **`CORS_ALLOWED_ORIGINS`**:
  - unset or `*` → wildcard, exactly as before (no breaking change for existing deployments and public OAuth/metadata discovery)
  - a comma-separated origin list → the request `Origin` is echoed only on a case-insensitive match, with `Vary: Origin`; non-matching or absent origins get **no** CORS header
- Credentials remain off everywhere — `Access-Control-Allow-Credentials` is never set, keeping the safe wildcard/credentials separation the issue noted.
- Side benefit: the five copy-pasted header blocks in `auth_handlers.go` collapse into one helper call each.

## Testing
- Test-first: `pkg/corsutil/corsutil_test.go` covers unconfigured/explicit wildcard, allowlist echo, case-insensitivity, mismatch/absent-origin omission, and header/Vary emission.
- Full `proxy` and `api` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)