### PR TITLE
fix: quickstart analytics never reached the dashboard — PLUGINS_CONFIG_PATH pointed at a non-existent file

### DIFF
--- a/quickstart/confs/mgw-ce.env
+++ b/quickstart/confs/mgw-ce.env
@@ -128,7 +128,7 @@ OCI_PLUGINS_REQUIRE_SIGNATURE=true
 # Plugin Configuration
 # ============================================================================
 # Analytics plugin for sending data to control plane
-PLUGINS_CONFIG_PATH=./analytics-pulse-config.yaml
+PLUGINS_CONFIG_PATH=/app/mgw-analytics.yaml
 
 # Alternative: Service-based configuration
 # PLUGINS_CONFIG_SERVICE_URL=

--- a/quickstart/confs/mgw-ent.env
+++ b/quickstart/confs/mgw-ent.env
@@ -127,7 +127,7 @@ OCI_PLUGINS_PUBKEY_FILE_LIVE=./keys/plugins/plugin-live.pub
 # Plugin Configuration
 # ============================================================================
 # Analytics plugin for sending data to control plane
-PLUGINS_CONFIG_PATH=./analytics-pulse-config.yaml
+PLUGINS_CONFIG_PATH=/opt/tyk-microgateway/mgw-analytics.yaml
 
 # Alternative: Service-based configuration
 # PLUGINS_CONFIG_SERVICE_URL=


### PR DESCRIPTION
## Problem

The quickstart composes (CE and enterprise) mount `quickstart/confs/mgw-analytics.yaml` into the microgateway container, but `PLUGINS_CONFIG_PATH` in both mgw env files pointed at `./analytics-pulse-config.yaml`, which doesn't exist in the container.

The file-based plugin config loader silently returns an empty plugin list when the configured file is missing (`microgateway/internal/config/file_plugin_loader.go`), so the `analytics_pulse` data-collection plugin never loaded and no analytics were pushed to the Studio dashboard — with no error or warning anywhere in the logs.

## Fix

Point `PLUGINS_CONFIG_PATH` at the actual mount target in each edition:

- `mgw-ent.env`: `/opt/tyk-microgateway/mgw-analytics.yaml` (matches the enterprise compose mounts updated in #415)
- `mgw-ce.env`: `/app/mgw-analytics.yaml` (matches the CE compose mount)

## Verification

Ran the enterprise quickstart with this change and `LOG_LEVEL=debug`:

```
DBG Loading global data collection plugins config_path=/opt/tyk-microgateway/mgw-analytics.yaml
DBG Loaded plugin configurations count=1
DBG Built-in analytics pulse plugin loaded successfully edge_id=edge-01 plugin=analytics_pulse
DBG Deferred built-in analytics pulse plugin loaded successfully hook_types=["analytics","budget","proxy_log"]
DBG Next analytics pulse scheduled next_pulse_in=10000
```

## Follow-up worth considering (not in this PR)

- The silent skip on a missing `PLUGINS_CONFIG_PATH` file made this invisible; a warning log there would have surfaced it immediately.
- The env value has to track the compose mount path across editions; a workdir-relative path (`./mgw-analytics.yaml`) plus matching mounts would decouple them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)