### PR TITLE
fix: derive MCP tool annotations from the HTTP method (#485)

### DIFF
--- a/features/Tools.md
+++ b/features/Tools.md
@@ -316,6 +316,31 @@ The Tool System provides native integration with the Model Context Protocol (MCP
   * Request parameters are mapped to MCP tool arguments with proper typing.
   * Tool responses are formatted as MCP text content with JSON serialization when appropriate.
 
+* **Tool Annotations:**
+  * Each operation's MCP annotations are derived from its HTTP method:
+
+    | Method | `readOnlyHint` | `destructiveHint` | `idempotentHint` |
+    |---|---|---|---|
+    | `GET`, `HEAD`, `OPTIONS` | `true` | `false` | `true` |
+    | `PUT`, `DELETE` | `false` | `true` | `true` |
+    | `POST`, `PATCH` | `false` | `true` | `false` |
+
+  * `openWorldHint` is `true` for every operation: they all reach a third-party API.
+  * The HTTP method only approximates what an operation does, so a spec can
+    override any hint per operation with a boolean extension:
+
+    ```yaml
+    paths:
+      /search:
+        post:
+          operationId: searchRates
+          x-mcp-read-only: true      # a POST that only reads
+          x-mcp-destructive: false
+          # x-mcp-idempotent, x-mcp-open-world are also honoured
+    ```
+
+  * A non-boolean extension value is ignored and the method-derived hint stands.
+
 **7. Potential Considerations & Future Enhancements**
 
 * **Additional Tool Types:** Support for non-REST tool types (e.g., database queries, custom functions).

--- a/proxy/mcp_annotations_test.go
+++ b/proxy/mcp_annotations_test.go
@@ -1,0 +1,166 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/universalclient"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPAnnotationsForMethod(t *testing.T) {
+	cases := []struct {
+		method                            string
+		readOnly, destructive, idempotent bool
+	}{
+		{"GET", true, false, true},
+		{"HEAD", true, false, true},
+		{"OPTIONS", true, false, true},
+		{"PUT", false, true, true},
+		{"DELETE", false, true, true},
+		{"POST", false, true, false},
+		{"PATCH", false, true, false},
+		// Unknown methods keep the cautious defaults.
+		{"TRACE", false, true, false},
+		{"", false, true, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			a := mcpAnnotationsForMethod(tc.method)
+			require.NotNil(t, a.ReadOnlyHint)
+			require.NotNil(t, a.DestructiveHint)
+			require.NotNil(t, a.IdempotentHint)
+			require.NotNil(t, a.OpenWorldHint)
+
+			assert.Equal(t, tc.readOnly, *a.ReadOnlyHint, "readOnlyHint")
+			assert.Equal(t, tc.destructive, *a.DestructiveHint, "destructiveHint")
+			assert.Equal(t, tc.idempotent, *a.IdempotentHint, "idempotentHint")
+			// Every operation reaches a third-party API.
+			assert.True(t, *a.OpenWorldHint, "openWorldHint")
+		})
+	}
+
+	t.Run("method matching is case-insensitive", func(t *testing.T) {
+		assert.True(t, *mcpAnnotationsForMethod("get").ReadOnlyHint)
+	})
+}
+
+func TestApplyMCPAnnotationOverrides(t *testing.T) {
+	t.Run("no extensions leaves the method-derived hints alone", func(t *testing.T) {
+		a := applyMCPAnnotationOverrides(mcpAnnotationsForMethod("POST"), nil)
+		assert.True(t, *a.DestructiveHint)
+		assert.False(t, *a.ReadOnlyHint)
+	})
+
+	t.Run("an author can mark a POST read-only", func(t *testing.T) {
+		// A POST that runs a search is not destructive; the HTTP method only
+		// ever approximates what the operation does.
+		a := applyMCPAnnotationOverrides(mcpAnnotationsForMethod("POST"), map[string]string{
+			extReadOnlyHint:    "true",
+			extDestructiveHint: "false",
+			extIdempotentHint:  "true",
+			extOpenWorldHint:   "false",
+		})
+		assert.True(t, *a.ReadOnlyHint)
+		assert.False(t, *a.DestructiveHint)
+		assert.True(t, *a.IdempotentHint)
+		assert.False(t, *a.OpenWorldHint)
+	})
+
+	t.Run("a non-boolean value is ignored", func(t *testing.T) {
+		a := applyMCPAnnotationOverrides(mcpAnnotationsForMethod("GET"), map[string]string{
+			extDestructiveHint: "maybe",
+		})
+		assert.False(t, *a.DestructiveHint, "the method-derived hint must survive a bad override")
+	})
+}
+
+func TestMCPAnnotationsForOperation(t *testing.T) {
+	const spec = `{
+      "openapi": "3.0.0",
+      "info": {"title": "Currency Exchange Rates", "version": "1.0.0"},
+      "servers": [{"url": "https://api.example.com"}],
+      "paths": {
+        "/rate/{base}/{quote}": {
+          "get": {
+            "operationId": "getExchangeRate",
+            "parameters": [
+              {"name": "base", "in": "path", "required": true, "schema": {"type": "string"}},
+              {"name": "quote", "in": "path", "required": true, "schema": {"type": "string"}}
+            ],
+            "responses": {"200": {"description": "OK"}}
+          }
+        },
+        "/alerts": {
+          "post": {
+            "operationId": "createAlert",
+            "responses": {"201": {"description": "Created"}}
+          }
+        },
+        "/search": {
+          "post": {
+            "operationId": "searchRates",
+            "x-mcp-read-only": true,
+            "x-mcp-destructive": false,
+            "responses": {"200": {"description": "OK"}}
+          }
+        }
+      }
+    }`
+
+	client, err := universalclient.NewClient([]byte(spec), "")
+	require.NoError(t, err)
+
+	t.Run("a read-only GET is not annotated destructive", func(t *testing.T) {
+		a := mcpAnnotationsForOperation(client, "getExchangeRate")
+		assert.True(t, *a.ReadOnlyHint)
+		assert.False(t, *a.DestructiveHint, "a GET must not carry a DESTRUCTIVE badge")
+		assert.True(t, *a.IdempotentHint)
+		assert.True(t, *a.OpenWorldHint)
+	})
+
+	t.Run("a POST stays destructive", func(t *testing.T) {
+		a := mcpAnnotationsForOperation(client, "createAlert")
+		assert.False(t, *a.ReadOnlyHint)
+		assert.True(t, *a.DestructiveHint)
+		assert.False(t, *a.IdempotentHint)
+	})
+
+	t.Run("the spec can override the method", func(t *testing.T) {
+		a := mcpAnnotationsForOperation(client, "searchRates")
+		assert.True(t, *a.ReadOnlyHint)
+		assert.False(t, *a.DestructiveHint)
+	})
+
+	t.Run("an unknown operation falls back to the cautious defaults", func(t *testing.T) {
+		a := mcpAnnotationsForOperation(client, "noSuchOperation")
+		assert.False(t, *a.ReadOnlyHint)
+		assert.True(t, *a.DestructiveHint)
+	})
+
+	t.Run("annotations reach the wire format", func(t *testing.T) {
+		tool := mcp.NewTool("getExchangeRate",
+			mcp.WithToolAnnotation(mcpAnnotationsForOperation(client, "getExchangeRate")))
+
+		encoded, err := json.Marshal(tool)
+		require.NoError(t, err)
+
+		var decoded struct {
+			Annotations struct {
+				ReadOnlyHint    *bool `json:"readOnlyHint"`
+				DestructiveHint *bool `json:"destructiveHint"`
+				IdempotentHint  *bool `json:"idempotentHint"`
+				OpenWorldHint   *bool `json:"openWorldHint"`
+			} `json:"annotations"`
+		}
+		require.NoError(t, json.Unmarshal(encoded, &decoded))
+		require.NotNil(t, decoded.Annotations.DestructiveHint)
+		assert.False(t, *decoded.Annotations.DestructiveHint)
+		assert.True(t, *decoded.Annotations.ReadOnlyHint)
+		assert.True(t, *decoded.Annotations.IdempotentHint)
+		assert.True(t, *decoded.Annotations.OpenWorldHint)
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1777,6 +1777,84 @@ func reconstructNestedObject(request mcp.CallToolRequest, prefix string, schema 
 	return result
 }
 
+// MCP annotation overrides an author can set on an OpenAPI operation. The HTTP
+// method is only ever an approximation of what an operation does - a POST that
+// runs a search is not destructive, and a GET that mints a resource is - so a
+// spec can say so directly.
+const (
+	extReadOnlyHint    = "x-mcp-read-only"
+	extDestructiveHint = "x-mcp-destructive"
+	extIdempotentHint  = "x-mcp-idempotent"
+	extOpenWorldHint   = "x-mcp-open-world"
+)
+
+// mcpAnnotationsForMethod derives MCP tool annotations from an operation's HTTP
+// method. Without this every operation inherited mcp.NewTool's conservative
+// defaults - readOnly false, destructive true - so a read-only GET was rendered
+// with a red DESTRUCTIVE badge, and clients that gate on destructiveHint
+// treated every tool as dangerous, devaluing the hint where it matters.
+func mcpAnnotationsForMethod(method string) mcp.ToolAnnotation {
+	annotation := mcp.ToolAnnotation{
+		// Every operation calls out to a third-party API.
+		OpenWorldHint: mcp.ToBoolPtr(true),
+	}
+
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		annotation.ReadOnlyHint = mcp.ToBoolPtr(true)
+		annotation.DestructiveHint = mcp.ToBoolPtr(false)
+		annotation.IdempotentHint = mcp.ToBoolPtr(true)
+	case http.MethodPut, http.MethodDelete:
+		annotation.ReadOnlyHint = mcp.ToBoolPtr(false)
+		annotation.DestructiveHint = mcp.ToBoolPtr(true)
+		annotation.IdempotentHint = mcp.ToBoolPtr(true)
+	case http.MethodPost, http.MethodPatch:
+		annotation.ReadOnlyHint = mcp.ToBoolPtr(false)
+		annotation.DestructiveHint = mcp.ToBoolPtr(true)
+		annotation.IdempotentHint = mcp.ToBoolPtr(false)
+	default:
+		// An unrecognised method gets the cautious defaults.
+		annotation.ReadOnlyHint = mcp.ToBoolPtr(false)
+		annotation.DestructiveHint = mcp.ToBoolPtr(true)
+		annotation.IdempotentHint = mcp.ToBoolPtr(false)
+	}
+
+	return annotation
+}
+
+// applyMCPAnnotationOverrides lets the OpenAPI document override any hint the
+// HTTP method implied. A non-boolean value is ignored rather than guessed at.
+func applyMCPAnnotationOverrides(annotation mcp.ToolAnnotation, extensions map[string]string) mcp.ToolAnnotation {
+	override := func(target **bool, name string) {
+		raw, ok := extensions[name]
+		if !ok {
+			return
+		}
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			logger.Warnf("MCP annotation %s: %q is not a boolean, ignoring", name, raw)
+			return
+		}
+		*target = mcp.ToBoolPtr(value)
+	}
+
+	override(&annotation.ReadOnlyHint, extReadOnlyHint)
+	override(&annotation.DestructiveHint, extDestructiveHint)
+	override(&annotation.IdempotentHint, extIdempotentHint)
+	override(&annotation.OpenWorldHint, extOpenWorldHint)
+
+	return annotation
+}
+
+func mcpAnnotationsForOperation(client *universalclient.Client, operationID string) mcp.ToolAnnotation {
+	binding, err := client.GetOperationBinding(operationID)
+	if err != nil {
+		logger.Warnf("MCP operation %s: could not resolve HTTP binding, using default annotations: %v", operationID, err)
+		return mcpAnnotationsForMethod("")
+	}
+	return applyMCPAnnotationOverrides(mcpAnnotationsForMethod(binding.Method), binding.Extensions)
+}
+
 func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*MCPServerCache, error) {
 	// Create a hash of the tool operations to detect changes
 	currentOpHash := p.generateOperationHash(toolModel)
@@ -1859,6 +1937,7 @@ func (p *Proxy) getMCPServerForTool(toolModel *models.Tool, r *http.Request) (*M
 		// Create a new MCP tool with the operation name and description
 		toolOptions := []mcp.ToolOption{
 			mcp.WithDescription(llmsTool.Function.Description),
+			mcp.WithToolAnnotation(mcpAnnotationsForOperation(client, operationID)),
 		}
 
 		// Add parameters based on the function definition

--- a/universalclient/operation_index_test.go
+++ b/universalclient/operation_index_test.go
@@ -1,0 +1,148 @@
+package universalclient
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// multiMethodSpec exercises every HTTP verb a path item can carry, so the index
+// has to record the right method for each of them.
+const multiMethodSpec = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Verbs", "version": "1.0.0"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {
+    "/things": {
+      "get":    {"operationId": "listThings",   "responses": {"200": {"description": "ok"}}},
+      "post":   {"operationId": "createThing",  "responses": {"200": {"description": "ok"}}},
+      "put":    {"operationId": "replaceThing", "responses": {"200": {"description": "ok"}}},
+      "delete": {"operationId": "deleteThing",  "responses": {"200": {"description": "ok"}}},
+      "patch":  {"operationId": "patchThing",   "responses": {"200": {"description": "ok"}}},
+      "head":   {"operationId": "headThing",    "responses": {"200": {"description": "ok"}}},
+      "options":{"operationId": "optionsThing", "responses": {"200": {"description": "ok"}}}
+    },
+    "/things/{id}": {
+      "get": {"operationId": "getThing", "responses": {"200": {"description": "ok"}}}
+    }
+  }
+}`
+
+// The index has to resolve every operation to the same path and method the
+// document declares it under, across all path items.
+func TestOperationIndexResolvesEveryMethod(t *testing.T) {
+	client, err := NewClient([]byte(multiMethodSpec), "")
+	require.NoError(t, err)
+
+	cases := []struct {
+		operationID string
+		method      string
+		path        string
+	}{
+		{"listThings", http.MethodGet, "/things"},
+		{"createThing", http.MethodPost, "/things"},
+		{"replaceThing", http.MethodPut, "/things"},
+		{"deleteThing", http.MethodDelete, "/things"},
+		{"patchThing", http.MethodPatch, "/things"},
+		{"headThing", http.MethodHead, "/things"},
+		{"optionsThing", http.MethodOptions, "/things"},
+		{"getThing", http.MethodGet, "/things/{id}"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.operationID, func(t *testing.T) {
+			operation, path, method, err := client.findOperation(tc.operationID)
+			require.NoError(t, err)
+			assert.Equal(t, tc.operationID, operation.OperationId)
+			assert.Equal(t, tc.method, method)
+			assert.Equal(t, tc.path, path)
+		})
+	}
+}
+
+func TestOperationIndexUnknownOperation(t *testing.T) {
+	client, err := NewClient([]byte(multiMethodSpec), "")
+	require.NoError(t, err)
+
+	_, _, _, err = client.findOperation("noSuchOperation")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operation not found: noSuchOperation")
+}
+
+// The index is what keeps a lookup off the O(number of operations) scan the
+// document walk used to do, so it has to survive the first call: building an
+// MCP server calls findOperation once per operation, twice over.
+func TestOperationIndexBuiltOnce(t *testing.T) {
+	client, err := NewClient([]byte(multiMethodSpec), "")
+	require.NoError(t, err)
+
+	first, err := client.operationLocations()
+	require.NoError(t, err)
+	second, err := client.operationLocations()
+	require.NoError(t, err)
+
+	// Both calls handed back the same map, so the second one did not rescan.
+	first["sentinel"] = &operationLocation{}
+	assert.Contains(t, second, "sentinel")
+}
+
+// The handlers an MCP server registers capture the client and can run at the
+// same time, so the lazily built index must be safe to race on.
+func TestOperationIndexConcurrentLookups(t *testing.T) {
+	client, err := NewClient([]byte(multiMethodSpec), "")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, path, method, err := client.findOperation("getThing")
+			assert.NoError(t, err)
+			assert.Equal(t, http.MethodGet, method)
+			assert.Equal(t, "/things/{id}", path)
+		}()
+	}
+	wg.Wait()
+}
+
+// A lookup used to walk every path item, so cost grew with the size of the
+// spec. Benchmark against a deliberately large document to keep that honest.
+func BenchmarkFindOperationLargeSpec(b *testing.B) {
+	paths := ""
+	const operationCount = 500
+	for i := 0; i < operationCount; i++ {
+		if i > 0 {
+			paths += ","
+		}
+		paths += fmt.Sprintf(
+			`"/resource%d": {"get": {"operationId": "getResource%d", "responses": {"200": {"description": "ok"}}}}`,
+			i, i,
+		)
+	}
+	spec := fmt.Sprintf(`{
+  "openapi": "3.0.0",
+  "info": {"title": "Large", "version": "1.0.0"},
+  "servers": [{"url": "https://api.example.com"}],
+  "paths": {%s}
+}`, paths)
+
+	client, err := NewClient([]byte(spec), "")
+	require.NoError(b, err)
+
+	// The last operation is the worst case for the old linear scan.
+	target := fmt.Sprintf("getResource%d", operationCount-1)
+	_, _, _, err = client.findOperation(target)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := client.findOperation(target); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/universalclient/universalclient.go
+++ b/universalclient/universalclient.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pb33f/libopenapi"
@@ -92,6 +93,12 @@ type Client struct {
 	httpClient     *http.Client
 	responseFormat ResponseFormat
 	authConfig     AuthConfig
+
+	// The spec is fixed for the lifetime of a client, so the operation index
+	// is built once on first use. See operationLocations.
+	operationIndexOnce sync.Once
+	operationIndex     map[string]*operationLocation
+	operationIndexErr  error
 }
 
 // ClientOption is a function that configures a Client
@@ -383,37 +390,87 @@ func (c *Client) CallOperation(operationId string, params map[string][]string, p
 	return c.parseResponse(resp, operation)
 }
 
-func (c *Client) findOperation(operationId string) (*v3.Operation, string, string, error) {
-	model, err := c.spec.BuildV3Model()
-	if err != nil {
-		return nil, "", "", fmt.Errorf("failed to build V3 model: %v", err)
+// operationLocation records where an operation lives in the spec, so a lookup
+// by operation ID does not have to walk the document.
+type operationLocation struct {
+	operation *v3.Operation
+	path      string
+	method    string // upper-case HTTP method, e.g. "GET"
+}
+
+// pathItemOperations returns a path item's operations paired with their HTTP
+// method. The order is fixed rather than map iteration order so that a spec
+// which reuses an operation ID resolves to the same operation on every run.
+func pathItemOperations(pathItem *v3.PathItem) []operationLocation {
+	return []operationLocation{
+		{operation: pathItem.Get, method: http.MethodGet},
+		{operation: pathItem.Post, method: http.MethodPost},
+		{operation: pathItem.Put, method: http.MethodPut},
+		{operation: pathItem.Delete, method: http.MethodDelete},
+		{operation: pathItem.Options, method: http.MethodOptions},
+		{operation: pathItem.Head, method: http.MethodHead},
+		{operation: pathItem.Patch, method: http.MethodPatch},
+		{operation: pathItem.Trace, method: http.MethodTrace},
 	}
+}
 
-	pathItems := model.Model.Paths.PathItems
-
-	for pair := pathItems.First(); pair != nil; pair = pair.Next() {
-		path := pair.Key()
-		pathItem := pair.Value()
-
-		methods := map[string]*v3.Operation{
-			"GET":     pathItem.Get,
-			"POST":    pathItem.Post,
-			"PUT":     pathItem.Put,
-			"DELETE":  pathItem.Delete,
-			"OPTIONS": pathItem.Options,
-			"HEAD":    pathItem.Head,
-			"PATCH":   pathItem.Patch,
-			"TRACE":   pathItem.Trace,
+// operationLocations returns the operation-ID index, building it on first use.
+//
+// This used to be a scan of every path item on every lookup. Both AsTool and
+// the MCP annotation lookup call findOperation once per operation, so building
+// an MCP server for a tool with N operations over an M-operation spec walked
+// the document O(N*M) times. The spec cannot change after NewClient, so one
+// pass is enough and every later lookup is a map hit.
+//
+// The returned map is shared and must be treated as read-only by callers.
+func (c *Client) operationLocations() (map[string]*operationLocation, error) {
+	c.operationIndexOnce.Do(func() {
+		model, err := c.spec.BuildV3Model()
+		if err != nil {
+			c.operationIndexErr = fmt.Errorf("failed to build V3 model: %v", err)
+			return
 		}
 
-		for method, op := range methods {
-			if op != nil && op.OperationId == operationId {
-				return op, path, method, nil
+		index := make(map[string]*operationLocation)
+		for pair := model.Model.Paths.PathItems.First(); pair != nil; pair = pair.Next() {
+			path := pair.Key()
+
+			for _, entry := range pathItemOperations(pair.Value()) {
+				if entry.operation == nil || entry.operation.OperationId == "" {
+					continue
+				}
+				// Operation IDs are unique within a spec. If one is duplicated
+				// anyway, the first occurrence wins, as the old scan did.
+				if _, exists := index[entry.operation.OperationId]; exists {
+					continue
+				}
+
+				index[entry.operation.OperationId] = &operationLocation{
+					operation: entry.operation,
+					path:      path,
+					method:    entry.method,
+				}
 			}
 		}
+
+		c.operationIndex = index
+	})
+
+	return c.operationIndex, c.operationIndexErr
+}
+
+func (c *Client) findOperation(operationId string) (*v3.Operation, string, string, error) {
+	index, err := c.operationLocations()
+	if err != nil {
+		return nil, "", "", err
 	}
 
-	return nil, "", "", fmt.Errorf("operation not found: %s", operationId)
+	location, ok := index[operationId]
+	if !ok {
+		return nil, "", "", fmt.Errorf("operation not found: %s", operationId)
+	}
+
+	return location.operation, location.path, location.method, nil
 }
 
 func (c *Client) constructURL(path string, params map[string][]string) (string, error) {

--- a/universalclient/universalclient.go
+++ b/universalclient/universalclient.go
@@ -589,6 +589,47 @@ func (c *Client) parseXMLResponse(data []byte, schema *base.SchemaProxy) (interf
 	return result, nil
 }
 
+// OperationBinding describes how an operation is bound to HTTP, along with the
+// scalar vendor extensions declared on it. Callers that need to reason about an
+// operation's effects - the MCP bridge derives its tool annotations this way -
+// need the method, which is otherwise only visible inside findOperation.
+type OperationBinding struct {
+	OperationID string
+	Method      string // upper-case HTTP method, e.g. "GET"
+	Path        string // templated path, e.g. "/rate/{base}/{quote}"
+
+	// Extensions holds the operation's x-* extensions whose value is a scalar,
+	// keyed by the lower-cased extension name including the "x-" prefix.
+	Extensions map[string]string
+}
+
+// GetOperationBinding returns the HTTP binding for an operation ID.
+func (c *Client) GetOperationBinding(operationId string) (*OperationBinding, error) {
+	operation, path, method, err := c.findOperation(operationId)
+	if err != nil {
+		return nil, err
+	}
+
+	binding := &OperationBinding{
+		OperationID: operationId,
+		Method:      strings.ToUpper(method),
+		Path:        path,
+		Extensions:  map[string]string{},
+	}
+
+	if operation.Extensions != nil {
+		for pair := operation.Extensions.First(); pair != nil; pair = pair.Next() {
+			node := pair.Value()
+			if node == nil || node.Kind != yaml.ScalarNode {
+				continue
+			}
+			binding.Extensions[strings.ToLower(pair.Key())] = node.Value
+		}
+	}
+
+	return binding, nil
+}
+
 func (c *Client) ListOperations() ([]string, error) {
 	model, err := c.spec.BuildV3Model()
 	if err != nil {


### PR DESCRIPTION
Fixes #485.

## Problem

`mcp.NewTool` seeds every tool with deliberately cautious annotations — `readOnlyHint: false`, `destructiveHint: true` — and nothing ever overrode them. So `tools/list` reported a read-only `GET` that looks up a currency exchange rate as:

```json
"annotations": {
  "readOnlyHint": false,
  "destructiveHint": true,
  "idempotentHint": false,
  "openWorldHint": true
}
```

MCP Inspector renders that as a red **DESTRUCTIVE** badge, and clients that gate on `destructiveHint` — asking for confirmation, or refusing autonomous use — treated every AI Studio tool as dangerous. That both degrades the experience and devalues the hint for the operations that genuinely are destructive.

## Changes

Annotations are now derived from the operation's HTTP method, which the bridge already has:

| Method | `readOnlyHint` | `destructiveHint` | `idempotentHint` |
|---|---|---|---|
| `GET`, `HEAD`, `OPTIONS` | `true` | `false` | `true` |
| `PUT`, `DELETE` | `false` | `true` | `true` |
| `POST`, `PATCH` | `false` | `true` | `false` |

`openWorldHint` stays `true` throughout — every operation reaches a third-party API — and an unrecognised method keeps the cautious defaults.

**Per-operation override.** The issue notes that "destructive" is a judgement the HTTP method only approximates. A spec can say so directly, with no schema or UI change:

```yaml
paths:
  /search:
    post:
      operationId: searchRates
      x-mcp-read-only: true      # a POST that only reads
      x-mcp-destructive: false
      # x-mcp-idempotent and x-mcp-open-world are also honoured
```

A non-boolean value is logged and ignored, and the method-derived hint stands.

**`universalclient.GetOperationBinding`** exposes an operation's method, templated path and scalar vendor extensions, which were previously only visible inside the unexported `findOperation`.

## Tests

- `TestMCPAnnotationsForMethod` — all seven methods plus an unknown one and the empty string; case-insensitive matching.
- `TestApplyMCPAnnotationOverrides` — no extensions leaves the method-derived hints alone; all four overrides applied; a non-boolean value ignored.
- `TestMCPAnnotationsForOperation` — driven from a real spec: a `GET` is not destructive, a `POST` still is, `x-mcp-*` overrides the method, an unknown operation falls back to the cautious defaults, and the hints survive to the marshalled `annotations` object an MCP client reads.

`features/Tools.md` documents the mapping and the extensions. `go test ./proxy/ ./universalclient/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
