### PR TITLE
fix: invalidate the edge MCP server cache (#482)

### DIFF
--- a/microgateway/internal/services/edge_sync_tools_test.go
+++ b/microgateway/internal/services/edge_sync_tools_test.go
@@ -427,6 +427,41 @@ func TestGatewayAdapterToolMethods(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	// The gateway's MCP server cache invalidates on the tool's version. When
+	// the adapter dropped the timestamps, every edge-served tool carried the
+	// zero time, the comparison always matched, and the cache was never
+	// rebuilt — so a deleted-and-recreated tool kept calling the old tool's ID.
+	t.Run("GetToolByID_PreservesTimestamps", func(t *testing.T) {
+		var dbTool database.Tool
+		require.NoError(t, db.First(&dbTool, 1).Error)
+
+		tool, err := adapter.GetToolByID(1)
+		require.NoError(t, err)
+		assert.False(t, tool.UpdatedAt.IsZero(), "UpdatedAt must be carried over from SQLite")
+		assert.True(t, dbTool.UpdatedAt.Equal(tool.UpdatedAt))
+		assert.True(t, dbTool.CreatedAt.Equal(tool.CreatedAt))
+	})
+
+	t.Run("GetToolBySlug_PreservesTimestamps", func(t *testing.T) {
+		tool, err := adapter.GetToolBySlug("weather-api")
+		require.NoError(t, err)
+		assert.False(t, tool.UpdatedAt.IsZero(), "UpdatedAt must be carried over from SQLite")
+	})
+
+	t.Run("GetActiveDatasources_PreservesTimestamps", func(t *testing.T) {
+		datasources, err := adapter.GetActiveDatasources()
+		require.NoError(t, err)
+		require.NotEmpty(t, datasources)
+		assert.False(t, datasources[0].UpdatedAt.IsZero())
+	})
+
+	t.Run("GetActiveLLMs_PreservesTimestamps", func(t *testing.T) {
+		llms, err := adapter.GetActiveLLMs()
+		require.NoError(t, err)
+		require.NotEmpty(t, llms)
+		assert.False(t, llms[0].UpdatedAt.IsZero())
+	})
+
 	t.Run("GetActiveDatasources", func(t *testing.T) {
 		datasources, err := adapter.GetActiveDatasources()
 		require.NoError(t, err)

--- a/microgateway/internal/services/gateway_adapter.go
+++ b/microgateway/internal/services/gateway_adapter.go
@@ -937,6 +937,7 @@ func (a *GatewayServiceAdapter) convertDatabaseLLMToModel(dbLLM *database.LLM) m
 	}
 
 	llm := models.LLM{
+		Model:         gorm.Model{ID: dbLLM.ID, CreatedAt: dbLLM.CreatedAt, UpdatedAt: dbLLM.UpdatedAt},
 		ID:            dbLLM.ID,
 		Name:          dbLLM.Slug, // Use slug as name for AI Gateway routing
 		Vendor:        models.Vendor(dbLLM.Vendor),
@@ -966,6 +967,7 @@ func (a *GatewayServiceAdapter) convertDatabaseLLMToModel(dbLLM *database.LLM) m
 
 func (a *GatewayServiceAdapter) convertDatabaseCredentialToModel(dbCred *database.Credential) models.Credential {
 	return models.Credential{
+		Model:  gorm.Model{ID: dbCred.ID, CreatedAt: dbCred.CreatedAt, UpdatedAt: dbCred.UpdatedAt},
 		ID:     dbCred.ID,
 		KeyID:  dbCred.KeyID,
 		Secret: dbCred.SecretHash, // Note: this is the hashed version
@@ -1009,6 +1011,7 @@ func (a *GatewayServiceAdapter) convertDatabaseAppToModel(dbApp *database.App) m
 	}
 
 	modelApp := models.App{
+		Model:           gorm.Model{ID: dbApp.ID, CreatedAt: dbApp.CreatedAt, UpdatedAt: dbApp.UpdatedAt},
 		ID:              dbApp.ID,
 		Name:            dbApp.Name,
 		Description:     dbApp.Description,
@@ -1059,6 +1062,10 @@ func (a *GatewayServiceAdapter) convertDatabaseToolToModel(dbTool *database.Tool
 	}
 
 	return models.Tool{
+		// Timestamps matter: the gateway's MCP server and parsed-spec caches
+		// are keyed on the tool's version, and a zero UpdatedAt makes every
+		// comparison match, so the caches would never invalidate on an edge.
+		Model:               gorm.Model{ID: dbTool.ID, CreatedAt: dbTool.CreatedAt, UpdatedAt: dbTool.UpdatedAt},
 		ID:                  dbTool.ID,
 		Name:                dbTool.Name,
 		Slug:                dbTool.Slug,
@@ -1106,6 +1113,7 @@ func (a *GatewayServiceAdapter) convertDatabaseDatasourceToModel(dbDS *database.
 	}
 
 	return models.Datasource{
+		Model:            gorm.Model{ID: dbDS.ID, CreatedAt: dbDS.CreatedAt, UpdatedAt: dbDS.UpdatedAt},
 		ID:               dbDS.ID,
 		Name:             dbDS.Name,
 		ShortDescription: dbDS.ShortDescription,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -110,7 +110,7 @@ type EmbeddingResponse struct {
 type OpenAPICache struct {
 	Document    libopenapi.Document
 	Operations  []string
-	ToolVersion int64
+	ToolVersion string
 	CreatedAt   time.Time
 }
 
@@ -118,7 +118,7 @@ type MCPServerCache struct {
 	SSEServer        *server.SSEServer
 	StreamableServer *server.StreamableHTTPServer
 	MCPServer        *server.MCPServer
-	ToolVersion      int64
+	ToolVersion      string
 	OperationHash    string
 }
 
@@ -1575,7 +1575,7 @@ func (p *Proxy) getParsedOpenAPISpec(toolModel *models.Tool) (*universalclient.C
 
 	// Check if cache is valid (tool version matches and cache is recent)
 	cacheExpiry := 30 * time.Minute
-	if exists && cache.ToolVersion == toolModel.UpdatedAt.UnixNano() &&
+	if exists && cache.ToolVersion == p.toolCacheVersion(toolModel) &&
 		time.Since(cache.CreatedAt) < cacheExpiry {
 		// Create client from cached document
 		decodedSpec, err := base64.StdEncoding.DecodeString(toolModel.OASSpec)
@@ -1611,12 +1611,27 @@ func (p *Proxy) getParsedOpenAPISpec(toolModel *models.Tool) (*universalclient.C
 	p.openAPICacheMu.Lock()
 	p.openAPICache[cacheKey] = &OpenAPICache{
 		Operations:  operations,
-		ToolVersion: toolModel.UpdatedAt.UnixNano(),
+		ToolVersion: p.toolCacheVersion(toolModel),
 		CreatedAt:   time.Now(),
 	}
 	p.openAPICacheMu.Unlock()
 
 	return client, operations, nil
+}
+
+// toolCacheVersion fingerprints everything the cached MCP server and parsed
+// spec are derived from. UpdatedAt alone is not enough: a data plane builds
+// models.Tool by hand from local SQLite, and any converter that forgets the
+// timestamps leaves it at the zero time, in which case a timestamp comparison
+// always matches and the entry is never invalidated. Hashing the spec and the
+// whitelisted operations makes the check correct regardless.
+func (p *Proxy) toolCacheVersion(toolModel *models.Tool) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%d\x00%d\x00", toolModel.ID, toolModel.UpdatedAt.UnixNano())
+	h.Write([]byte(toolModel.OASSpec))
+	h.Write([]byte("\x00"))
+	h.Write([]byte(strings.Join(toolModel.GetOperations(), ",")))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
 func (p *Proxy) generateOperationHash(toolModel *models.Tool) string {
@@ -1628,7 +1643,7 @@ func (p *Proxy) generateOperationHash(toolModel *models.Tool) string {
 	}
 
 	// Create hash from tool version + allowed operations
-	hashData := fmt.Sprintf("%d:%s", toolModel.UpdatedAt.UnixNano(), strings.Join(allowedOps, ","))
+	hashData := fmt.Sprintf("%s:%s", p.toolCacheVersion(toolModel), strings.Join(allowedOps, ","))
 	h := sha256.New()
 	h.Write([]byte(hashData))
 	return fmt.Sprintf("%x", h.Sum(nil))
@@ -1780,9 +1795,15 @@ func reconstructNestedObject(request mcp.CallToolRequest, prefix string, schema 
 func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*MCPServerCache, error) {
 	// Create a hash of the tool operations to detect changes
 	currentOpHash := p.generateOperationHash(toolModel)
+	currentVersion := p.toolCacheVersion(toolModel)
 
-	// Use slug.Make to create cache key from tool name
-	cacheKey := slug.Make(toolModel.Name)
+	// The slug is the public path segment (/tools/{slug}/mcp), so the SSE
+	// server's base path is built from it. The cache is keyed on the tool ID
+	// instead: a slug is not stable across a delete and recreate, and the
+	// cached handler closures capture the tool ID, so a slug-keyed entry could
+	// outlive its tool and keep calling an ID that no longer exists.
+	toolSlug := slug.Make(toolModel.Name)
+	cacheKey := fmt.Sprintf("%d", toolModel.ID)
 
 	p.mcpServersMu.RLock()
 	cache, exists := p.mcpServers[cacheKey]
@@ -1790,8 +1811,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 
 	// Check if we have a valid cached server
 	if exists {
-		// Compare cache.ToolVersion with toolModel.UpdatedAt.UnixNano() to fix type mismatch
-		if cache.ToolVersion == toolModel.UpdatedAt.UnixNano() && cache.OperationHash == currentOpHash {
+		if cache.ToolVersion == currentVersion && cache.OperationHash == currentOpHash {
 			// Tool hasn't changed, return cached server
 			return cache, nil
 		}
@@ -1805,7 +1825,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 
 	// Check again in case another goroutine updated it
 	cache, exists = p.mcpServers[cacheKey]
-	if exists && cache.ToolVersion == toolModel.UpdatedAt.UnixNano() && cache.OperationHash == currentOpHash {
+	if exists && cache.ToolVersion == currentVersion && cache.OperationHash == currentOpHash {
 		return cache, nil
 	}
 
@@ -2007,7 +2027,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 		server.WithBaseURL(baseURL),
 		server.WithDynamicBasePath(func(req *http.Request, sessionID string) string {
 			// This tells the server that its base path is /tools/{toolSlug}/mcp
-			return fmt.Sprintf("/tools/%s/mcp", cacheKey)
+			return fmt.Sprintf("/tools/%s/mcp", toolSlug)
 		}),
 	)
 
@@ -2019,7 +2039,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 		SSEServer:        sseServer,
 		StreamableServer: streamableServer,
 		MCPServer:        mcpServer,
-		ToolVersion:      toolModel.UpdatedAt.UnixNano(),
+		ToolVersion:      currentVersion,
 		OperationHash:    currentOpHash,
 	}
 

--- a/proxy/tool_cache_version_test.go
+++ b/proxy/tool_cache_version_test.go
@@ -1,0 +1,70 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+	"gorm.io/gorm"
+)
+
+func newCachedTool(id uint, updatedAt time.Time, spec, operations string) *models.Tool {
+	return &models.Tool{
+		Model:               gorm.Model{ID: id, UpdatedAt: updatedAt},
+		ID:                  id,
+		Name:                "Currency Exchange Rates",
+		OASSpec:             spec,
+		AvailableOperations: operations,
+	}
+}
+
+func TestToolCacheVersion(t *testing.T) {
+	p := &Proxy{}
+	now := time.Now()
+	base := newCachedTool(4, now, "c3BlYy12MQ==", "getExchangeRate")
+
+	t.Run("stable for an unchanged tool", func(t *testing.T) {
+		if p.toolCacheVersion(base) != p.toolCacheVersion(newCachedTool(4, now, "c3BlYy12MQ==", "getExchangeRate")) {
+			t.Fatal("an unchanged tool must keep its version, or the cache never hits")
+		}
+	})
+
+	t.Run("changes when the tool is updated", func(t *testing.T) {
+		if p.toolCacheVersion(base) == p.toolCacheVersion(newCachedTool(4, now.Add(time.Second), "c3BlYy12MQ==", "getExchangeRate")) {
+			t.Fatal("a newer UpdatedAt must produce a different version")
+		}
+	})
+
+	t.Run("changes when the spec is edited", func(t *testing.T) {
+		// The reported case: an edited OpenAPI document whose operation names
+		// are unchanged. UpdatedAt alone covers this on the control plane, but
+		// hashing the spec makes it hold even where timestamps are unreliable.
+		if p.toolCacheVersion(base) == p.toolCacheVersion(newCachedTool(4, now, "c3BlYy12Mg==", "getExchangeRate")) {
+			t.Fatal("an edited spec must produce a different version")
+		}
+	})
+
+	t.Run("changes when operations are whitelisted or removed", func(t *testing.T) {
+		if p.toolCacheVersion(base) == p.toolCacheVersion(newCachedTool(4, now, "c3BlYy12MQ==", "getExchangeRate,getExchangeRates")) {
+			t.Fatal("a changed operation list must produce a different version")
+		}
+	})
+
+	t.Run("distinguishes tools with zero timestamps", func(t *testing.T) {
+		// An edge builds models.Tool by hand from local SQLite. If a converter
+		// omits UpdatedAt, both tools carry the zero time — the version must
+		// still tell a deleted tool apart from its same-named replacement.
+		deleted := newCachedTool(4, time.Time{}, "c3BlYy12MQ==", "getExchangeRate")
+		recreated := newCachedTool(5, time.Time{}, "c3BlYy12MQ==", "getExchangeRate")
+		if p.toolCacheVersion(deleted) == p.toolCacheVersion(recreated) {
+			t.Fatal("tools with different IDs must not share a cache version")
+		}
+	})
+}
+
+func TestGenerateOperationHash_EmptyWithoutOperations(t *testing.T) {
+	p := &Proxy{}
+	if got := p.generateOperationHash(newCachedTool(4, time.Now(), "c3BlYw==", "")); got != "" {
+		t.Fatalf("expected empty hash for a tool with no operations, got %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #482.

## Problem

`getMCPServerForTool` invalidates its cache by comparing the cached `ToolVersion` against `toolModel.UpdatedAt.UnixNano()`. On an edge gateway that comparison can never fail: `convertDatabaseToolToModel` builds `models.Tool` field by field from local SQLite and never set the timestamps, so `UpdatedAt` was always the zero time and `0 == 0` always matched. `generateOperationHash` hashed the same zero timestamp, so it was constant too.

The cache was keyed on the tool **slug**, and the cached handler closures capture the tool **ID**. So:

- **Delete a Tool, recreate it with the same name.** Every MCP call thereafter returned `failed to get tool <old id>: tool with ID <old id> not found`, permanently. REST and chat were unaffected — they resolve per request.
- **Edit a spec without renaming an operation.** The edge kept serving the old schema.

`POST /api/v1/edges/reload-all` did not clear it; only a restart did. `getParsedOpenAPISpec` used the same comparison, so its cached operation list was stale too.

## Changes

**`microgateway/internal/services/gateway_adapter.go`** — carry `CreatedAt`/`UpdatedAt` through `convertDatabaseToolToModel`. `EdgeSyncService.syncTools` already writes them into SQLite correctly; only the converter dropped them. The issue asked for an audit of the siblings: `convertDatabaseLLMToModel`, `convertDatabaseAppToModel`, `convertDatabaseCredentialToModel` and `convertDatabaseDatasourceToModel` had the same omission and are fixed alongside.

**`proxy/proxy.go` — key the cache on the tool ID, not the slug.** A slug is not stable across a delete and recreate, and the entry outlives the tool it was built for. The slug is still what builds the SSE server's public base path (`/tools/{slug}/mcp`), which must keep matching the request URL.

**`proxy/proxy.go` — fingerprint instead of a bare timestamp.** Both caches now compare `toolCacheVersion()`, a SHA-256 over the tool ID, `UpdatedAt`, the OpenAPI spec and the whitelisted operations. This is defence in depth: it keeps invalidation correct in any data plane that assembles `models.Tool` by hand, rather than depending on every future converter remembering the timestamps.

## Tests

- `TestToolCacheVersion` — stable for an unchanged tool; changes on a newer `UpdatedAt`, on an edited spec with unchanged operation names, and on a changed operation list; distinguishes two tools that both carry the zero timestamp (the deleted-and-recreated case).
- `TestGatewayAdapterToolMethods/*_PreservesTimestamps` — asserts tools, datasources and LLMs read back from edge SQLite carry non-zero timestamps matching the stored row.

`go test ./proxy/` and `go test ./internal/services/` (microgateway) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
