### PR TITLE
fix: MCP inputSchema keeps required markers and parameter descriptions (#484)

### DIFF
--- a/proxy/mcp_input_schema_test.go
+++ b/proxy/mcp_input_schema_test.go
@@ -1,0 +1,157 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/universalclient"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// exchangeRatesSpec mirrors the shape reported in #484: two required path
+// parameters and one optional query parameter, each described on the parameter
+// object as authors normally write them.
+const exchangeRatesSpec = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Currency Exchange Rates", "version": "1.0.0"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/rate/{base}/{quote}": {
+      "get": {
+        "operationId": "getExchangeRate",
+        "description": "Look up the exchange rate between two currencies.",
+        "parameters": [
+          {
+            "name": "base",
+            "in": "path",
+            "required": true,
+            "description": "ISO 4217 code of the currency being converted from.",
+            "schema": {"type": "string"}
+          },
+          {
+            "name": "quote",
+            "in": "path",
+            "required": true,
+            "description": "ISO 4217 code of the currency being converted to.",
+            "schema": {"type": "string"}
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "description": "Rate date in YYYY-MM-DD; defaults to the latest.",
+            "schema": {"type": "string"}
+          }
+        ],
+        "responses": {"200": {"description": "OK"}}
+      }
+    }
+  }
+}`
+
+// buildMCPTool runs a spec through the same path the MCP bridge uses:
+// AsTool -> mcpParameterOptions -> mcp.NewTool.
+func buildMCPTool(t *testing.T, spec, operationID string) mcp.Tool {
+	t.Helper()
+
+	client, err := universalclient.NewClient([]byte(spec), "")
+	require.NoError(t, err)
+
+	tools, err := client.AsTool(operationID)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+
+	opts := []mcp.ToolOption{mcp.WithDescription(tools[0].Function.Description)}
+	opts = append(opts, mcpParameterOptions(tools[0].Function.Parameters)...)
+	return mcp.NewTool(tools[0].Function.Name, opts...)
+}
+
+func TestMCPInputSchemaMarksRequiredParameters(t *testing.T) {
+	tool := buildMCPTool(t, exchangeRatesSpec, "getExchangeRate")
+
+	assert.ElementsMatch(t, []string{"base", "quote"}, tool.InputSchema.Required,
+		"required path parameters must surface as required over MCP")
+
+	// And through the wire format an MCP client actually reads.
+	encoded, err := json.Marshal(tool.InputSchema)
+	require.NoError(t, err)
+
+	var inputSchema struct {
+		Required   []string                          `json:"required"`
+		Properties map[string]map[string]interface{} `json:"properties"`
+	}
+	require.NoError(t, json.Unmarshal(encoded, &inputSchema))
+	assert.ElementsMatch(t, []string{"base", "quote"}, inputSchema.Required)
+	assert.Contains(t, inputSchema.Properties, "date")
+}
+
+func TestMCPInputSchemaCarriesParameterDescriptions(t *testing.T) {
+	tool := buildMCPTool(t, exchangeRatesSpec, "getExchangeRate")
+
+	for name, want := range map[string]string{
+		"base":  "ISO 4217 code of the currency being converted from.",
+		"quote": "ISO 4217 code of the currency being converted to.",
+		"date":  "Rate date in YYYY-MM-DD; defaults to the latest.",
+	} {
+		prop, ok := tool.InputSchema.Properties[name].(map[string]interface{})
+		require.Truef(t, ok, "missing property %q", name)
+		assert.Equalf(t, want, prop["description"],
+			"parameter %q lost the description written on the OpenAPI parameter object", name)
+	}
+}
+
+func TestMCPInputSchemaOmitsEmptyDescriptions(t *testing.T) {
+	const spec = `{
+      "openapi": "3.0.0",
+      "info": {"title": "Bare", "version": "1.0.0"},
+      "servers": [{"url": "https://api.example.com"}],
+      "paths": {
+        "/thing": {
+          "get": {
+            "operationId": "getThing",
+            "parameters": [{"name": "id", "in": "query", "schema": {"type": "string"}}],
+            "responses": {"200": {"description": "OK"}}
+          }
+        }
+      }
+    }`
+
+	tool := buildMCPTool(t, spec, "getThing")
+	prop, ok := tool.InputSchema.Properties["id"].(map[string]interface{})
+	require.True(t, ok)
+	_, hasDescription := prop["description"]
+	assert.False(t, hasDescription, `a parameter with no description must not publish "description": ""`)
+}
+
+func TestSchemaRequiredNames(t *testing.T) {
+	// buildParametersSchema emits []string; a JSON round trip yields
+	// []interface{}. Both have to be understood.
+	assert.Equal(t, []string{"base", "quote"}, schemaRequiredNames([]string{"base", "quote"}))
+	assert.Equal(t, []string{"base", "quote"}, schemaRequiredNames([]interface{}{"base", "quote"}))
+	assert.Equal(t, []string{"base"}, schemaRequiredNames([]interface{}{"base", 42, nil}))
+	assert.Nil(t, schemaRequiredNames(nil))
+	assert.Nil(t, schemaRequiredNames("base"))
+}
+
+func TestFlattenSchemaPropertiesKeepsNestedRequired(t *testing.T) {
+	// SchemaToMap emits a nested object's "required" as []string too.
+	properties := map[string]interface{}{
+		"body": map[string]interface{}{
+			"type":     "object",
+			"required": []string{"amount"},
+			"properties": map[string]interface{}{
+				"amount": map[string]interface{}{"type": "number", "description": "Amount to convert."},
+				"memo":   map[string]interface{}{"type": "string"},
+			},
+		},
+	}
+
+	flattened, required := flattenSchemaProperties(properties, []string{"body"}, "")
+
+	assert.Contains(t, flattened, "body_amount")
+	assert.Contains(t, flattened, "body_memo")
+	assert.Equal(t, []string{"body_amount"}, required)
+	assert.Equal(t, "Amount to convert.", flattened["body_amount"]["description"])
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1662,6 +1662,28 @@ func convertMCPParameterValue(val string, paramType string) interface{} {
 	}
 }
 
+// schemaRequiredNames reads a JSON Schema "required" list. The list arrives as
+// a []string when the schema was built in Go (universalclient.buildParametersSchema
+// and SchemaToMap both emit that) and as a []interface{} when it came back
+// through a JSON round trip. Asserting only one of the two silently dropped
+// every required marker, so an MCP client saw no required parameters at all.
+func schemaRequiredNames(value interface{}) []string {
+	switch list := value.(type) {
+	case []string:
+		return list
+	case []interface{}:
+		names := make([]string, 0, len(list))
+		for _, item := range list {
+			if name, ok := item.(string); ok {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		return nil
+	}
+}
+
 func flattenSchemaProperties(properties map[string]interface{}, required []string, prefix string) (map[string]map[string]interface{}, []string) {
 	flattened := make(map[string]map[string]interface{})
 	flattenedRequired := []string{}
@@ -1684,14 +1706,7 @@ func flattenSchemaProperties(properties map[string]interface{}, required []strin
 			if paramType == "object" {
 				// Recursively flatten nested objects
 				if nestedProps, ok := paramDefMap["properties"].(map[string]interface{}); ok {
-					var nestedRequired []string
-					if reqList, ok := paramDefMap["required"].([]interface{}); ok {
-						for _, req := range reqList {
-							if reqStr, ok := req.(string); ok {
-								nestedRequired = append(nestedRequired, reqStr)
-							}
-						}
-					}
+					nestedRequired := schemaRequiredNames(paramDefMap["required"])
 
 					nestedFlattened, nestedFlattenedRequired := flattenSchemaProperties(nestedProps, nestedRequired, paramName)
 					for k, v := range nestedFlattened {
@@ -1720,32 +1735,59 @@ func flattenSchemaProperties(properties map[string]interface{}, required []strin
 	return flattened, flattenedRequired
 }
 
+// mcpParameterOptions turns the JSON Schema an llms.Tool carries into MCP tool
+// options, flattening nested objects and preserving which parameters the
+// OpenAPI document marks required.
+func mcpParameterOptions(parameters interface{}) []mcp.ToolOption {
+	parametersSchema, ok := parameters.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	properties, ok := parametersSchema["properties"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	required := schemaRequiredNames(parametersSchema["required"])
+
+	// Flatten all properties (including nested objects) for MCP exposure
+	flattenedParams, flattenedRequired := flattenSchemaProperties(properties, required, "")
+	flattenedRequiredSet := make(map[string]bool, len(flattenedRequired))
+	for _, req := range flattenedRequired {
+		flattenedRequiredSet[req] = true
+	}
+
+	options := make([]mcp.ToolOption, 0, len(flattenedParams))
+	for paramName, paramSchema := range flattenedParams {
+		options = append(options, addMCPToolParameter(paramName, paramSchema, flattenedRequiredSet[paramName]))
+	}
+	return options
+}
+
 func addMCPToolParameter(paramName string, paramSchema map[string]interface{}, isRequired bool) mcp.ToolOption {
 	paramType, _ := paramSchema["type"].(string)
 	description, _ := paramSchema["description"].(string)
 
+	// mcp.Description sets the key unconditionally, so passing an empty string
+	// would publish `"description": ""` on every parameter that has none.
+	opts := []mcp.PropertyOption{}
+	if isRequired {
+		opts = append(opts, mcp.Required())
+	}
+	if description != "" {
+		opts = append(opts, mcp.Description(description))
+	}
+
 	switch paramType {
-	case "string":
-		if isRequired {
-			return mcp.WithString(paramName, mcp.Required(), mcp.Description(description))
-		}
-		return mcp.WithString(paramName, mcp.Description(description))
 	case "number", "integer":
-		if isRequired {
-			return mcp.WithNumber(paramName, mcp.Required(), mcp.Description(description))
-		}
-		return mcp.WithNumber(paramName, mcp.Description(description))
+		return mcp.WithNumber(paramName, opts...)
 	case "boolean":
-		if isRequired {
-			return mcp.WithBoolean(paramName, mcp.Required(), mcp.Description(description))
-		}
-		return mcp.WithBoolean(paramName, mcp.Description(description))
+		return mcp.WithBoolean(paramName, opts...)
+	case "string":
+		return mcp.WithString(paramName, opts...)
 	default:
 		// Default to string
-		if isRequired {
-			return mcp.WithString(paramName, mcp.Required(), mcp.Description(description))
-		}
-		return mcp.WithString(paramName, mcp.Description(description))
+		return mcp.WithString(paramName, opts...)
 	}
 }
 
@@ -1860,33 +1902,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 		toolOptions := []mcp.ToolOption{
 			mcp.WithDescription(llmsTool.Function.Description),
 		}
-
-		// Add parameters based on the function definition
-		if parametersSchema, ok := llmsTool.Function.Parameters.(map[string]interface{}); ok {
-			if properties, ok := parametersSchema["properties"].(map[string]interface{}); ok {
-				var required []string
-				if reqList, ok := parametersSchema["required"].([]interface{}); ok {
-					for _, req := range reqList {
-						if reqStr, ok := req.(string); ok {
-							required = append(required, reqStr)
-						}
-					}
-				}
-
-				// Flatten all properties (including nested objects) for MCP exposure
-				flattenedParams, flattenedRequired := flattenSchemaProperties(properties, required, "")
-				flattenedRequiredSet := make(map[string]bool)
-				for _, req := range flattenedRequired {
-					flattenedRequiredSet[req] = true
-				}
-
-				// Add each flattened parameter to MCP tool options
-				for paramName, paramSchema := range flattenedParams {
-					isRequired := flattenedRequiredSet[paramName]
-					toolOptions = append(toolOptions, addMCPToolParameter(paramName, paramSchema, isRequired))
-				}
-			}
-		}
+		toolOptions = append(toolOptions, mcpParameterOptions(llmsTool.Function.Parameters)...)
 
 		mcpTool := mcp.NewTool(llmsTool.Function.Name, toolOptions...)
 

--- a/universalclient/universalclient.go
+++ b/universalclient/universalclient.go
@@ -798,7 +798,29 @@ func (c *Client) buildParametersSchema(operation *v3.Operation) map[string]inter
 	required := []string{}
 
 	for _, param := range operation.Parameters {
-		properties[param.Name] = c.SchemaToMap(param.Schema.Schema())
+		if param == nil {
+			continue
+		}
+
+		var schemaMap map[string]interface{}
+		if param.Schema != nil {
+			schemaMap = c.SchemaToMap(param.Schema.Schema())
+		}
+		if schemaMap == nil {
+			// A parameter can describe its payload with `content` instead of
+			// `schema`, and SchemaToMap returns nil for a nil schema.
+			schemaMap = map[string]interface{}{}
+		}
+
+		// Authors normally put the guidance on the parameter object, not on
+		// its schema, so prefer it and keep the schema description as the
+		// fallback. Without this the description is lost and every parameter
+		// reaches an MCP client with no explanation of what it is for.
+		if param.Description != "" {
+			schemaMap["description"] = param.Description
+		}
+
+		properties[param.Name] = schemaMap
 		if param.Required == nil {
 			continue
 		}


### PR DESCRIPTION
Fixes #484.

## 1. No parameter was ever marked required

`buildParametersSchema` emits the JSON Schema `required` list as a `[]string`:

```go
required := []string{}
r := map[string]interface{}{"type": "object", "properties": properties, "required": required}
```

but the MCP tool-options builder asserted the other shape:

```go
if reqList, ok := parametersSchema["required"].([]interface{}); ok {
```

The assertion always failed, so `required` was dropped from every MCP tool and a client — or the model behind it — could omit a mandatory parameter and only find out from the upstream error.

`SchemaToMap` sets a nested object's `required` as a `[]string` too, so `flattenSchemaProperties` had the identical bug for nested body properties.

Both now go through `schemaRequiredNames`, which accepts a `[]string` (built in Go) or a `[]interface{}` (survived a JSON round trip).

## 2. Parameter descriptions arrived empty

`buildParametersSchema` described each parameter with `SchemaToMap(param.Schema.Schema())`, which only sees the **schema's** `description`. Authors normally write the guidance on the OpenAPI **parameter object**, and that was discarded, so every property reached MCP as `"description": ""` — the operation-level description survived, but the per-parameter guidance did not.

The parameter's own description now takes precedence, with the schema description as the fallback.

## Also in this change

- `mcp.Description` sets the key unconditionally, so a parameter with genuinely no description published `"description": ""`. It is now omitted rather than sent empty.
- `buildParametersSchema` no longer dereferences a nil `param.Schema`, which a parameter declared with `content` instead of `schema` would have panicked on.
- The tool-options loop moves out of `getMCPServerForTool` into `mcpParameterOptions`, so the boundary the issue calls out as uncovered can be tested directly.

## Tests

Against a spec shaped like the reported one (two required path parameters, one optional query parameter, descriptions on the parameter objects), driven through the real path — `AsTool` → `mcpParameterOptions` → `mcp.NewTool`:

- `TestMCPInputSchemaMarksRequiredParameters` — `base` and `quote` surface as required, both on the struct and in the marshalled `inputSchema` an MCP client reads.
- `TestMCPInputSchemaCarriesParameterDescriptions` — each parameter keeps the description written on its OpenAPI parameter object.
- `TestMCPInputSchemaOmitsEmptyDescriptions` — a parameter with no description publishes no `description` key.
- `TestSchemaRequiredNames` — both list shapes, plus mixed and non-list input.
- `TestFlattenSchemaPropertiesKeepsNestedRequired` — a required nested body property survives flattening with its description.

`go test ./proxy/ ./universalclient/ ./chat_session/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
