### PR TITLE
fix: UTF-8-safe OpenAPI spec encoding on import (#481)

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -530,6 +530,8 @@ type ToolInput struct {
 			Name           string   `json:"name"`
 			Description    string   `json:"description"`
 			ToolType       string   `json:"tool_type"`
+			// OASSpec must be the base64 encoding of the UTF-8 OpenAPI
+			// document. Raw JSON or YAML is rejected with a 400.
 			OASSpec        string   `json:"oas_spec"`
 			PrivacyScore   int      `json:"privacy_score"`
 			AuthKey        string   `json:"auth_key"`

--- a/api/tool_handlers.go
+++ b/api/tool_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"net/http"
@@ -71,6 +72,16 @@ func (a *API) createTool(c *gin.Context) {
 		}
 	}
 
+	if err := validateOASSpecEncoding(input.Data.Attributes.OASSpec); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Errors: []struct {
+				Title  string `json:"title"`
+				Detail string `json:"detail"`
+			}{{Title: "Bad Request", Detail: err.Error()}},
+		})
+		return
+	}
+
 	// Create the tool via service layer (includes auto-assignment to Default catalogue)
 	tool, err := a.service.CreateTool(
 		input.Data.Attributes.Name,
@@ -128,6 +139,21 @@ func (a *API) createTool(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, gin.H{"data": serializeTool(tool, a.config.DB)})
+}
+
+// validateOASSpecEncoding checks that an oas_spec attribute is the base64 the
+// rest of the platform expects. The field is typed as a string, so raw JSON or
+// YAML binds happily and is stored as-is; the failure then surfaces much later
+// and far away, as "illegal base64 data" from /spec-operations or from a tool
+// call. Catching it here names the actual problem.
+func validateOASSpecEncoding(spec string) error {
+	if spec == "" {
+		return nil
+	}
+	if _, err := base64.StdEncoding.DecodeString(spec); err != nil {
+		return fmt.Errorf("oas_spec must be base64-encoded (got %v)", err)
+	}
+	return nil
 }
 
 // @Summary Get a tool by ID
@@ -210,6 +236,16 @@ func (a *API) updateTool(c *gin.Context) {
 				Title  string `json:"title"`
 				Detail string `json:"detail"`
 			}{{Title: "Not Found", Detail: "Tool not found"}},
+		})
+		return
+	}
+
+	if err := validateOASSpecEncoding(input.Data.Attributes.OASSpec); err != nil {
+		c.JSON(http.StatusBadRequest, ErrorResponse{
+			Errors: []struct {
+				Title  string `json:"title"`
+				Detail string `json:"detail"`
+			}{{Title: "Bad Request", Detail: err.Error()}},
 		})
 		return
 	}

--- a/api/tool_handlers_test.go
+++ b/api/tool_handlers_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,12 @@ import (
 	"github.com/TykTechnologies/midsommar/v2/models"
 	"github.com/stretchr/testify/assert"
 )
+
+// testOASSpec encodes a spec the way the API requires. oas_spec is typed as a
+// string but must carry base64; raw JSON is rejected with a 400.
+func testOASSpec(spec string) string {
+	return base64.StdEncoding.EncodeToString([]byte(spec))
+}
 
 func TestToolEndpoints(t *testing.T) {
 	api, _ := setupTestAPI(t)
@@ -44,7 +51,7 @@ func TestToolEndpoints(t *testing.T) {
 				Name:         "Test Tool",
 				Description:  "A test tool",
 				ToolType:     models.ToolTypeREST,
-				OASSpec:      `{"openapi": "3.0.0"}`,
+				OASSpec:      testOASSpec(`{"openapi": "3.0.0"}`),
 				PrivacyScore: 8,
 				Operations:   []string{"operation1", "operation2"},
 			},
@@ -96,7 +103,7 @@ func TestToolEndpoints(t *testing.T) {
 				Name:         "Updated Tool",
 				Description:  "An updated test tool",
 				ToolType:     models.ToolTypeREST,
-				OASSpec:      `{"openapi": "3.0.1"}`,
+				OASSpec:      testOASSpec(`{"openapi": "3.0.1"}`),
 				PrivacyScore: 9,
 				Operations:   []string{"operation1", "operation2", "operation3"},
 			},
@@ -179,7 +186,7 @@ func TestToolAuthKeyRedaction(t *testing.T) {
 					Name:     name,
 					AuthKey:  authKey,
 					ToolType: models.ToolTypeREST,
-					OASSpec:  `{"openapi": "3.0.0"}`,
+					OASSpec:  testOASSpec(`{"openapi": "3.0.0"}`),
 				},
 			},
 		}
@@ -271,7 +278,7 @@ func TestToolEndpointsErrors(t *testing.T) {
 				Name:         "Updated Tool",
 				Description:  "An updated test tool",
 				ToolType:     models.ToolTypeREST,
-				OASSpec:      `{"openapi": "3.0.1"}`,
+				OASSpec:      testOASSpec(`{"openapi": "3.0.1"}`),
 				PrivacyScore: 9,
 				Operations:   []string{"operation1", "operation2", "operation3"},
 			},

--- a/api/tool_spec_encoding_test.go
+++ b/api/tool_spec_encoding_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestValidateOASSpecEncoding(t *testing.T) {
+	const spec = `{"openapi":"3.0.0","info":{"title":"Canada’s holidays — v1"}}`
+
+	t.Run("empty spec is allowed", func(t *testing.T) {
+		if err := validateOASSpecEncoding(""); err != nil {
+			t.Fatalf("expected no error for empty spec, got %v", err)
+		}
+	})
+
+	t.Run("base64 of a UTF-8 spec is accepted", func(t *testing.T) {
+		encoded := base64.StdEncoding.EncodeToString([]byte(spec))
+		if err := validateOASSpecEncoding(encoded); err != nil {
+			t.Fatalf("expected base64 spec to be accepted, got %v", err)
+		}
+	})
+
+	t.Run("raw JSON is rejected", func(t *testing.T) {
+		// The natural mistake when scripting the API: the field is a string, so
+		// raw JSON binds and used to be stored, failing much later at
+		// /spec-operations with "illegal base64 data".
+		err := validateOASSpecEncoding(spec)
+		if err == nil {
+			t.Fatal("expected raw JSON to be rejected")
+		}
+	})
+
+	t.Run("raw YAML is rejected", func(t *testing.T) {
+		if err := validateOASSpecEncoding("openapi: 3.0.0\npaths: {}\n"); err == nil {
+			t.Fatal("expected raw YAML to be rejected")
+		}
+	})
+}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/TykTechnologies/midsommar/v2/config"
 	"github.com/gin-gonic/gin"
@@ -155,9 +156,15 @@ func DecodeToUTF8(s string) (string, error) {
 		return "", fmt.Errorf("base64 decoding failed: %v", err)
 	}
 
-	// Step 2 & 3: Convert to UTF-8
-	// This example assumes the original encoding was Windows-1252 (a common encoding)
-	// Replace this with the correct encoding if known
+	// Step 2: Payloads written by the UI (and by anything base64-encoding UTF-8
+	// bytes) are already UTF-8 — re-decoding them as Windows-1252 turns every
+	// non-ASCII character into mojibake, so hand them back untouched.
+	if utf8.Valid(decodedBytes) {
+		return string(decodedBytes), nil
+	}
+
+	// Step 3: Not valid UTF-8. Historically the import wizard used btoa(), which
+	// writes U+0080-U+00FF as single bytes, so fall back to Windows-1252.
 	reader := transform.NewReader(strings.NewReader(string(decodedBytes)), charmap.Windows1252.NewDecoder())
 	utf8Bytes, err := io.ReadAll(reader)
 	if err != nil {

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -338,6 +339,32 @@ func TestDecodeToUTF8(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeToUTF8_Encodings(t *testing.T) {
+	t.Run("UTF-8 payload is returned unchanged", func(t *testing.T) {
+		// What the import wizard now produces: base64 of UTF-8 bytes.
+		const spec = `{"info":{"title":"Canada\u2019s holidays \u2014 jours f\u00e9ri\u00e9s"}}`
+		decoded, err := DecodeToUTF8(base64.StdEncoding.EncodeToString([]byte(spec)))
+		assert.NoError(t, err)
+		assert.Equal(t, spec, decoded)
+	})
+
+	t.Run("multi-byte scripts survive the round trip", func(t *testing.T) {
+		const spec = "祝日 \U0001F341"
+		decoded, err := DecodeToUTF8(base64.StdEncoding.EncodeToString([]byte(spec)))
+		assert.NoError(t, err)
+		assert.Equal(t, spec, decoded)
+	})
+
+	t.Run("legacy Windows-1252 payload is still transcoded", func(t *testing.T) {
+		// What btoa() produced for Latin-1 input: one byte per code point,
+		// which is not valid UTF-8 and needs the charmap fallback.
+		latin1 := []byte{'c', 'a', 'f', 0xE9} // "café" as Windows-1252
+		decoded, err := DecodeToUTF8(base64.StdEncoding.EncodeToString(latin1))
+		assert.NoError(t, err)
+		assert.Equal(t, "café", decoded)
+	})
 }
 
 func TestSendErrorResponse(t *testing.T) {

--- a/ui/admin-frontend/src/admin/components/tools/ImportOpenAPIWizard/utils/specUtils.js
+++ b/ui/admin-frontend/src/admin/components/tools/ImportOpenAPIWizard/utils/specUtils.js
@@ -49,8 +49,21 @@ export const encodeSpec = (spec) => {
   try {
     // If spec is an object, stringify it
     const specString = typeof spec === "string" ? spec : JSON.stringify(spec);
-    // Convert to base64
-    return btoa(specString);
+    // btoa() operates on Latin-1: it throws on any code point above U+00FF
+    // (curly quotes, em dashes, CJK) and silently writes U+0080-U+00FF as a
+    // single byte, which produces base64 the server cannot read back as UTF-8.
+    // Encode to UTF-8 bytes first so any valid spec round-trips.
+    const bytes = new TextEncoder().encode(specString);
+    // Chunked so a large spec does not blow the argument limit of apply().
+    const chunkSize = 0x8000;
+    let binary = "";
+    for (let i = 0; i < bytes.length; i += chunkSize) {
+      binary += String.fromCharCode.apply(
+        null,
+        bytes.subarray(i, i + chunkSize)
+      );
+    }
+    return btoa(binary);
   } catch (error) {
     console.error("Failed to encode spec:", error);
     throw new Error("Failed to encode OpenAPI specification");

--- a/ui/admin-frontend/src/admin/components/tools/ImportOpenAPIWizard/utils/specUtils.test.js
+++ b/ui/admin-frontend/src/admin/components/tools/ImportOpenAPIWizard/utils/specUtils.test.js
@@ -1,0 +1,44 @@
+import { encodeSpec } from "./specUtils";
+
+// Decodes what encodeSpec produced back into a JS string, the way the server
+// does: base64 -> bytes -> UTF-8.
+const decodeSpec = (encoded) => {
+  const binary = atob(encoded);
+  const bytes = Uint8Array.from(binary, (ch) => ch.charCodeAt(0));
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+};
+
+describe("encodeSpec", () => {
+  it("round-trips an ASCII spec", () => {
+    const spec = '{"openapi":"3.0.0","info":{"title":"Rates"}}';
+    expect(decodeSpec(encodeSpec(spec))).toBe(spec);
+  });
+
+  it("round-trips characters above the Latin-1 range", () => {
+    // Curly quotes and an em dash: btoa() throws on these.
+    const spec = '{"info":{"title":"Canada’s holidays — “v1”"}}';
+    expect(decodeSpec(encodeSpec(spec))).toBe(spec);
+  });
+
+  it("round-trips Latin-1 characters as UTF-8", () => {
+    // btoa() accepted these but wrote them as single bytes, so the stored
+    // base64 was not valid UTF-8 and came back as mojibake.
+    const spec = '{"info":{"title":"Jours fériés"}}';
+    expect(decodeSpec(encodeSpec(spec))).toBe(spec);
+  });
+
+  it("round-trips multi-byte scripts and astral characters", () => {
+    const spec = '{"info":{"title":"祝日 🍁"}}';
+    expect(decodeSpec(encodeSpec(spec))).toBe(spec);
+  });
+
+  it("stringifies an object spec", () => {
+    const spec = { info: { title: "café" } };
+    expect(decodeSpec(encodeSpec(spec))).toBe(JSON.stringify(spec));
+  });
+
+  it("handles a spec larger than one encoding chunk", () => {
+    const spec = `{"description":"${"é".repeat(40000)}"}`;
+    expect(decodeSpec(encodeSpec(spec))).toBe(spec);
+  });
+});

--- a/ui/admin-frontend/src/setupTests.js
+++ b/ui/admin-frontend/src/setupTests.js
@@ -3,6 +3,15 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// jsdom omits TextEncoder/TextDecoder, which browsers have had for years.
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}
 
 // Mock use-debounce
 jest.mock('use-debounce', () => ({


### PR DESCRIPTION
Fixes #481.

## Problem

`encodeSpec()` in the OpenAPI import wizard base64-encoded the spec with `btoa()`. `btoa()` is a Latin-1 API:

- **Above U+00FF it throws.** A single curly quote or em dash anywhere in the document failed the whole import with *"Failed to encode OpenAPI specification"*. All three import methods (URL, file, paste) funnel through it, so there was no way around it from the UI.
- **Inside Latin-1 it silently corrupts.** `é`, `ü`, `ñ` were written as single bytes, so the stored base64 was not valid UTF-8. `helpers.DecodeToUTF8` then ran a Windows-1252 → UTF-8 transform over it and non-ASCII text came back as mojibake rather than failing loudly.

## Changes

**`specUtils.js` — encode UTF-8 bytes, not code points**

`TextEncoder` first, then base64 over the resulting bytes. Chunked at 32K so a large spec does not exceed the argument limit of `String.fromCharCode.apply`.

**`helpers/helpers.go` — stop transcoding what is already UTF-8**

`DecodeToUTF8` now returns the decoded bytes as-is when they are valid UTF-8, and falls back to the Windows-1252 transform only when they are not — which is exactly the shape of a spec stored by the old `btoa()` path, so existing tools keep working.

**`api/tool_handlers.go` — reject a non-base64 `oas_spec` at the door**

The issue's "Related" note: `oas_spec` is typed `string`, so posting raw JSON bound happily, returned 201, and then failed much later and far away with `illegal base64 data` from `/spec-operations`. `POST`/`PUT /tools` now return a 400 naming the problem. The field is documented as base64 on `ToolInput`.

**`setupTests.js`** polyfills `TextEncoder`/`TextDecoder`, which jsdom omits.

## Tests

- `specUtils.test.js` — round-trips ASCII, above-Latin-1 (`’ “ ” —`), Latin-1 (`fériés`), multi-byte + astral (`祝日 🍁`), an object spec, and a spec larger than one encoding chunk, decoding each the way the server does.
- `TestDecodeToUTF8_Encodings` — UTF-8 payload unchanged, multi-byte round trip, legacy Windows-1252 payload still transcoded.
- `TestValidateOASSpecEncoding` — base64 accepted, raw JSON and raw YAML rejected.

Both real-world specs named in the issue (Canada Holidays API, Frankfurter) encode cleanly with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
