### PR TITLE
fix: return JSON from MCP tools/call, not Go map formatting (#483)

### DIFF
--- a/proxy/mcp_tool_result_test.go
+++ b/proxy/mcp_tool_result_test.go
@@ -1,0 +1,83 @@
+package proxy
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// textOf pulls the single text block out of an MCP tool result.
+func textOf(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	require.Len(t, result.Content, 1)
+	text, ok := mcp.AsTextContent(result.Content[0])
+	require.True(t, ok, "expected a text content block")
+	return text.Text
+}
+
+func TestMCPToolResultFromValue(t *testing.T) {
+	t.Run("a map is rendered as JSON, not Go map syntax", func(t *testing.T) {
+		// universalclient returns a map when the operation documents a response
+		// schema for the status code. This used to come back as
+		// "map[base:EUR date:2026-08-28 quote:GBP rate:0.85765]".
+		result := mcpToolResultFromValue("getExchangeRate", map[string]interface{}{
+			"date":  "2026-08-28",
+			"base":  "EUR",
+			"quote": "GBP",
+			"rate":  0.85765,
+		})
+
+		text := textOf(t, result)
+		assert.NotContains(t, text, "map[")
+
+		var decoded map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(text), &decoded), "result must be valid JSON")
+		assert.Equal(t, "EUR", decoded["base"])
+		assert.Equal(t, "GBP", decoded["quote"])
+		assert.Equal(t, "2026-08-28", decoded["date"])
+		assert.InDelta(t, 0.85765, decoded["rate"], 1e-9)
+	})
+
+	t.Run("map key order is stable across calls", func(t *testing.T) {
+		payload := map[string]interface{}{"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}
+		first := textOf(t, mcpToolResultFromValue("op", payload))
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, first, textOf(t, mcpToolResultFromValue("op", payload)))
+		}
+	})
+
+	t.Run("a slice is rendered as a JSON array", func(t *testing.T) {
+		result := mcpToolResultFromValue("listRates", []interface{}{
+			map[string]interface{}{"quote": "GBP"},
+			map[string]interface{}{"quote": "USD"},
+		})
+
+		text := textOf(t, result)
+		var decoded []map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(text), &decoded))
+		require.Len(t, decoded, 2)
+		assert.Equal(t, "GBP", decoded[0]["quote"])
+	})
+
+	t.Run("a string passes through untouched", func(t *testing.T) {
+		// An operation with no documented response schema already came back as
+		// the raw upstream body; re-encoding it would double-quote the JSON.
+		const body = `{"date":"2026-08-28","rate":0.85765}`
+		assert.Equal(t, body, textOf(t, mcpToolResultFromValue("getExchangeRate", body)))
+	})
+
+	t.Run("a nil result is rendered as JSON null", func(t *testing.T) {
+		assert.Equal(t, "null", textOf(t, mcpToolResultFromValue("op", nil)))
+	})
+
+	t.Run("an unmarshalable value falls back to Go formatting", func(t *testing.T) {
+		// json.Marshal rejects NaN. The call must still return content rather
+		// than dropping the tool result.
+		text := textOf(t, mcpToolResultFromValue("op", map[string]interface{}{"x": math.NaN()}))
+		assert.NotEmpty(t, text)
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1777,6 +1777,28 @@ func reconstructNestedObject(request mcp.CallToolRequest, prefix string, schema 
 	return result
 }
 
+// mcpToolResultFromValue renders a tool operation result as MCP text content.
+//
+// universalclient.parseResponse returns a string when the operation documents
+// no response schema for the status code, and a map or slice when it does. The
+// map/slice case used to go through fmt's %v, which prints Go's map syntax:
+// not JSON, not documented anywhere, and in map-iteration order, so it was not
+// even stable between calls. Anything that is not already a string is now
+// marshalled as JSON, so MCP clients see the same payload the REST endpoint
+// returns for the same operation.
+func mcpToolResultFromValue(operationID string, result interface{}) *mcp.CallToolResult {
+	if str, ok := result.(string); ok {
+		return mcp.NewToolResultText(str)
+	}
+
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		logger.Warnf("MCP operation %s: could not marshal result as JSON, falling back to Go formatting: %v", operationID, err)
+		return mcp.NewToolResultText(fmt.Sprintf("%v", result))
+	}
+	return mcp.NewToolResultText(string(jsonData))
+}
+
 func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*MCPServerCache, error) {
 	// Create a hash of the tool operations to detect changes
 	currentOpHash := p.generateOperationHash(toolModel)
@@ -1969,26 +1991,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 			)
 
 			// Convert the result to MCP format
-			switch res := result.(type) {
-			case string:
-				return mcp.NewToolResultText(res), nil
-			case map[string]interface{}, []interface{}:
-				return mcp.NewToolResultText(fmt.Sprintf("%v", res)), nil
-			default:
-				// Try to marshal any other type to JSON
-				jsonData, err := json.Marshal(result)
-				if err != nil {
-					return mcp.NewToolResultText(fmt.Sprintf("%v", result)), nil
-				}
-				// Check if it's a JSON object or array
-				if len(jsonData) > 0 && (jsonData[0] == '{' || jsonData[0] == '[') {
-					var obj interface{}
-					if err := json.Unmarshal(jsonData, &obj); err == nil {
-						return mcp.NewToolResultText(string(jsonData)), nil
-					}
-				}
-				return mcp.NewToolResultText(string(jsonData)), nil
-			}
+			return mcpToolResultFromValue(operationID, result), nil
 		})
 	}
 


### PR DESCRIPTION
Fixes #483.

## Problem

Over MCP, `tools/call` rendered a map or slice result with `fmt.Sprintf("%v", res)` — Go's default map formatting. The same tool, the same operation, two surfaces:

```
REST  POST /tools/currency-exchange-rates
      {"date":"2026-08-28","base":"EUR","quote":"GBP","rate":0.85765}

MCP   tools/call getExchangeRate
      map[base:EUR date:2026-08-28 quote:GBP rate:0.85765]
```

An MCP client, and the model behind it, received something that is not JSON and not documented anywhere. Because it is map-iteration order, it was not even stable between calls.

Worse, which branch was taken depended on the spec: `universalclient.parseResponse` returns a `string` when the operation has no response schema for the status code, and a map/slice when it does. So documenting your 200 response got you the broken formatting, and omitting it got you correct JSON — a perverse incentive, with "omit the 200 response schema" as the workaround.

## Changes

The conversion moves out of the inline switch and into `mcpToolResultFromValue`:

- a `string` passes through untouched — an undocumented response is already the raw upstream body, and re-encoding it would double-quote the JSON;
- everything else is `json.Marshal`ed, so MCP clients see the same payload the REST endpoint returns for the same operation;
- `%v` survives only as a last-resort fallback if marshalling fails, logged rather than silent.

This also drops the redundant marshal → unmarshal → discard round trip the old `default` branch performed to "check if it's a JSON object or array".

## Tests

`TestMCPToolResultFromValue` covers a map (asserting the output parses as JSON and contains no `map[`), stable key order across 20 calls, a slice rendering as a JSON array, a string passing through unchanged, `nil`, and an unmarshalable value (NaN) still returning content via the fallback.

`go test ./proxy/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
