### PR TITLE
fix: let browser MCP clients reach the tool endpoints (#486)

### DIFF
--- a/microgateway/internal/api/gateway_routes_test.go
+++ b/microgateway/internal/api/gateway_routes_test.go
@@ -14,6 +14,7 @@ import (
 // SetupRouter.
 func mountGatewayRoutes(router *gin.Engine, h http.Handler) {
 	gateway := router.Group("/")
+	gateway.Any("/.well-known/*path", gin.WrapH(h))
 	gateway.Any("/llm/*path", gin.WrapH(h))
 	gateway.Any("/tools/*path", gin.WrapH(h))
 	gateway.Any("/datasource/*path", gin.WrapH(h))
@@ -64,6 +65,48 @@ func TestGatewayRoutes_ForwardAnthropicBridge(t *testing.T) {
 			}
 			if !tc.wantForward && gotPath != "" {
 				t.Errorf("did not expect forward, but handler saw %q", gotPath)
+			}
+		})
+	}
+}
+
+// TestGatewayRoutes_ServeOAuthProtectedResourceMetadata covers the discovery
+// document an unauthenticated MCP request advertises in its WWW-Authenticate
+// header. Before it was mounted, the edge pointed clients at a URL that gin
+// answered with a 404, so a browser client could complete no handshake.
+func TestGatewayRoutes_ServeOAuthProtectedResourceMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var gotPath string
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	})
+
+	router := gin.New()
+	mountGatewayRoutes(router, stub)
+
+	cases := []struct {
+		name        string
+		method      string
+		path        string
+		wantStatus  int
+		wantForward bool
+	}{
+		{"metadata", http.MethodGet, "/.well-known/oauth-protected-resource", http.StatusOK, true},
+		{"metadata preflight", http.MethodOptions, "/.well-known/oauth-protected-resource", http.StatusOK, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath = ""
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, nil))
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", w.Code, tc.wantStatus)
+			}
+			if tc.wantForward && gotPath != tc.path {
+				t.Errorf("expected forward to handler with path %q, got %q", tc.path, gotPath)
 			}
 		})
 	}

--- a/microgateway/internal/api/router.go
+++ b/microgateway/internal/api/router.go
@@ -278,6 +278,12 @@ func SetupRouter(config *RouterConfig) *gin.Engine {
 		gateway := router.Group("/")
 
 		log.Debug().Msg("Mounting AI Gateway handler (plugins integrated via hooks)")
+		// An unauthenticated MCP request to the edge answers with
+		// WWW-Authenticate: Bearer ... resource_metadata_uri="<edge>/.well-known/
+		// oauth-protected-resource". Without this mount the edge advertised a
+		// document it did not serve, and a client following the metadata got a
+		// 404 from gin. The gateway handler already implements the endpoint.
+		gateway.Any("/.well-known/*path", gin.WrapH(config.Gateway.Handler()))
 		gateway.Any("/llm/*path", gin.WrapH(config.Gateway.Handler()))
 		gateway.Any("/tools/*path", gin.WrapH(config.Gateway.Handler()))
 		gateway.Any("/datasource/*path", gin.WrapH(config.Gateway.Handler()))

--- a/pkg/corsutil/corsutil.go
+++ b/pkg/corsutil/corsutil.go
@@ -41,9 +41,22 @@ func AllowOrigin(requestOrigin string) (string, bool) {
 	return "", true
 }
 
+// DefaultAllowHeaders is the Access-Control-Allow-Headers value used by
+// SetCORSHeaders.
+const DefaultAllowHeaders = "Origin, Content-Type, Accept, Authorization"
+
 // SetCORSHeaders applies the CORS policy to a response header set.
 // methods is the value for Access-Control-Allow-Methods.
 func SetCORSHeaders(h http.Header, requestOrigin, methods string) {
+	SetCORSHeadersFor(h, requestOrigin, methods, DefaultAllowHeaders, "")
+}
+
+// SetCORSHeadersFor applies the CORS policy with explicit allowed and exposed
+// header lists. Protocols carried over HTTP need more than the default set:
+// MCP's StreamableHTTP transport sends Mcp-Session-Id and MCP-Protocol-Version
+// on requests and returns Mcp-Session-Id, which a browser client cannot read
+// unless it is exposed. exposeHeaders may be empty.
+func SetCORSHeadersFor(h http.Header, requestOrigin, methods, allowHeaders, exposeHeaders string) {
 	origin, configured := AllowOrigin(requestOrigin)
 	if origin != "" {
 		h.Set("Access-Control-Allow-Origin", origin)
@@ -52,6 +65,12 @@ func SetCORSHeaders(h http.Header, requestOrigin, methods string) {
 		h.Add("Vary", "Origin")
 	}
 	h.Set("Access-Control-Allow-Methods", methods)
-	h.Set("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, Authorization")
+	if allowHeaders == "" {
+		allowHeaders = DefaultAllowHeaders
+	}
+	h.Set("Access-Control-Allow-Headers", allowHeaders)
+	if exposeHeaders != "" {
+		h.Set("Access-Control-Expose-Headers", exposeHeaders)
+	}
 	h.Set("Access-Control-Max-Age", "43200") // 12 hours
 }

--- a/pkg/corsutil/corsutil_test.go
+++ b/pkg/corsutil/corsutil_test.go
@@ -81,3 +81,46 @@ func TestSetCORSHeaders(t *testing.T) {
 		}
 	})
 }
+
+func TestSetCORSHeadersFor(t *testing.T) {
+	t.Run("custom allow and expose header lists", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "")
+		w := httptest.NewRecorder()
+		SetCORSHeadersFor(w.Header(), "https://x.example.com",
+			"GET, POST, DELETE, OPTIONS",
+			DefaultAllowHeaders+", Mcp-Session-Id",
+			"Mcp-Session-Id")
+
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != DefaultAllowHeaders+", Mcp-Session-Id" {
+			t.Errorf("unexpected allow-headers: %q", got)
+		}
+		if got := w.Header().Get("Access-Control-Expose-Headers"); got != "Mcp-Session-Id" {
+			t.Errorf("unexpected expose-headers: %q", got)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, DELETE, OPTIONS" {
+			t.Errorf("unexpected allow-methods: %q", got)
+		}
+	})
+
+	t.Run("empty allow list falls back to the default", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "")
+		w := httptest.NewRecorder()
+		SetCORSHeadersFor(w.Header(), "https://x.example.com", "GET, OPTIONS", "", "")
+
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != DefaultAllowHeaders {
+			t.Errorf("unexpected allow-headers: %q", got)
+		}
+		if w.Header().Get("Access-Control-Expose-Headers") != "" {
+			t.Error("expose-headers must be omitted when empty")
+		}
+	})
+
+	t.Run("origin policy still applies", func(t *testing.T) {
+		t.Setenv(EnvAllowedOrigins, "https://app.example.com")
+		w := httptest.NewRecorder()
+		SetCORSHeadersFor(w.Header(), "https://evil.example.com", "GET, OPTIONS", "", "")
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("expected no allow-origin header, got %q", got)
+		}
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -422,8 +422,49 @@ func (p *Proxy) createHandler() http.Handler {
 
 	// Middleware chain (innermost to outermost):
 	// 1. combinedHandler - Route /ai/ separately from authenticated routes
-	// 2. cloudflareHeadersMiddleware - Add Cloudflare headers
-	return p.cloudflareHeadersMiddleware(combinedHandler)
+	// 2. toolCORSMiddleware - CORS + preflight for /tools/, ahead of auth
+	// 3. cloudflareHeadersMiddleware - Add Cloudflare headers
+	return p.cloudflareHeadersMiddleware(toolCORSMiddleware(combinedHandler))
+}
+
+// Header names the MCP StreamableHTTP transport relies on. A browser client
+// sends the session id and negotiated protocol version on every request after
+// initialize, and reads the session id off the initialize response, so both
+// have to be allowed and the response one exposed. Last-Event-ID is how a
+// resumed SSE stream says where it left off.
+const (
+	mcpCORSAllowHeaders  = corsutil.DefaultAllowHeaders + ", Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID"
+	mcpCORSExposeHeaders = "Mcp-Session-Id, MCP-Protocol-Version, WWW-Authenticate"
+	mcpCORSAllowMethods  = "GET, POST, DELETE, OPTIONS"
+)
+
+// toolCORSMiddleware makes the tool and MCP endpoints reachable from a browser.
+//
+// pkg/corsutil was applied to the OAuth and metadata handlers but never to
+// /tools/{slug} or its MCP transports, and the preflight never reached a
+// handler that could have added the headers: OPTIONS carries no credentials,
+// so the credential middleware answered it with a 401 and no
+// Access-Control-Allow-Origin. The effect was that MCP Inspector - the
+// protocol's reference client, which talks to HTTP servers directly from the
+// browser - could not connect at all. Running ahead of authentication is what
+// the CORS preflight requires: it is an unauthenticated probe by design.
+func toolCORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/tools/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		corsutil.SetCORSHeadersFor(w.Header(), r.Header.Get("Origin"),
+			mcpCORSAllowMethods, mcpCORSAllowHeaders, mcpCORSExposeHeaders)
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 // upstreamGuardedTransport is the shared transport for all upstream LLM

--- a/proxy/tool_cors_test.go
+++ b/proxy/tool_cors_test.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/TykTechnologies/midsommar/v2/pkg/corsutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// inspectorOrigin is the origin MCP Inspector v2 serves itself from.
+const inspectorOrigin = "http://127.0.0.1:6274"
+
+func corsTestHandler() (http.Handler, *bool) {
+	reached := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	return toolCORSMiddleware(next), &reached
+}
+
+func TestToolCORSMiddleware_AnswersPreflightAheadOfAuth(t *testing.T) {
+	t.Setenv(corsutil.EnvAllowedOrigins, "")
+
+	for _, path := range []string{
+		"/tools/currency-exchange-rates",
+		"/tools/currency-exchange-rates/mcp",
+		"/tools/currency-exchange-rates/mcp/sse",
+		"/tools/currency-exchange-rates/mcp/message",
+	} {
+		t.Run(path, func(t *testing.T) {
+			handler, reached := corsTestHandler()
+
+			req := httptest.NewRequest(http.MethodOptions, path, nil)
+			req.Header.Set("Origin", inspectorOrigin)
+			req.Header.Set("Access-Control-Request-Method", "POST")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			// The preflight carries no credentials by design, so it has to be
+			// answered before the credential middleware turns it into a 401.
+			assert.Equal(t, http.StatusNoContent, w.Code)
+			assert.False(t, *reached, "the preflight must not reach the authenticated handler")
+			assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+			assert.Contains(t, w.Header().Get("Access-Control-Allow-Methods"), "POST")
+		})
+	}
+}
+
+func TestToolCORSMiddleware_AllowsMCPTransportHeaders(t *testing.T) {
+	t.Setenv(corsutil.EnvAllowedOrigins, "")
+	handler, _ := corsTestHandler()
+
+	req := httptest.NewRequest(http.MethodOptions, "/tools/x/mcp", nil)
+	req.Header.Set("Origin", inspectorOrigin)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	allow := w.Header().Get("Access-Control-Allow-Headers")
+	for _, header := range []string{"Authorization", "Content-Type", "Mcp-Session-Id", "MCP-Protocol-Version", "Last-Event-ID"} {
+		assert.Truef(t, strings.Contains(allow, header), "Access-Control-Allow-Headers must include %s, got %q", header, allow)
+	}
+
+	// The session id is minted on the initialize response; a browser client
+	// cannot read it back unless it is exposed.
+	expose := w.Header().Get("Access-Control-Expose-Headers")
+	assert.Contains(t, expose, "Mcp-Session-Id")
+	assert.Contains(t, expose, "WWW-Authenticate")
+}
+
+func TestToolCORSMiddleware_TagsActualRequests(t *testing.T) {
+	t.Setenv(corsutil.EnvAllowedOrigins, "")
+	handler, reached := corsTestHandler()
+
+	req := httptest.NewRequest(http.MethodPost, "/tools/x/mcp", strings.NewReader("{}"))
+	req.Header.Set("Origin", inspectorOrigin)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	require.True(t, *reached, "a real request must still reach the authenticated handler")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"),
+		"without this the browser discards the response even though the call succeeded")
+}
+
+func TestToolCORSMiddleware_HonoursAllowlist(t *testing.T) {
+	t.Setenv(corsutil.EnvAllowedOrigins, inspectorOrigin)
+
+	t.Run("allowlisted origin is echoed", func(t *testing.T) {
+		handler, _ := corsTestHandler()
+		req := httptest.NewRequest(http.MethodOptions, "/tools/x/mcp", nil)
+		req.Header.Set("Origin", inspectorOrigin)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, inspectorOrigin, w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "Origin", w.Header().Get("Vary"))
+	})
+
+	t.Run("other origins get no allow-origin header", func(t *testing.T) {
+		handler, _ := corsTestHandler()
+		req := httptest.NewRequest(http.MethodOptions, "/tools/x/mcp", nil)
+		req.Header.Set("Origin", "https://evil.example.com")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestToolCORSMiddleware_LeavesOtherPathsAlone(t *testing.T) {
+	t.Setenv(corsutil.EnvAllowedOrigins, "")
+
+	for _, path := range []string{"/llm/rest/openai/chat/completions", "/datasource/kb", "/v1/chat/completions"} {
+		t.Run(path, func(t *testing.T) {
+			handler, reached := corsTestHandler()
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req.Header.Set("Origin", inspectorOrigin)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			assert.True(t, *reached)
+			assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+		})
+	}
+}


### PR DESCRIPTION
Fixes #486.

## 1. No CORS on the tool/MCP data endpoints — both gateways

`pkg/corsutil` was applied to `handleOAuthProtectedResourceMetadata` and five handlers in `api/auth_handlers.go`, but never to `/tools/{slug}`, `/tools/{slug}/mcp`, `/tools/{slug}/mcp/sse` or `/tools/{slug}/mcp/message`. And the preflight never reached a handler that could have added the headers — a CORS preflight carries no credentials by design, so the credential middleware answered it first:

```
OPTIONS /tools/currency-exchange-rates/mcp
  Origin: http://127.0.0.1:6274
-> 401, no Access-Control-Allow-Origin        (identical on :9091 and :9595)
```

The effect was that MCP Inspector v2 — the protocol's reference client, which talks to HTTP servers directly from the browser — could not connect to AI Studio at all.

`toolCORSMiddleware` now runs **ahead of authentication** for `/tools/`, answering the preflight with a 204 and tagging real responses. Its header lists cover what the StreamableHTTP transport actually needs, not just the generic set:

- **allowed on requests**: the default list plus `Mcp-Session-Id`, `MCP-Protocol-Version`, `Last-Event-ID` (how a resumed SSE stream says where it left off);
- **exposed on responses**: `Mcp-Session-Id` (minted on the `initialize` response — a browser client cannot read it back otherwise) and `WWW-Authenticate` (so a client can find the discovery document on a 401).

The `CORS_ALLOWED_ORIGINS` policy is unchanged and still applies: `corsutil` gains `SetCORSHeadersFor` for callers needing explicit header lists, and `SetCORSHeaders` delegates to it. Only `/tools/` paths are affected; `/llm/`, `/datasource/` and `/v1/` are untouched.

## 2. The edge did not serve the discovery document it advertises

An unauthenticated MCP request to an edge answers with `WWW-Authenticate: Bearer realm="MCPResources", resource_metadata_uri="…/.well-known/oauth-protected-resource"`, but `microgateway/internal/api/router.go` mounted `proxy.Handler()` under only six prefixes — `/llm`, `/tools`, `/datasource`, `/ai`, `/anthropic`, `/v1`. `/.well-known/*` was not among them, so gin returned a 404 for the URL the edge itself had just named.

It is now mounted. No new handler was needed: the gateway handler already implements the endpoint (the embedded gateway serves it correctly), and the credential middleware already exempts `.well-known` from authentication.

## Why these belong together

Fixing only the discovery half would let a browser client finish the handshake and then fail on its first JSON-RPC POST, because of (1). Both halves are needed.

## Not changed

The issue's third suggestion — deriving `resource` from the serving address and defaulting the authorization server to the admin URL — concerns the quickstart's `PROXY_URL`/`SITE_URL` defaults, which the issue itself notes is "not a code bug". Changing the precedence would alter the advertised identity for deployments that configure `PROXY_OAUTH_METADATA_URL` deliberately, so it is left as configuration. Happy to take it in a follow-up if you'd like the derivation changed.

## Tests

- `TestToolCORSMiddleware_AnswersPreflightAheadOfAuth` — all four tool/MCP paths return 204 with `Access-Control-Allow-Origin` and never reach the authenticated handler.
- `TestToolCORSMiddleware_AllowsMCPTransportHeaders` — the MCP transport headers are allowed, and `Mcp-Session-Id`/`WWW-Authenticate` exposed.
- `TestToolCORSMiddleware_TagsActualRequests` — a real POST still reaches the handler and carries the header.
- `TestToolCORSMiddleware_HonoursAllowlist` — an allowlisted origin is echoed with `Vary: Origin`; others get no header.
- `TestToolCORSMiddleware_LeavesOtherPathsAlone` — `/llm/`, `/datasource/`, `/v1/` unchanged.
- `TestGatewayRoutes_ServeOAuthProtectedResourceMetadata` — the edge forwards `GET` and `OPTIONS` on the metadata path to the gateway handler.
- `TestSetCORSHeadersFor` — custom lists, the empty-list fallback, and the origin policy still applying.

`go test ./proxy/ ./pkg/corsutil/` and `go test ./internal/api/` (microgateway) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
