### PR TITLE
fix: ship per-operation tool calls in the analytics pulse (#487)

### DIFF
--- a/api/analytics_date_range_test.go
+++ b/api/analytics_date_range_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func dateRangeContext(query string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/analytics/tool-usage-statistics?"+query, nil)
+	return c
+}
+
+func TestGetDateRange(t *testing.T) {
+	t.Run("valid range", func(t *testing.T) {
+		start, end, err := getDateRange(dateRangeContext("start_date=2026-08-01&end_date=2026-08-28"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start.Format("2006-01-02") != "2026-08-01" {
+			t.Errorf("unexpected start: %v", start)
+		}
+		// The end date is widened to the end of the day.
+		if end.Format("2006-01-02 15:04:05") != "2026-08-28 23:59:59" {
+			t.Errorf("unexpected end: %v", end)
+		}
+	})
+
+	// A missing parameter used to surface time.Parse's raw Go format string:
+	// `parsing time "" as "2006-01-02": cannot parse "" as "2006"`, which names
+	// neither the parameter nor what it wanted.
+	t.Run("missing start_date names the parameter", func(t *testing.T) {
+		_, _, err := getDateRange(dateRangeContext("end_date=2026-08-28"))
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		assertMentions(t, err.Error(), "start_date", "YYYY-MM-DD")
+		assertOmits(t, err.Error(), "2006")
+	})
+
+	t.Run("missing end_date names the parameter", func(t *testing.T) {
+		_, _, err := getDateRange(dateRangeContext("start_date=2026-08-01"))
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		assertMentions(t, err.Error(), "end_date", "YYYY-MM-DD")
+	})
+
+	t.Run("both missing", func(t *testing.T) {
+		_, _, err := getDateRange(dateRangeContext(""))
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		assertMentions(t, err.Error(), "start_date")
+	})
+
+	t.Run("malformed date echoes what was sent", func(t *testing.T) {
+		_, _, err := getDateRange(dateRangeContext("start_date=28-08-2026&end_date=2026-08-28"))
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		assertMentions(t, err.Error(), "start_date", "28-08-2026")
+		assertOmits(t, err.Error(), "2006")
+	})
+}
+
+func assertMentions(t *testing.T, got string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Errorf("error %q should mention %q", got, want)
+		}
+	}
+}
+
+func assertOmits(t *testing.T, got string, unwanted ...string) {
+	t.Helper()
+	for _, bad := range unwanted {
+		if strings.Contains(got, bad) {
+			t.Errorf("error %q should not leak the Go layout string %q", got, bad)
+		}
+	}
+}

--- a/api/analytics_handlers.go
+++ b/api/analytics_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -147,17 +148,31 @@ func (a *API) getChatRecordsPerUser(c *gin.Context) {
 	c.JSON(http.StatusOK, chartData)
 }
 
+// parseDateParam reads a required YYYY-MM-DD query parameter. Returning
+// time.Parse's error verbatim surfaced a raw Go format string to API callers
+// (`parsing time "" as "2006-01-02": cannot parse "" as "2006"`), which says
+// nothing about which parameter was wrong or what it wanted.
+func parseDateParam(c *gin.Context, name string) (time.Time, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("%s is required, in YYYY-MM-DD format", name)
+	}
+
+	value, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s must be in YYYY-MM-DD format, got %q", name, raw)
+	}
+	return value, nil
+}
+
 // Helper function to parse date range from query parameters
 func getDateRange(c *gin.Context) (time.Time, time.Time, error) {
-	startDateStr := c.Query("start_date")
-	endDateStr := c.Query("end_date")
-
-	startDate, err := time.Parse("2006-01-02", startDateStr)
+	startDate, err := parseDateParam(c, "start_date")
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}
 
-	endDate, err := time.Parse("2006-01-02", endDateStr)
+	endDate, err := parseDateParam(c, "end_date")
 	if err != nil {
 		return time.Time{}, time.Time{}, err
 	}

--- a/features/Tools.md
+++ b/features/Tools.md
@@ -324,4 +324,12 @@ The Tool System provides native integration with the Model Context Protocol (MCP
 * **Advanced Dependency Management:** Versioning of tools and dependencies and conditional dependencies based on context.
 * **Improved Documentation:** Structured documentation format for better LLM understanding and automatic example generation.
 * **Analytics Integration:** Tracking of tool usage patterns and performance metrics for tool operations.
+  Tool calls are recorded per operation wherever they are served. On an edge
+  Microgateway, `MicrogatewaAnalyticsHandler.RecordToolCall` queues the call to
+  the analytics pulse plugin's buffer; the next pulse (every 30 seconds by
+  default) batches it into the gRPC `AnalyticsPulse` message as a
+  `ToolCallProto`, and the control server's `SendAnalyticsPulse` handler
+  records it exactly as it would a locally served call. `tool-usage-statistics`,
+  `tool-operations-usage-over-time` and `tool-calls-per-day` therefore count
+  edge and embedded-gateway traffic alike.
 * **Enhanced Security:** More authentication methods, request signing and verification, and rate limiting.

--- a/grpc/analytics_pulse_test.go
+++ b/grpc/analytics_pulse_test.go
@@ -21,7 +21,15 @@ func setupPulseTestDB(t *testing.T) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	require.NoError(t, err)
 
-	err = db.AutoMigrate(&models.LLMChatRecord{}, &models.ProxyLog{}, &models.EdgeInstance{}, &models.ComplianceEvent{})
+	// A sqlite ":memory:" database belongs to its connection, so a pooled
+	// second connection opens an empty one and the analytics worker writes
+	// into a database with no tables. Pin the pool to a single connection.
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	err = db.AutoMigrate(&models.LLMChatRecord{}, &models.ProxyLog{}, &models.EdgeInstance{},
+		&models.ComplianceEvent{}, &models.ToolCallRecord{})
 	require.NoError(t, err)
 
 	return db

--- a/grpc/analytics_pulse_tool_calls_test.go
+++ b/grpc/analytics_pulse_tool_calls_test.go
@@ -1,0 +1,117 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/midsommar/v2/models"
+	pb "github.com/TykTechnologies/midsommar/v2/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Edge-served tool calls used to reach the control plane only as an aggregate
+// count with no operation attached, so tool-usage-statistics,
+// tool-operations-usage-over-time and tool-calls-per-day silently under-reported
+// by whatever share of traffic the edges handled.
+func TestSendAnalyticsPulse_ToolCallsAreRecorded(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	now := time.Now()
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-tools",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   3,
+		ToolCalls: []*pb.ToolCallProto{
+			{ToolId: 4, OperationId: "getExchangeRate", ExecTimeMs: 120, Timestamp: timestamppb.New(now)},
+			{ToolId: 4, OperationId: "getExchangeRate", ExecTimeMs: 98, Timestamp: timestamppb.New(now.Add(time.Second))},
+			{ToolId: 4, OperationId: "getExchangeRates", ExecTimeMs: 210, Timestamp: timestamppb.New(now.Add(2 * time.Second))},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(3), response.ProcessedRecords)
+
+	require.Eventually(t, func() bool {
+		var count int64
+		db.Model(&models.ToolCallRecord{}).Count(&count)
+		return count == 3
+	}, 5*time.Second, 50*time.Millisecond, "edge tool calls must reach the tool analytics table")
+
+	var records []models.ToolCallRecord
+	require.NoError(t, db.Order("exec_time asc").Find(&records).Error)
+	require.Len(t, records, 3)
+
+	// Each record has to name its operation, which is what the per-operation
+	// charts group by.
+	byOperation := map[string]int{}
+	for _, r := range records {
+		assert.Equal(t, uint(4), r.ToolID)
+		byOperation[r.Name]++
+	}
+	assert.Equal(t, 2, byOperation["getExchangeRate"])
+	assert.Equal(t, 1, byOperation["getExchangeRates"])
+
+	assert.Equal(t, 98, records[0].ExecTime)
+}
+
+func TestSendAnalyticsPulse_ToolCallWithoutTimestamp(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	before := time.Now().Add(-time.Second)
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-no-ts",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		TotalRecords:   1,
+		ToolCalls: []*pb.ToolCallProto{
+			{ToolId: 7, OperationId: "search", ExecTimeMs: 10},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+
+	require.Eventually(t, func() bool {
+		var count int64
+		db.Model(&models.ToolCallRecord{}).Count(&count)
+		return count == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	var record models.ToolCallRecord
+	require.NoError(t, db.First(&record).Error)
+	assert.False(t, record.TimeStamp.Before(before), "a missing timestamp falls back to receipt time")
+}
+
+func TestSendAnalyticsPulse_NoToolCalls(t *testing.T) {
+	db := setupPulseTestDB(t)
+	server := setupControlServer(t, db)
+
+	pulse := &pb.AnalyticsPulse{
+		EdgeId:         "test-edge-empty",
+		EdgeNamespace:  "test",
+		SequenceNumber: 1,
+		ComplianceEvents: []*pb.ComplianceEventProto{
+			{AppId: 1, EventType: "unrelated", Severity: "info", Timestamp: timestamppb.Now()},
+		},
+	}
+
+	response, err := server.SendAnalyticsPulse(context.Background(), pulse)
+	require.NoError(t, err)
+	assert.True(t, response.Success)
+	assert.Equal(t, uint64(1), response.ProcessedRecords)
+
+	time.Sleep(200 * time.Millisecond)
+
+	var count int64
+	db.Model(&models.ToolCallRecord{}).Count(&count)
+	assert.Equal(t, int64(0), count)
+}

--- a/grpc/control_server.go
+++ b/grpc/control_server.go
@@ -794,6 +794,7 @@ func (s *ControlServer) SendAnalyticsPulse(ctx context.Context, req *pb.Analytic
 		Int("budget_events", len(req.BudgetEvents)).
 		Int("proxy_summaries", len(req.ProxySummaries)).
 		Int("compliance_events", len(req.ComplianceEvents)).
+		Int("tool_calls", len(req.ToolCalls)).
 		Msg("AI Studio control server: received analytics pulse from edge")
 
 	processedRecords := uint64(0)
@@ -900,6 +901,25 @@ func (s *ControlServer) SendAnalyticsPulse(ctx context.Context, req *pb.Analytic
 			Str("edge_id", req.EdgeId).
 			Int("compliance_events", len(req.ComplianceEvents)).
 			Msg("Compliance events processed from edge pulse")
+	}
+
+	// Process per-operation tool calls served by the edge. Without these the
+	// tool analytics endpoints only ever counted calls served by the control
+	// plane's embedded gateway, so the figures under-reported by whatever
+	// share of traffic a distributed deployment routes through its edges.
+	for _, tc := range req.ToolCalls {
+		timestamp := time.Now()
+		if tc.Timestamp != nil {
+			timestamp = tc.Timestamp.AsTime()
+		}
+		analytics.RecordToolCall(ctx, tc.OperationId, timestamp, int(tc.ExecTimeMs), uint(tc.ToolId))
+		processedRecords++
+	}
+	if len(req.ToolCalls) > 0 {
+		log.Debug().
+			Str("edge_id", req.EdgeId).
+			Int("tool_calls", len(req.ToolCalls)).
+			Msg("Tool calls processed from edge pulse")
 	}
 
 	// Process budget events (for now just log - AI Studio budget integration would need budget service)

--- a/microgateway/internal/plugins/analytics_pulse_compliance_test.go
+++ b/microgateway/internal/plugins/analytics_pulse_compliance_test.go
@@ -116,7 +116,7 @@ func TestAnalyticsPulsePlugin_BuildPulseMessage_WithComplianceEvents(t *testing.
 		},
 	}
 
-	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, 42)
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, nil, 42)
 
 	require.NotNil(t, pulse)
 	assert.Equal(t, "test-edge", pulse.EdgeId)
@@ -209,13 +209,13 @@ func TestAnalyticsPulsePlugin_BuildPulseMessage_EmptyComplianceData(t *testing.T
 	}
 
 	// Empty compliance data should produce nil ComplianceEvents (not empty slice)
-	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, nil, 1)
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, nil, nil, 1)
 	require.NotNil(t, pulse)
 	assert.Nil(t, pulse.ComplianceEvents)
 	assert.Equal(t, uint32(0), pulse.TotalRecords)
 
 	// Empty slice should also produce nil
-	pulse = plugin.buildPulseMessage(nil, nil, nil, nil, []ComplianceEventBuffer{}, 2)
+	pulse = plugin.buildPulseMessage(nil, nil, nil, nil, []ComplianceEventBuffer{}, nil, 2)
 	require.NotNil(t, pulse)
 	assert.Nil(t, pulse.ComplianceEvents)
 }
@@ -256,7 +256,7 @@ func TestAnalyticsPulsePlugin_BuildPulseMessage_ComplianceWithMissingFields(t *t
 		},
 	}
 
-	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, 1)
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, complianceData, nil, 1)
 	require.NotNil(t, pulse)
 	require.Len(t, pulse.ComplianceEvents, 2)
 
@@ -295,7 +295,7 @@ func TestAnalyticsPulsePlugin_BuildPulseMessage_MixedData(t *testing.T) {
 		},
 	}
 
-	pulse := plugin.buildPulseMessage(nil, nil, budgetData, nil, complianceData, 1)
+	pulse := plugin.buildPulseMessage(nil, nil, budgetData, nil, complianceData, nil, 1)
 
 	require.NotNil(t, pulse)
 	assert.Equal(t, uint32(2), pulse.TotalRecords) // 1 budget + 1 compliance

--- a/microgateway/internal/plugins/analytics_pulse_plugin.go
+++ b/microgateway/internal/plugins/analytics_pulse_plugin.go
@@ -29,6 +29,7 @@ type AnalyticsPulsePlugin struct {
 	budgetBuffer       []BudgetUsageBuffer
 	proxyBuffer        []ProxyLogBuffer
 	complianceBuffer   []ComplianceEventBuffer
+	toolCallBuffer     []ToolCallBuffer
 	bufferMutex        sync.RWMutex
 
 	// Pulse management
@@ -113,6 +114,17 @@ type ComplianceEventBuffer struct {
 	Metadata    string // JSON blob
 	Vendor      string
 	ModelName   string
+	Timestamp   time.Time
+}
+
+// ToolCallBuffer holds a single tool operation call for batching in pulses.
+// The aggregate ToolCalls counter on an analytics event says how many calls a
+// request made but not which operations they were, so tool analytics on the
+// control plane has nothing to attribute edge traffic to without these.
+type ToolCallBuffer struct {
+	ToolID      uint32
+	OperationID string
+	ExecTimeMs  int32
 	Timestamp   time.Time
 }
 
@@ -395,6 +407,25 @@ func (p *AnalyticsPulsePlugin) BufferComplianceEvents(events []ComplianceEventBu
 		Msg("Compliance events buffered for pulse")
 }
 
+// BufferToolCalls adds tool operation calls to the buffer for pulse
+// transmission. Called by the microgateway analytics handler whenever a tool
+// operation is served by this edge, over REST or over MCP.
+func (p *AnalyticsPulsePlugin) BufferToolCalls(calls []ToolCallBuffer) {
+	if len(calls) == 0 {
+		return
+	}
+
+	p.bufferMutex.Lock()
+	defer p.bufferMutex.Unlock()
+
+	p.toolCallBuffer = append(p.toolCallBuffer, calls...)
+
+	log.Debug().
+		Int("count", len(calls)).
+		Int("buffer_size", len(p.toolCallBuffer)).
+		Msg("Tool calls buffered for pulse")
+}
+
 // schedulePulse schedules the next pulse
 func (p *AnalyticsPulsePlugin) schedulePulse() {
 	if p.pulseTimer != nil {
@@ -426,7 +457,8 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 	p.bufferMutex.Lock()
 
 	// Check if there's any data to send
-	if len(p.analyticsBuffer) == 0 && len(p.budgetBuffer) == 0 && len(p.proxyBuffer) == 0 && len(p.complianceBuffer) == 0 {
+	if len(p.analyticsBuffer) == 0 && len(p.budgetBuffer) == 0 && len(p.proxyBuffer) == 0 &&
+		len(p.complianceBuffer) == 0 && len(p.toolCallBuffer) == 0 {
 		p.bufferMutex.Unlock()
 		log.Debug().Msg("No analytics data to pulse - skipping")
 		return
@@ -453,13 +485,17 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 	copy(complianceSnapshot, p.complianceBuffer)
 	p.complianceBuffer = p.complianceBuffer[:0]
 
+	toolCallSnapshot := make([]ToolCallBuffer, len(p.toolCallBuffer))
+	copy(toolCallSnapshot, p.toolCallBuffer)
+	p.toolCallBuffer = p.toolCallBuffer[:0]
+
 	sequenceNum := p.sequenceNumber
 	p.sequenceNumber++
 
 	p.bufferMutex.Unlock()
 
 	// Build and send pulse
-	pulse := p.buildPulseMessage(analyticsSnapshot, metadataSnapshot, budgetSnapshot, proxySnapshot, complianceSnapshot, sequenceNum)
+	pulse := p.buildPulseMessage(analyticsSnapshot, metadataSnapshot, budgetSnapshot, proxySnapshot, complianceSnapshot, toolCallSnapshot, sequenceNum)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.TimeoutSeconds)*time.Second)
 	defer cancel()
@@ -470,6 +506,7 @@ func (p *AnalyticsPulsePlugin) sendPulse() {
 		Int("budget_events", len(budgetSnapshot)).
 		Int("proxy_summaries", len(proxySnapshot)).
 		Int("compliance_events", len(complianceSnapshot)).
+		Int("tool_calls", len(toolCallSnapshot)).
 		Uint32("total_records", pulse.TotalRecords).
 		Msg("Sending analytics pulse to control server")
 
@@ -508,6 +545,7 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 	budgetData []BudgetUsageBuffer,
 	proxyData []ProxyLogBuffer,
 	complianceData []ComplianceEventBuffer,
+	toolCallData []ToolCallBuffer,
 	sequenceNum uint64,
 ) *pb.AnalyticsPulse {
 	now := time.Now()
@@ -631,7 +669,18 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 		})
 	}
 
-	totalRecords := uint32(len(analyticsEvents) + len(budgetEvents) + len(proxySummaries) + len(complianceEvents))
+	// Convert tool calls
+	var toolCalls []*pb.ToolCallProto
+	for _, tc := range toolCallData {
+		toolCalls = append(toolCalls, &pb.ToolCallProto{
+			ToolId:      tc.ToolID,
+			OperationId: tc.OperationID,
+			ExecTimeMs:  tc.ExecTimeMs,
+			Timestamp:   timestamppb.New(tc.Timestamp),
+		})
+	}
+
+	totalRecords := uint32(len(analyticsEvents) + len(budgetEvents) + len(proxySummaries) + len(complianceEvents) + len(toolCalls))
 
 	return &pb.AnalyticsPulse{
 		EdgeId:           p.edgeID,
@@ -644,6 +693,7 @@ func (p *AnalyticsPulsePlugin) buildPulseMessage(
 		BudgetEvents:     budgetEvents,
 		ProxySummaries:   proxySummaries,
 		ComplianceEvents: complianceEvents,
+		ToolCalls:        toolCalls,
 		IsCompressed:     p.config.CompressionEnabled,
 		TotalRecords:     totalRecords,
 		DataSizeBytes:    0, // TODO: Calculate if needed
@@ -691,10 +741,12 @@ func (p *AnalyticsPulsePlugin) GetStats() map[string]interface{} {
 	stats := map[string]interface{}{
 		"total_pulses_sent":     p.totalPulsesSent,
 		"total_records_sent":    p.totalRecordsSent,
-		"current_buffer_size":   len(p.analyticsBuffer) + len(p.budgetBuffer) + len(p.proxyBuffer),
+		"current_buffer_size":   len(p.analyticsBuffer) + len(p.budgetBuffer) + len(p.proxyBuffer) + len(p.complianceBuffer) + len(p.toolCallBuffer),
 		"analytics_buffered":    len(p.analyticsBuffer),
 		"budget_buffered":       len(p.budgetBuffer),
 		"proxy_buffered":        len(p.proxyBuffer),
+		"compliance_buffered":   len(p.complianceBuffer),
+		"tool_calls_buffered":   len(p.toolCallBuffer),
 		"sequence_number":       p.sequenceNumber,
 		"last_pulse_time":       p.lastPulseTime,
 		"pulse_interval_seconds": p.config.IntervalSeconds,

--- a/microgateway/internal/plugins/analytics_pulse_tool_calls_test.go
+++ b/microgateway/internal/plugins/analytics_pulse_tool_calls_test.go
@@ -1,0 +1,112 @@
+package plugins
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyticsPulsePlugin_BufferToolCalls(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{config: &PulsePluginConfig{}}
+
+	plugin.BufferToolCalls([]ToolCallBuffer{
+		{ToolID: 4, OperationID: "getExchangeRate", ExecTimeMs: 120, Timestamp: time.Now()},
+		{ToolID: 4, OperationID: "getExchangeRates", ExecTimeMs: 95, Timestamp: time.Now()},
+	})
+
+	plugin.bufferMutex.RLock()
+	require.Len(t, plugin.toolCallBuffer, 2)
+	assert.Equal(t, "getExchangeRate", plugin.toolCallBuffer[0].OperationID)
+	assert.Equal(t, "getExchangeRates", plugin.toolCallBuffer[1].OperationID)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BufferToolCalls_EmptySlice(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{config: &PulsePluginConfig{}}
+
+	plugin.BufferToolCalls(nil)
+	plugin.BufferToolCalls([]ToolCallBuffer{})
+
+	plugin.bufferMutex.RLock()
+	assert.Empty(t, plugin.toolCallBuffer)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BufferToolCalls_ConcurrentAccess(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{config: &PulsePluginConfig{}}
+
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+			plugin.BufferToolCalls([]ToolCallBuffer{
+				{ToolID: uint32(id), OperationID: "concurrent", Timestamp: time.Now()},
+			})
+		}(i)
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	plugin.bufferMutex.RLock()
+	assert.Len(t, plugin.toolCallBuffer, 10)
+	plugin.bufferMutex.RUnlock()
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_WithToolCalls(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config:        &PulsePluginConfig{},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	now := time.Now()
+	toolCalls := []ToolCallBuffer{
+		{ToolID: 4, OperationID: "getExchangeRate", ExecTimeMs: 120, Timestamp: now},
+		{ToolID: 4, OperationID: "getExchangeRates", ExecTimeMs: 95, Timestamp: now.Add(time.Second)},
+	}
+
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, nil, toolCalls, 7)
+
+	require.NotNil(t, pulse)
+	require.Len(t, pulse.ToolCalls, 2)
+
+	// Each call has to carry the operation it was, or the control plane has
+	// nothing to attribute it to.
+	assert.Equal(t, uint32(4), pulse.ToolCalls[0].ToolId)
+	assert.Equal(t, "getExchangeRate", pulse.ToolCalls[0].OperationId)
+	assert.Equal(t, int32(120), pulse.ToolCalls[0].ExecTimeMs)
+	require.NotNil(t, pulse.ToolCalls[0].Timestamp)
+	assert.WithinDuration(t, now, pulse.ToolCalls[0].Timestamp.AsTime(), time.Second)
+
+	assert.Equal(t, "getExchangeRates", pulse.ToolCalls[1].OperationId)
+
+	// Tool calls count toward the pulse's record total.
+	assert.Equal(t, uint32(2), pulse.TotalRecords)
+}
+
+func TestAnalyticsPulsePlugin_BuildPulseMessage_NoToolCalls(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{
+		config:        &PulsePluginConfig{},
+		edgeID:        "test-edge",
+		edgeNamespace: "test",
+		lastPulseTime: time.Now().Add(-5 * time.Minute),
+	}
+
+	pulse := plugin.buildPulseMessage(nil, nil, nil, nil, nil, nil, 1)
+	require.NotNil(t, pulse)
+	assert.Nil(t, pulse.ToolCalls)
+	assert.Equal(t, uint32(0), pulse.TotalRecords)
+}
+
+func TestAnalyticsPulsePlugin_GetStatsIncludesToolCalls(t *testing.T) {
+	plugin := &AnalyticsPulsePlugin{config: &PulsePluginConfig{IntervalSeconds: 10}}
+	plugin.BufferToolCalls([]ToolCallBuffer{{ToolID: 1, OperationID: "op", Timestamp: time.Now()}})
+
+	stats := plugin.GetStats()
+	assert.Equal(t, 1, stats["tool_calls_buffered"])
+	assert.Equal(t, 1, stats["current_buffer_size"])
+}

--- a/microgateway/internal/services/analytics_handler.go
+++ b/microgateway/internal/services/analytics_handler.go
@@ -653,11 +653,23 @@ func (h *MicrogatewaAnalyticsHandler) RecordToolCall(_ context.Context, name str
 		Str("tool_name", name).
 		Uint("tool_id", toolID).
 		Int("exec_time_ms", execTimeMs).
-		Msg("Recording standalone tool call analytics (AI Studio compatibility)")
+		Msg("Recording standalone tool call analytics")
 
-	// Note: In microgateway, tool calls are tracked as part of LLM analytics
-	// This method is here for AI Studio interface compatibility
-	// Standalone tool call tracking may not be applicable in proxy-only mode
+	if h.pluginManager == nil {
+		return
+	}
+
+	// Forward to the pulse plugin so the control plane can attribute the call
+	// to a tool and an operation. The aggregate ToolCalls counter that rides on
+	// an analytics event carries no operation, so without this an edge-served
+	// tool call is invisible to the control plane's tool analytics, and every
+	// chart under-reports by whatever share of traffic the edges handle.
+	h.pluginManager.BufferToolCalls([]internalPlugins.ToolCallBuffer{{
+		ToolID:      uint32(toolID),
+		OperationID: name,
+		ExecTimeMs:  int32(execTimeMs),
+		Timestamp:   timestamp,
+	}})
 }
 
 // RecordChatRecordsBatch implements batch recording for microgateway analytics

--- a/microgateway/internal/services/analytics_handler_tool_calls_test.go
+++ b/microgateway/internal/services/analytics_handler_tool_calls_test.go
@@ -1,0 +1,16 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// A gateway running without a plugin manager (no pulse plugin configured) has
+// nowhere to forward a tool call. It must drop it quietly rather than panic on
+// the request path.
+func TestRecordToolCall_NoPluginManager(t *testing.T) {
+	handler := NewMicrogatewaAnalyticsHandler(nil, nil, nil, nil)
+
+	handler.RecordToolCall(context.Background(), "getExchangeRate", time.Now(), 120, 4)
+}

--- a/microgateway/plugins/manager.go
+++ b/microgateway/plugins/manager.go
@@ -1755,6 +1755,25 @@ func (pm *PluginManager) BufferComplianceEvents(events []plugins.ComplianceEvent
 	log.Debug().Int("count", len(events)).Msg("No analytics pulse plugin found for compliance events - events dropped")
 }
 
+// BufferToolCalls forwards tool operation calls to the built-in analytics pulse
+// plugin for batch transmission to the control plane during the next pulse.
+func (pm *PluginManager) BufferToolCalls(calls []plugins.ToolCallBuffer) {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	for _, globalPlugin := range pm.globalDataPlugins {
+		if globalPlugin.LoadedPlugin.BuiltinPlugin == nil {
+			continue
+		}
+		if pulsePlugin, ok := globalPlugin.LoadedPlugin.BuiltinPlugin.(*plugins.AnalyticsPulsePlugin); ok {
+			pulsePlugin.BufferToolCalls(calls)
+			return
+		}
+	}
+
+	log.Debug().Int("count", len(calls)).Msg("No analytics pulse plugin found for tool calls - calls dropped")
+}
+
 // executeDataCollectionPlugin executes a specific plugin for the given data type
 func (pm *PluginManager) executeDataCollectionPlugin(ctx context.Context, plugin *GlobalPlugin, hookType string, data interface{}) error {
 	// Check if this is a built-in plugin

--- a/proto/config_sync.pb.go
+++ b/proto/config_sync.pb.go
@@ -1556,6 +1556,7 @@ type AnalyticsPulse struct {
 	BudgetEvents     []*BudgetUsageEvent     `protobuf:"bytes,8,rep,name=budget_events,json=budgetEvents,proto3" json:"budget_events,omitempty"`              // Budget usage events
 	ProxySummaries   []*ProxyLogSummary      `protobuf:"bytes,9,rep,name=proxy_summaries,json=proxySummaries,proto3" json:"proxy_summaries,omitempty"`        // Summarized proxy logs (not full payloads)
 	ComplianceEvents []*ComplianceEventProto `protobuf:"bytes,13,rep,name=compliance_events,json=complianceEvents,proto3" json:"compliance_events,omitempty"` // Script-reported compliance events
+	ToolCalls        []*ToolCallProto        `protobuf:"bytes,14,rep,name=tool_calls,json=toolCalls,proto3" json:"tool_calls,omitempty"`                      // Per-operation tool call records
 	// Pulse metadata
 	IsCompressed  bool   `protobuf:"varint,10,opt,name=is_compressed,json=isCompressed,proto3" json:"is_compressed,omitempty"`      // Whether data is compressed
 	TotalRecords  uint32 `protobuf:"varint,11,opt,name=total_records,json=totalRecords,proto3" json:"total_records,omitempty"`      // Total number of records in pulse
@@ -1660,6 +1661,13 @@ func (x *AnalyticsPulse) GetProxySummaries() []*ProxyLogSummary {
 func (x *AnalyticsPulse) GetComplianceEvents() []*ComplianceEventProto {
 	if x != nil {
 		return x.ComplianceEvents
+	}
+	return nil
+}
+
+func (x *AnalyticsPulse) GetToolCalls() []*ToolCallProto {
+	if x != nil {
+		return x.ToolCalls
 	}
 	return nil
 }
@@ -2533,6 +2541,78 @@ func (x *ComplianceEventProto) GetTimestamp() *timestamppb.Timestamp {
 	return nil
 }
 
+// ToolCallProto represents a single tool operation call served by an edge
+// gateway. The aggregate ToolCalls counter on AnalyticsEvent says how many
+// calls a request made, but carries no operation to attribute them to, so
+// tool analytics on the control plane cannot count edge traffic without this.
+type ToolCallProto struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ToolId        uint32                 `protobuf:"varint,1,opt,name=tool_id,json=toolId,proto3" json:"tool_id,omitempty"`               // Tool ID (matches the control plane's)
+	OperationId   string                 `protobuf:"bytes,2,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"` // OpenAPI operationId that was called
+	ExecTimeMs    int32                  `protobuf:"varint,3,opt,name=exec_time_ms,json=execTimeMs,proto3" json:"exec_time_ms,omitempty"` // Wall-clock duration of the call
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`                        // When the call completed
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ToolCallProto) Reset() {
+	*x = ToolCallProto{}
+	mi := &file_proto_config_sync_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ToolCallProto) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ToolCallProto) ProtoMessage() {}
+
+func (x *ToolCallProto) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_config_sync_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ToolCallProto.ProtoReflect.Descriptor instead.
+func (*ToolCallProto) Descriptor() ([]byte, []int) {
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ToolCallProto) GetToolId() uint32 {
+	if x != nil {
+		return x.ToolId
+	}
+	return 0
+}
+
+func (x *ToolCallProto) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *ToolCallProto) GetExecTimeMs() int32 {
+	if x != nil {
+		return x.ExecTimeMs
+	}
+	return 0
+}
+
+func (x *ToolCallProto) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
 // PluginControlPayload represents a single payload from an edge plugin to control
 type PluginControlPayload struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2549,7 +2629,7 @@ type PluginControlPayload struct {
 
 func (x *PluginControlPayload) Reset() {
 	*x = PluginControlPayload{}
-	mi := &file_proto_config_sync_proto_msgTypes[24]
+	mi := &file_proto_config_sync_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2561,7 +2641,7 @@ func (x *PluginControlPayload) String() string {
 func (*PluginControlPayload) ProtoMessage() {}
 
 func (x *PluginControlPayload) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[24]
+	mi := &file_proto_config_sync_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2574,7 +2654,7 @@ func (x *PluginControlPayload) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlPayload.ProtoReflect.Descriptor instead.
 func (*PluginControlPayload) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{24}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *PluginControlPayload) GetPluginId() uint32 {
@@ -2641,7 +2721,7 @@ type PluginControlBatch struct {
 
 func (x *PluginControlBatch) Reset() {
 	*x = PluginControlBatch{}
-	mi := &file_proto_config_sync_proto_msgTypes[25]
+	mi := &file_proto_config_sync_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2653,7 +2733,7 @@ func (x *PluginControlBatch) String() string {
 func (*PluginControlBatch) ProtoMessage() {}
 
 func (x *PluginControlBatch) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[25]
+	mi := &file_proto_config_sync_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2666,7 +2746,7 @@ func (x *PluginControlBatch) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlBatch.ProtoReflect.Descriptor instead.
 func (*PluginControlBatch) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{25}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *PluginControlBatch) GetEdgeId() string {
@@ -2726,7 +2806,7 @@ type PluginControlBatchResponse struct {
 
 func (x *PluginControlBatchResponse) Reset() {
 	*x = PluginControlBatchResponse{}
-	mi := &file_proto_config_sync_proto_msgTypes[26]
+	mi := &file_proto_config_sync_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2738,7 +2818,7 @@ func (x *PluginControlBatchResponse) String() string {
 func (*PluginControlBatchResponse) ProtoMessage() {}
 
 func (x *PluginControlBatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[26]
+	mi := &file_proto_config_sync_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2751,7 +2831,7 @@ func (x *PluginControlBatchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginControlBatchResponse.ProtoReflect.Descriptor instead.
 func (*PluginControlBatchResponse) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{26}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PluginControlBatchResponse) GetSuccess() bool {
@@ -2808,7 +2888,7 @@ type PluginPayloadError struct {
 
 func (x *PluginPayloadError) Reset() {
 	*x = PluginPayloadError{}
-	mi := &file_proto_config_sync_proto_msgTypes[27]
+	mi := &file_proto_config_sync_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2820,7 +2900,7 @@ func (x *PluginPayloadError) String() string {
 func (*PluginPayloadError) ProtoMessage() {}
 
 func (x *PluginPayloadError) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_config_sync_proto_msgTypes[27]
+	mi := &file_proto_config_sync_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2833,7 +2913,7 @@ func (x *PluginPayloadError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginPayloadError.ProtoReflect.Descriptor instead.
 func (*PluginPayloadError) Descriptor() ([]byte, []int) {
-	return file_proto_config_sync_proto_rawDescGZIP(), []int{27}
+	return file_proto_config_sync_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *PluginPayloadError) GetPluginId() uint32 {
@@ -2981,7 +3061,7 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	"\amessage\x18\x05 \x01(\tR\amessage\x122\n" +
 	"\x15config_version_before\x18\x06 \x01(\tR\x13configVersionBefore\x120\n" +
 	"\x14config_version_after\x18\a \x01(\tR\x12configVersionAfter\x128\n" +
-	"\ttimestamp\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xc5\x05\n" +
+	"\ttimestamp\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\x81\x06\n" +
 	"\x0eAnalyticsPulse\x12\x17\n" +
 	"\aedge_id\x18\x01 \x01(\tR\x06edgeId\x12%\n" +
 	"\x0eedge_namespace\x18\x02 \x01(\tR\redgeNamespace\x12C\n" +
@@ -2992,7 +3072,9 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	"\x10analytics_events\x18\a \x03(\v2\x1c.microgateway.AnalyticsEventR\x0fanalyticsEvents\x12C\n" +
 	"\rbudget_events\x18\b \x03(\v2\x1e.microgateway.BudgetUsageEventR\fbudgetEvents\x12F\n" +
 	"\x0fproxy_summaries\x18\t \x03(\v2\x1d.microgateway.ProxyLogSummaryR\x0eproxySummaries\x12O\n" +
-	"\x11compliance_events\x18\r \x03(\v2\".microgateway.ComplianceEventProtoR\x10complianceEvents\x12#\n" +
+	"\x11compliance_events\x18\r \x03(\v2\".microgateway.ComplianceEventProtoR\x10complianceEvents\x12:\n" +
+	"\n" +
+	"tool_calls\x18\x0e \x03(\v2\x1b.microgateway.ToolCallProtoR\ttoolCalls\x12#\n" +
 	"\ris_compressed\x18\n" +
 	" \x01(\bR\fisCompressed\x12#\n" +
 	"\rtotal_records\x18\v \x01(\rR\ftotalRecords\x12&\n" +
@@ -3095,7 +3177,13 @@ const file_proto_config_sync_proto_rawDesc = "" +
 	" \x01(\tR\x06vendor\x12\x1d\n" +
 	"\n" +
 	"model_name\x18\v \x01(\tR\tmodelName\x128\n" +
-	"\ttimestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xf9\x02\n" +
+	"\ttimestamp\x18\f \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xa7\x01\n" +
+	"\rToolCallProto\x12\x17\n" +
+	"\atool_id\x18\x01 \x01(\rR\x06toolId\x12!\n" +
+	"\foperation_id\x18\x02 \x01(\tR\voperationId\x12 \n" +
+	"\fexec_time_ms\x18\x03 \x01(\x05R\n" +
+	"execTimeMs\x128\n" +
+	"\ttimestamp\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\"\xf9\x02\n" +
 	"\x14PluginControlPayload\x12\x1b\n" +
 	"\tplugin_id\x18\x01 \x01(\rR\bpluginId\x12\x18\n" +
 	"\apayload\x18\x02 \x01(\fR\apayload\x12\x17\n" +
@@ -3156,7 +3244,7 @@ func file_proto_config_sync_proto_rawDescGZIP() []byte {
 }
 
 var file_proto_config_sync_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_proto_config_sync_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
+var file_proto_config_sync_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_proto_config_sync_proto_goTypes = []any{
 	(ReloadPhase)(0),                    // 0: microgateway.ReloadPhase
 	(*EdgeRegistrationRequest)(nil),     // 1: microgateway.EdgeRegistrationRequest
@@ -3183,25 +3271,26 @@ var file_proto_config_sync_proto_goTypes = []any{
 	(*BudgetUsageEvent)(nil),            // 22: microgateway.BudgetUsageEvent
 	(*ProxyLogSummary)(nil),             // 23: microgateway.ProxyLogSummary
 	(*ComplianceEventProto)(nil),        // 24: microgateway.ComplianceEventProto
-	(*PluginControlPayload)(nil),        // 25: microgateway.PluginControlPayload
-	(*PluginControlBatch)(nil),          // 26: microgateway.PluginControlBatch
-	(*PluginControlBatchResponse)(nil),  // 27: microgateway.PluginControlBatchResponse
-	(*PluginPayloadError)(nil),          // 28: microgateway.PluginPayloadError
-	nil,                                 // 29: microgateway.EdgeRegistrationRequest.MetadataEntry
-	nil,                                 // 30: microgateway.EdgeMetrics.CustomMetricsEntry
-	nil,                                 // 31: microgateway.PluginControlPayload.MetadataEntry
-	(*HealthStatus)(nil),                // 32: microgateway.HealthStatus
-	(*ConfigurationSnapshot)(nil),       // 33: microgateway.ConfigurationSnapshot
-	(*timestamppb.Timestamp)(nil),       // 34: google.protobuf.Timestamp
-	(*ConfigurationChange)(nil),         // 35: microgateway.ConfigurationChange
-	(*AppConfig)(nil),                   // 36: microgateway.AppConfig
-	(*emptypb.Empty)(nil),               // 37: google.protobuf.Empty
+	(*ToolCallProto)(nil),               // 25: microgateway.ToolCallProto
+	(*PluginControlPayload)(nil),        // 26: microgateway.PluginControlPayload
+	(*PluginControlBatch)(nil),          // 27: microgateway.PluginControlBatch
+	(*PluginControlBatchResponse)(nil),  // 28: microgateway.PluginControlBatchResponse
+	(*PluginPayloadError)(nil),          // 29: microgateway.PluginPayloadError
+	nil,                                 // 30: microgateway.EdgeRegistrationRequest.MetadataEntry
+	nil,                                 // 31: microgateway.EdgeMetrics.CustomMetricsEntry
+	nil,                                 // 32: microgateway.PluginControlPayload.MetadataEntry
+	(*HealthStatus)(nil),                // 33: microgateway.HealthStatus
+	(*ConfigurationSnapshot)(nil),       // 34: microgateway.ConfigurationSnapshot
+	(*timestamppb.Timestamp)(nil),       // 35: google.protobuf.Timestamp
+	(*ConfigurationChange)(nil),         // 36: microgateway.ConfigurationChange
+	(*AppConfig)(nil),                   // 37: microgateway.AppConfig
+	(*emptypb.Empty)(nil),               // 38: google.protobuf.Empty
 }
 var file_proto_config_sync_proto_depIdxs = []int32{
-	29, // 0: microgateway.EdgeRegistrationRequest.metadata:type_name -> microgateway.EdgeRegistrationRequest.MetadataEntry
-	32, // 1: microgateway.EdgeRegistrationRequest.health:type_name -> microgateway.HealthStatus
-	33, // 2: microgateway.EdgeRegistrationResponse.initial_config:type_name -> microgateway.ConfigurationSnapshot
-	34, // 3: microgateway.ConfigurationRequest.last_sync_time:type_name -> google.protobuf.Timestamp
+	30, // 0: microgateway.EdgeRegistrationRequest.metadata:type_name -> microgateway.EdgeRegistrationRequest.MetadataEntry
+	33, // 1: microgateway.EdgeRegistrationRequest.health:type_name -> microgateway.HealthStatus
+	34, // 2: microgateway.EdgeRegistrationResponse.initial_config:type_name -> microgateway.ConfigurationSnapshot
+	35, // 3: microgateway.ConfigurationRequest.last_sync_time:type_name -> google.protobuf.Timestamp
 	1,  // 4: microgateway.EdgeMessage.registration:type_name -> microgateway.EdgeRegistrationRequest
 	7,  // 5: microgateway.EdgeMessage.heartbeat:type_name -> microgateway.HeartbeatRequest
 	3,  // 6: microgateway.EdgeMessage.config_request:type_name -> microgateway.ConfigurationRequest
@@ -3209,64 +3298,66 @@ var file_proto_config_sync_proto_depIdxs = []int32{
 	17, // 8: microgateway.EdgeMessage.reload_response:type_name -> microgateway.ConfigurationReloadResponse
 	6,  // 9: microgateway.EdgeMessage.event:type_name -> microgateway.EventFrame
 	2,  // 10: microgateway.ControlMessage.registration_response:type_name -> microgateway.EdgeRegistrationResponse
-	33, // 11: microgateway.ControlMessage.configuration:type_name -> microgateway.ConfigurationSnapshot
-	35, // 12: microgateway.ControlMessage.change:type_name -> microgateway.ConfigurationChange
+	34, // 11: microgateway.ControlMessage.configuration:type_name -> microgateway.ConfigurationSnapshot
+	36, // 12: microgateway.ControlMessage.change:type_name -> microgateway.ConfigurationChange
 	8,  // 13: microgateway.ControlMessage.heartbeat_response:type_name -> microgateway.HeartbeatResponse
 	11, // 14: microgateway.ControlMessage.error:type_name -> microgateway.ErrorMessage
 	16, // 15: microgateway.ControlMessage.reload_request:type_name -> microgateway.ConfigurationReloadRequest
 	6,  // 16: microgateway.ControlMessage.event:type_name -> microgateway.EventFrame
-	32, // 17: microgateway.HeartbeatRequest.health:type_name -> microgateway.HealthStatus
+	33, // 17: microgateway.HeartbeatRequest.health:type_name -> microgateway.HealthStatus
 	10, // 18: microgateway.HeartbeatRequest.metrics:type_name -> microgateway.EdgeMetrics
-	34, // 19: microgateway.HeartbeatRequest.timestamp:type_name -> google.protobuf.Timestamp
-	30, // 20: microgateway.EdgeMetrics.custom_metrics:type_name -> microgateway.EdgeMetrics.CustomMetricsEntry
-	34, // 21: microgateway.TokenValidationResponse.expires_at:type_name -> google.protobuf.Timestamp
-	36, // 22: microgateway.TokenValidationResponse.app:type_name -> microgateway.AppConfig
-	34, // 23: microgateway.ConfigurationReloadRequest.initiated_at:type_name -> google.protobuf.Timestamp
+	35, // 19: microgateway.HeartbeatRequest.timestamp:type_name -> google.protobuf.Timestamp
+	31, // 20: microgateway.EdgeMetrics.custom_metrics:type_name -> microgateway.EdgeMetrics.CustomMetricsEntry
+	35, // 21: microgateway.TokenValidationResponse.expires_at:type_name -> google.protobuf.Timestamp
+	37, // 22: microgateway.TokenValidationResponse.app:type_name -> microgateway.AppConfig
+	35, // 23: microgateway.ConfigurationReloadRequest.initiated_at:type_name -> google.protobuf.Timestamp
 	0,  // 24: microgateway.ConfigurationReloadResponse.phase:type_name -> microgateway.ReloadPhase
-	34, // 25: microgateway.ConfigurationReloadResponse.timestamp:type_name -> google.protobuf.Timestamp
-	34, // 26: microgateway.AnalyticsPulse.pulse_timestamp:type_name -> google.protobuf.Timestamp
-	34, // 27: microgateway.AnalyticsPulse.data_from:type_name -> google.protobuf.Timestamp
-	34, // 28: microgateway.AnalyticsPulse.data_to:type_name -> google.protobuf.Timestamp
+	35, // 25: microgateway.ConfigurationReloadResponse.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 26: microgateway.AnalyticsPulse.pulse_timestamp:type_name -> google.protobuf.Timestamp
+	35, // 27: microgateway.AnalyticsPulse.data_from:type_name -> google.protobuf.Timestamp
+	35, // 28: microgateway.AnalyticsPulse.data_to:type_name -> google.protobuf.Timestamp
 	21, // 29: microgateway.AnalyticsPulse.analytics_events:type_name -> microgateway.AnalyticsEvent
 	22, // 30: microgateway.AnalyticsPulse.budget_events:type_name -> microgateway.BudgetUsageEvent
 	23, // 31: microgateway.AnalyticsPulse.proxy_summaries:type_name -> microgateway.ProxyLogSummary
 	24, // 32: microgateway.AnalyticsPulse.compliance_events:type_name -> microgateway.ComplianceEventProto
-	34, // 33: microgateway.AnalyticsPulseResponse.processed_at:type_name -> google.protobuf.Timestamp
-	20, // 34: microgateway.AnalyticsPulseResponse.updated_config:type_name -> microgateway.AnalyticsPulseConfig
-	34, // 35: microgateway.AnalyticsEvent.timestamp:type_name -> google.protobuf.Timestamp
-	34, // 36: microgateway.BudgetUsageEvent.timestamp:type_name -> google.protobuf.Timestamp
-	34, // 37: microgateway.BudgetUsageEvent.period_start:type_name -> google.protobuf.Timestamp
-	34, // 38: microgateway.BudgetUsageEvent.period_end:type_name -> google.protobuf.Timestamp
-	34, // 39: microgateway.ProxyLogSummary.first_request:type_name -> google.protobuf.Timestamp
-	34, // 40: microgateway.ProxyLogSummary.last_request:type_name -> google.protobuf.Timestamp
-	34, // 41: microgateway.ComplianceEventProto.timestamp:type_name -> google.protobuf.Timestamp
-	34, // 42: microgateway.PluginControlPayload.timestamp:type_name -> google.protobuf.Timestamp
-	31, // 43: microgateway.PluginControlPayload.metadata:type_name -> microgateway.PluginControlPayload.MetadataEntry
-	25, // 44: microgateway.PluginControlBatch.payloads:type_name -> microgateway.PluginControlPayload
-	34, // 45: microgateway.PluginControlBatch.batch_timestamp:type_name -> google.protobuf.Timestamp
-	34, // 46: microgateway.PluginControlBatchResponse.processed_at:type_name -> google.protobuf.Timestamp
-	28, // 47: microgateway.PluginControlBatchResponse.errors:type_name -> microgateway.PluginPayloadError
-	1,  // 48: microgateway.ConfigurationSyncService.RegisterEdge:input_type -> microgateway.EdgeRegistrationRequest
-	3,  // 49: microgateway.ConfigurationSyncService.GetFullConfiguration:input_type -> microgateway.ConfigurationRequest
-	4,  // 50: microgateway.ConfigurationSyncService.SubscribeToChanges:input_type -> microgateway.EdgeMessage
-	7,  // 51: microgateway.ConfigurationSyncService.SendHeartbeat:input_type -> microgateway.HeartbeatRequest
-	9,  // 52: microgateway.ConfigurationSyncService.UnregisterEdge:input_type -> microgateway.EdgeUnregistrationRequest
-	14, // 53: microgateway.ConfigurationSyncService.ValidateToken:input_type -> microgateway.TokenValidationRequest
-	18, // 54: microgateway.ConfigurationSyncService.SendAnalyticsPulse:input_type -> microgateway.AnalyticsPulse
-	26, // 55: microgateway.ConfigurationSyncService.SendPluginControlBatch:input_type -> microgateway.PluginControlBatch
-	2,  // 56: microgateway.ConfigurationSyncService.RegisterEdge:output_type -> microgateway.EdgeRegistrationResponse
-	33, // 57: microgateway.ConfigurationSyncService.GetFullConfiguration:output_type -> microgateway.ConfigurationSnapshot
-	5,  // 58: microgateway.ConfigurationSyncService.SubscribeToChanges:output_type -> microgateway.ControlMessage
-	8,  // 59: microgateway.ConfigurationSyncService.SendHeartbeat:output_type -> microgateway.HeartbeatResponse
-	37, // 60: microgateway.ConfigurationSyncService.UnregisterEdge:output_type -> google.protobuf.Empty
-	15, // 61: microgateway.ConfigurationSyncService.ValidateToken:output_type -> microgateway.TokenValidationResponse
-	19, // 62: microgateway.ConfigurationSyncService.SendAnalyticsPulse:output_type -> microgateway.AnalyticsPulseResponse
-	27, // 63: microgateway.ConfigurationSyncService.SendPluginControlBatch:output_type -> microgateway.PluginControlBatchResponse
-	56, // [56:64] is the sub-list for method output_type
-	48, // [48:56] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	25, // 33: microgateway.AnalyticsPulse.tool_calls:type_name -> microgateway.ToolCallProto
+	35, // 34: microgateway.AnalyticsPulseResponse.processed_at:type_name -> google.protobuf.Timestamp
+	20, // 35: microgateway.AnalyticsPulseResponse.updated_config:type_name -> microgateway.AnalyticsPulseConfig
+	35, // 36: microgateway.AnalyticsEvent.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 37: microgateway.BudgetUsageEvent.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 38: microgateway.BudgetUsageEvent.period_start:type_name -> google.protobuf.Timestamp
+	35, // 39: microgateway.BudgetUsageEvent.period_end:type_name -> google.protobuf.Timestamp
+	35, // 40: microgateway.ProxyLogSummary.first_request:type_name -> google.protobuf.Timestamp
+	35, // 41: microgateway.ProxyLogSummary.last_request:type_name -> google.protobuf.Timestamp
+	35, // 42: microgateway.ComplianceEventProto.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 43: microgateway.ToolCallProto.timestamp:type_name -> google.protobuf.Timestamp
+	35, // 44: microgateway.PluginControlPayload.timestamp:type_name -> google.protobuf.Timestamp
+	32, // 45: microgateway.PluginControlPayload.metadata:type_name -> microgateway.PluginControlPayload.MetadataEntry
+	26, // 46: microgateway.PluginControlBatch.payloads:type_name -> microgateway.PluginControlPayload
+	35, // 47: microgateway.PluginControlBatch.batch_timestamp:type_name -> google.protobuf.Timestamp
+	35, // 48: microgateway.PluginControlBatchResponse.processed_at:type_name -> google.protobuf.Timestamp
+	29, // 49: microgateway.PluginControlBatchResponse.errors:type_name -> microgateway.PluginPayloadError
+	1,  // 50: microgateway.ConfigurationSyncService.RegisterEdge:input_type -> microgateway.EdgeRegistrationRequest
+	3,  // 51: microgateway.ConfigurationSyncService.GetFullConfiguration:input_type -> microgateway.ConfigurationRequest
+	4,  // 52: microgateway.ConfigurationSyncService.SubscribeToChanges:input_type -> microgateway.EdgeMessage
+	7,  // 53: microgateway.ConfigurationSyncService.SendHeartbeat:input_type -> microgateway.HeartbeatRequest
+	9,  // 54: microgateway.ConfigurationSyncService.UnregisterEdge:input_type -> microgateway.EdgeUnregistrationRequest
+	14, // 55: microgateway.ConfigurationSyncService.ValidateToken:input_type -> microgateway.TokenValidationRequest
+	18, // 56: microgateway.ConfigurationSyncService.SendAnalyticsPulse:input_type -> microgateway.AnalyticsPulse
+	27, // 57: microgateway.ConfigurationSyncService.SendPluginControlBatch:input_type -> microgateway.PluginControlBatch
+	2,  // 58: microgateway.ConfigurationSyncService.RegisterEdge:output_type -> microgateway.EdgeRegistrationResponse
+	34, // 59: microgateway.ConfigurationSyncService.GetFullConfiguration:output_type -> microgateway.ConfigurationSnapshot
+	5,  // 60: microgateway.ConfigurationSyncService.SubscribeToChanges:output_type -> microgateway.ControlMessage
+	8,  // 61: microgateway.ConfigurationSyncService.SendHeartbeat:output_type -> microgateway.HeartbeatResponse
+	38, // 62: microgateway.ConfigurationSyncService.UnregisterEdge:output_type -> google.protobuf.Empty
+	15, // 63: microgateway.ConfigurationSyncService.ValidateToken:output_type -> microgateway.TokenValidationResponse
+	19, // 64: microgateway.ConfigurationSyncService.SendAnalyticsPulse:output_type -> microgateway.AnalyticsPulseResponse
+	28, // 65: microgateway.ConfigurationSyncService.SendPluginControlBatch:output_type -> microgateway.PluginControlBatchResponse
+	58, // [58:66] is the sub-list for method output_type
+	50, // [50:58] is the sub-list for method input_type
+	50, // [50:50] is the sub-list for extension type_name
+	50, // [50:50] is the sub-list for extension extendee
+	0,  // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_proto_config_sync_proto_init() }
@@ -3298,7 +3389,7 @@ func file_proto_config_sync_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_config_sync_proto_rawDesc), len(file_proto_config_sync_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   31,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/config_sync.proto
+++ b/proto/config_sync.proto
@@ -225,6 +225,7 @@ message AnalyticsPulse {
   repeated BudgetUsageEvent budget_events = 8;    // Budget usage events
   repeated ProxyLogSummary proxy_summaries = 9;   // Summarized proxy logs (not full payloads)
   repeated ComplianceEventProto compliance_events = 13; // Script-reported compliance events
+  repeated ToolCallProto tool_calls = 14;         // Per-operation tool call records
 
   // Pulse metadata
   bool is_compressed = 10;        // Whether data is compressed
@@ -350,6 +351,17 @@ message ComplianceEventProto {
   string vendor = 10;
   string model_name = 11;
   google.protobuf.Timestamp timestamp = 12;
+}
+
+// ToolCallProto represents a single tool operation call served by an edge
+// gateway. The aggregate ToolCalls counter on AnalyticsEvent says how many
+// calls a request made, but carries no operation to attribute them to, so
+// tool analytics on the control plane cannot count edge traffic without this.
+message ToolCallProto {
+  uint32 tool_id = 1;                            // Tool ID (matches the control plane's)
+  string operation_id = 2;                       // OpenAPI operationId that was called
+  int32 exec_time_ms = 3;                        // Wall-clock duration of the call
+  google.protobuf.Timestamp timestamp = 4;       // When the call completed
 }
 
 // Plugin Control Payload Messages


### PR DESCRIPTION
Fixes #487.

## Problem

Tool calls served by an edge microgateway never appeared in a Tool's analytics. The identical calls served by the control plane's embedded gateway appeared within seconds, and nothing in the UI indicated the figure was partial.

`analytics.RecordToolCall` was called correctly on both paths, but it delegates to a per-binary `globalHandler`, and the edge's implementation logged and discarded:

```go
// Note: In microgateway, tool calls are tracked as part of LLM analytics
// This method is here for AI Studio interface compatibility
```

They are not: the pulse carried only an aggregate `ToolCalls` count on the analytics event, with no operation attached, so however often the pulse fired the control plane had nothing to attribute to an operation.

`tool-usage-statistics`, `tool-operations-usage-over-time` and `tool-calls-per-day`, and the charts on `/admin/tools/{id}`, therefore under-reported by whatever share of traffic a distributed deployment routes through its edges — which is meant to be most of it. Two customers with identical usage saw wildly different numbers based only on topology.

## Changes

Per-operation records now ride the pulse, following the same path compliance events already take:

**proto** — `ToolCallProto` (tool id, operation id, exec time, timestamp) and `AnalyticsPulse.tool_calls = 14`. Regenerated with the same protoc/protoc-gen-go versions the file records.

**edge** — `MicrogatewaAnalyticsHandler.RecordToolCall` buffers to the pulse plugin via `PluginManager.BufferToolCalls`. The buffer is snapshotted and cleared per pulse like every other, counts toward `TotalRecords`, appears in `GetStats` (alongside `compliance_buffered`, which `current_buffer_size` had also been omitting), and a gateway with no plugin manager drops the call rather than panicking.

**control** — `SendAnalyticsPulse` replays each record through `analytics.RecordToolCall`, so an edge-served call lands in exactly the same table, with the same shape, as a locally served one. No new storage path, no reconciliation to get wrong. A record arriving without a timestamp falls back to receipt time.

## Also from the issue ("Minor, same area")

The tool-analytics endpoints surfaced `time.Parse`'s raw Go layout string when a date was missing:

```
GET /api/v1/analytics/tool-usage-statistics
-> 400 {"detail":"parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""}
```

`getDateRange` now names the parameter and the format it wants (`start_date is required, in YYYY-MM-DD format`), which covers every analytics endpoint that uses it.

## Test infrastructure

`setupPulseTestDB` pins its sqlite pool to a single connection. A `:memory:` database belongs to its connection, so a pooled second connection opened an empty one and the analytics worker wrote into a database with no tables — this made the new assertions fail intermittently and would have done the same to any future write-then-read test in the file.

## Tests

- `TestSendAnalyticsPulse_ToolCallsAreRecorded` — three edge calls across two operations land in `tool_call_records` with the right tool id, operation and exec time.
- `TestSendAnalyticsPulse_ToolCallWithoutTimestamp` — falls back to receipt time.
- `TestSendAnalyticsPulse_NoToolCalls` — a pulse with no tool calls writes none.
- `TestAnalyticsPulsePlugin_BufferToolCalls` (+ empty-slice and concurrent variants), `_BuildPulseMessage_WithToolCalls` / `_NoToolCalls`, `_GetStatsIncludesToolCalls`.
- `TestRecordToolCall_NoPluginManager` — no panic when no pulse plugin is configured.
- `TestGetDateRange` — valid range, each parameter missing, malformed input, and that no Go layout string leaks into the message.

`go test ./grpc/ ./api/ ./analytics/ ./proxy/` and `go test ./internal/plugins/ ./internal/services/ ./plugins/` (microgateway) pass, including `-count=3` on `./grpc/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
