### PR TITLE
fix: tighten file permissions and path handling in OCI storage (#403)

### DIFF
--- a/pkg/ociplugins/storage.go
+++ b/pkg/ociplugins/storage.go
@@ -8,9 +8,46 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
+
+const (
+	// storageDirPerm keeps cache directories inaccessible to other users.
+	storageDirPerm = 0o750
+	// storageExecPerm allows owner/group execution of cached plugin binaries.
+	storageExecPerm = 0o750
+)
+
+// digestPattern matches a lowercase hex SHA-256 digest. Digests and
+// architectures flow in from OCI manifests, so they are validated before
+// being used to build filesystem paths.
+var digestPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+// archNamePattern matches a platform string after "/" has been replaced with
+// "-" (e.g. "linux-amd64").
+var archNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$`)
+
+// validateDigest rejects digests that are not plain SHA-256 hex, preventing
+// path traversal out of the storage root.
+func validateDigest(digest string) error {
+	if !digestPattern.MatchString(digest) {
+		return fmt.Errorf("invalid content digest %q", digest)
+	}
+	return nil
+}
+
+// archFileComponent converts a platform string (e.g. "linux/amd64") to a safe
+// filename component, returning an error for values that could escape the
+// storage directory.
+func archFileComponent(arch string) (string, error) {
+	name := strings.ReplaceAll(arch, "/", "-")
+	if !archNamePattern.MatchString(name) || strings.Contains(name, "..") {
+		return "", fmt.Errorf("invalid architecture %q", arch)
+	}
+	return name, nil
+}
 
 // ContentStorage manages content-addressed storage for plugins
 type ContentStorage struct {
@@ -46,7 +83,7 @@ func (s *ContentStorage) initDirectories() error {
 	}
 
 	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, storageDirPerm); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
 		}
 	}
@@ -117,6 +154,9 @@ func (s *ContentStorage) StoreBlob(data []byte) (string, error) {
 
 // GetBlob retrieves blob data by digest
 func (s *ContentStorage) GetBlob(digest string) ([]byte, error) {
+	if err := validateDigest(digest); err != nil {
+		return nil, err
+	}
 	blobPath := filepath.Join(s.getCASDir(), digest)
 	data, err := os.ReadFile(blobPath)
 	if err != nil {
@@ -130,8 +170,16 @@ func (s *ContentStorage) GetBlob(digest string) ([]byte, error) {
 
 // StoreExecutable stores a plugin binary and returns the executable path
 func (s *ContentStorage) StoreExecutable(digest, arch string, data []byte) (string, error) {
+	if err := validateDigest(digest); err != nil {
+		return "", err
+	}
+	archName, err := archFileComponent(arch)
+	if err != nil {
+		return "", err
+	}
+
 	// Generate executable filename
-	execName := fmt.Sprintf("sha256-%s-%s", digest, strings.ReplaceAll(arch, "/", "-"))
+	execName := fmt.Sprintf("sha256-%s-%s", digest, archName)
 	execPath := filepath.Join(s.getBinsDir(), execName)
 
 	// Check if already exists
@@ -156,7 +204,7 @@ func (s *ContentStorage) StoreExecutable(digest, arch string, data []byte) (stri
 	}
 
 	// Make executable and move to final location
-	if err := os.Chmod(tempFile.Name(), 0755); err != nil {
+	if err := os.Chmod(tempFile.Name(), storageExecPerm); err != nil {
 		return "", fmt.Errorf("failed to set executable permissions: %w", err)
 	}
 
@@ -435,10 +483,13 @@ func (s *ContentStorage) cleanupOrphanedBlobs() error {
 
 // StoreMetadata stores plugin metadata
 func (s *ContentStorage) StoreMetadata(digest, arch string, metadata *PluginMetadata) error {
-	metadataFile := s.getMetadataPath(digest, arch)
+	metadataFile, err := s.metadataPath(digest, arch)
+	if err != nil {
+		return err
+	}
 
 	// Create metadata directory if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(metadataFile), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(metadataFile), storageDirPerm); err != nil {
 		return fmt.Errorf("failed to create metadata directory: %w", err)
 	}
 
@@ -474,7 +525,10 @@ func (s *ContentStorage) StoreMetadata(digest, arch string, metadata *PluginMeta
 
 // LoadMetadata loads plugin metadata by digest and architecture
 func (s *ContentStorage) LoadMetadata(digest, arch string) (*PluginMetadata, error) {
-	metadataFile := s.getMetadataPath(digest, arch)
+	metadataFile, err := s.metadataPath(digest, arch)
+	if err != nil {
+		return nil, err
+	}
 
 	data, err := os.ReadFile(metadataFile)
 	if err != nil {
@@ -492,16 +546,27 @@ func (s *ContentStorage) LoadMetadata(digest, arch string) (*PluginMetadata, err
 	return &metadata, nil
 }
 
-// getMetadataPath returns the path to metadata file for a plugin
-func (s *ContentStorage) getMetadataPath(digest, arch string) string {
-	filename := fmt.Sprintf("sha256-%s-%s.json", digest, strings.ReplaceAll(arch, "/", "-"))
-	return filepath.Join(s.getMetadataDir(), filename)
+// metadataPath validates digest and arch before building the metadata path,
+// confining the result to the metadata directory.
+func (s *ContentStorage) metadataPath(digest, arch string) (string, error) {
+	if err := validateDigest(digest); err != nil {
+		return "", err
+	}
+	archName, err := archFileComponent(arch)
+	if err != nil {
+		return "", err
+	}
+	filename := fmt.Sprintf("sha256-%s-%s.json", digest, archName)
+	return filepath.Join(s.getMetadataDir(), filename), nil
 }
 
 // HasMetadata checks if metadata exists for a plugin
 func (s *ContentStorage) HasMetadata(digest, arch string) bool {
-	metadataFile := s.getMetadataPath(digest, arch)
-	_, err := os.Stat(metadataFile)
+	metadataFile, err := s.metadataPath(digest, arch)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(metadataFile)
 	return err == nil
 }
 

--- a/pkg/ociplugins/storage_security_test.go
+++ b/pkg/ociplugins/storage_security_test.go
@@ -1,0 +1,141 @@
+package ociplugins
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Issue #403: storage directories must be 0750, stored files must not be
+// world-readable, and digest/arch inputs must be confined to the storage root.
+
+func newTestStorage(t *testing.T) *ContentStorage {
+	t.Helper()
+	s, err := NewContentStorage(t.TempDir(), 1<<30, time.Hour)
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+	return s
+}
+
+func digestOf(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func TestStorageDirectoryPermissions(t *testing.T) {
+	s := newTestStorage(t)
+
+	for _, dir := range []string{s.getCASDir(), s.getBinsDir(), s.getActiveDir(), s.getTempDir(), s.getMetadataDir()} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat %s: %v", dir, err)
+		}
+		if perm := info.Mode().Perm(); perm&0o007 != 0 {
+			t.Errorf("directory %s is world-accessible: %o", dir, perm)
+		}
+	}
+}
+
+func TestStoredBlobNotWorldReadable(t *testing.T) {
+	s := newTestStorage(t)
+
+	digest, err := s.StoreBlob([]byte("plugin-content"))
+	if err != nil {
+		t.Fatalf("StoreBlob: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(s.getCASDir(), digest))
+	if err != nil {
+		t.Fatalf("stat blob: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("blob is group/world-accessible: %o", perm)
+	}
+}
+
+func TestStoredExecutablePermissions(t *testing.T) {
+	s := newTestStorage(t)
+
+	data := []byte("#!/bin/sh\nexit 0\n")
+	path, err := s.StoreExecutable(digestOf(data), "linux/amd64", data)
+	if err != nil {
+		t.Fatalf("StoreExecutable: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat exec: %v", err)
+	}
+	perm := info.Mode().Perm()
+	if perm&0o100 == 0 {
+		t.Errorf("executable is not owner-executable: %o", perm)
+	}
+	if perm&0o007 != 0 {
+		t.Errorf("executable is world-accessible: %o", perm)
+	}
+}
+
+func TestGetBlobRejectsTraversalDigest(t *testing.T) {
+	s := newTestStorage(t)
+
+	// Plant a file outside the CAS dir that a traversal digest would reach
+	outside := filepath.Join(s.baseDir, "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, digest := range []string{
+		"../../secret.txt",
+		"..",
+		"",
+		"SHA256-UPPER-NOT-HEX",
+		strings.Repeat("a", 63), // wrong length
+	} {
+		if _, err := s.GetBlob(digest); err == nil {
+			t.Errorf("GetBlob(%q) should be rejected", digest)
+		}
+	}
+}
+
+func TestStoreExecutableRejectsBadInputs(t *testing.T) {
+	s := newTestStorage(t)
+	data := []byte("bin")
+
+	if _, err := s.StoreExecutable("../../evil", "linux/amd64", data); err == nil {
+		t.Error("traversal digest must be rejected")
+	}
+	if _, err := s.StoreExecutable(digestOf(data), "../..", data); err == nil {
+		t.Error("traversal arch must be rejected")
+	}
+}
+
+func TestMetadataRejectsTraversal(t *testing.T) {
+	s := newTestStorage(t)
+
+	meta := &PluginMetadata{Version: "1.0"}
+	if err := s.StoreMetadata("../../evil", "linux/amd64", meta); err == nil {
+		t.Error("traversal digest must be rejected in StoreMetadata")
+	}
+	if _, err := s.LoadMetadata("../../evil", "linux/amd64"); err == nil {
+		t.Error("traversal digest must be rejected in LoadMetadata")
+	}
+
+	// Valid round-trip still works
+	data := []byte("x")
+	d := digestOf(data)
+	if err := s.StoreMetadata(d, "linux/amd64", meta); err != nil {
+		t.Fatalf("StoreMetadata valid: %v", err)
+	}
+	got, err := s.LoadMetadata(d, "linux/amd64")
+	if err != nil {
+		t.Fatalf("LoadMetadata valid: %v", err)
+	}
+	if got.Version != "1.0" {
+		t.Errorf("metadata round-trip mangled: %+v", got)
+	}
+}

--- a/services/branding_file_storage.go
+++ b/services/branding_file_storage.go
@@ -54,8 +54,8 @@ func NewBrandingFileStorage(basePath string) (*BrandingFileStorage, error) {
 		basePath = DefaultBrandingStoragePath
 	}
 
-	// Create directory if it doesn't exist
-	if err := os.MkdirAll(basePath, 0755); err != nil {
+	// Create directory if it doesn't exist (no world access)
+	if err := os.MkdirAll(basePath, 0o750); err != nil {
 		return nil, fmt.Errorf("failed to create branding storage directory: %w", err)
 	}
 
@@ -155,9 +155,24 @@ func (bfs *BrandingFileStorage) SaveFavicon(file multipart.File, header *multipa
 	return filename, nil
 }
 
-// saveFile writes the uploaded file to disk
-func (bfs *BrandingFileStorage) saveFile(file multipart.File, filepath string) error {
-	dst, err := os.Create(filepath)
+// saveFile writes the uploaded file to disk, confined to the storage base
+// path and without world-readable permissions.
+func (bfs *BrandingFileStorage) saveFile(file multipart.File, path string) error {
+	// Confine the destination to the branding storage directory
+	baseAbs, err := filepath.Abs(bfs.BasePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve storage path: %w", err)
+	}
+	destAbs, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination path: %w", err)
+	}
+	rel, err := filepath.Rel(baseAbs, destAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("destination %q is outside the branding storage directory", path)
+	}
+
+	dst, err := os.OpenFile(destAbs, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o640)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}

--- a/services/branding_file_storage_security_test.go
+++ b/services/branding_file_storage_security_test.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #403: branding storage must not create world-accessible directories,
+// saved files must not be world-writable/readable beyond need, and the save
+// path must be confined to the storage root.
+
+func TestBrandingStorageDirectoryPermissions(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "branding")
+	_, err := NewBrandingFileStorage(base)
+	require.NoError(t, err)
+
+	info, err := os.Stat(base)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode().Perm()&0o007, "branding dir must not be world-accessible: %o", info.Mode().Perm())
+}
+
+func TestBrandingSaveFilePermissions(t *testing.T) {
+	storage, tempDir := setupBrandingStorageTest(t)
+
+	file := newMockFile([]byte("png-bytes"))
+	err := storage.saveFile(file, filepath.Join(tempDir, "logo.png"))
+	require.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(tempDir, "logo.png"))
+	require.NoError(t, err)
+	perm := info.Mode().Perm()
+	assert.Zero(t, perm&0o007, "saved file must not be world-accessible: %o", perm)
+	assert.Zero(t, perm&0o022, "saved file must not be group/world-writable: %o", perm)
+}
+
+func TestBrandingSaveFileConfinedToBase(t *testing.T) {
+	storage, tempDir := setupBrandingStorageTest(t)
+
+	outside := filepath.Join(filepath.Dir(tempDir), "escape.png")
+	err := storage.saveFile(newMockFile([]byte("x")), outside)
+	assert.Error(t, err, "saving outside the storage root must be rejected")
+
+	traversal := filepath.Join(tempDir, "..", "escape2.png")
+	err = storage.saveFile(newMockFile([]byte("x")), traversal)
+	assert.Error(t, err, "traversal outside the storage root must be rejected")
+
+	_, statErr := os.Stat(outside)
+	assert.True(t, os.IsNotExist(statErr), "no file must be written outside the root")
+}


### PR DESCRIPTION
## Summary
- Fixes #403 (Medium)
- **OCI plugin storage** (`pkg/ociplugins/storage.go`): directories now `0750` (were `0755`); cached plugin binaries `0750` (were `0755`); blob/metadata files keep `os.CreateTemp`'s `0600`. Beyond permissions, the variable-path concern is addressed at the source: digests must be 64-char lowercase hex and architecture strings are validated before any path is built, so values arriving via OCI manifests can no longer traverse out of the storage root (`GetBlob`, `StoreExecutable`, `StoreMetadata`/`LoadMetadata`/`HasMetadata`).
- **Branding storage** (`services/branding_file_storage.go`): base directory `0750`; uploaded files written with explicit `0640` instead of `os.Create`'s `0666&umask`; `saveFile` now refuses destinations outside the storage root.
- `verifier.go:270` (`ValidatePublicKey`) reads an operator-configured key path — left as-is; the argument-injection guard for the verifier landed in #410.

## Testing
- Test-first: `storage_security_test.go` (dir/blob/executable permission assertions, traversal-digest and traversal-arch rejection with a planted file proving no escape, valid metadata round-trip) and `branding_file_storage_security_test.go` (dir/file permissions, confinement, and proof nothing is written outside the root).
- Full existing `pkg/ociplugins` and `services` suites pass (incl. SaveLogo/SaveFavicon upload flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)