### PR TITLE
fix: portal tool docs generate a working Example Request (#488)

### DIFF
--- a/ui/admin-frontend/src/portal/components/AppDetailView.js
+++ b/ui/admin-frontend/src/portal/components/AppDetailView.js
@@ -609,7 +609,9 @@ const AppDetailView = () => {
             <FieldLabel>Key ID:</FieldLabel>
           </Grid>
           <Grid item xs={9}>
-            <FieldValue>{app.attributes.credential.keyID}</FieldValue>
+            {/* The API serialises this as key_id (CredentialDetail); keyID
+                read as undefined and the field rendered blank. */}
+            <FieldValue>{app.attributes.credential.key_id}</FieldValue>
           </Grid>
           <Grid item xs={3}>
             <FieldLabel>Secret:</FieldLabel>
@@ -1147,7 +1149,10 @@ const AppDetailView = () => {
               <CardContent>
                 <Typography variant="h6">{tool.attributes.name}</Typography>
                 <Typography variant="body2" color="text.secondary" mb={2}>
-                  {tool.attributes.short_description || "No description available"}
+                  {/* A Tool is serialised with `description`; only datasources
+                      carry `short_description`, so every tool showed the
+                      placeholder even when it had a description. */}
+                  {tool.attributes.short_description || tool.attributes.description || "No description available"}
                 </Typography>
 
                 <Typography

--- a/ui/admin-frontend/src/portal/pages/ToolDocumentationPage.js
+++ b/ui/admin-frontend/src/portal/pages/ToolDocumentationPage.js
@@ -28,138 +28,105 @@ import pubClient from '../../admin/utils/pubClient';
 import { getConfig } from '../../config';
 
 // Helper function to generate example curl commands
-const generateCurlExample = (operation, toolDetails, selectedApiToken = null) => {
+//
+// The tool endpoint is the bare POST /tools/{slug}: the operation and its
+// parameters are selected in the request body, never in the URL. Appending the
+// OpenAPI path template (or the operation's own HTTP method) produces a request
+// that matches no route, so neither is used here.
+export const generateCurlExample = (operation, toolDetails, selectedApiToken = null) => {
   if (!operation || !toolDetails) return 'curl example not available';
-  
+
   // Generate slug from tool name for the URL
   const toolSlug = toolDetails.attributes.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
   const operationId = operation.operation_id;
-  const method = operation.method.toUpperCase();
-  
-  // Build parts of the curl command as separate lines
+
+  // Build parts of the curl command as separate lines. Every tool call is a
+  // POST with a JSON body, whatever method the underlying operation uses.
   const parts = [];
-  parts.push(`curl -X ${method}`);
-  
-  // Add content type header if there's a request body
-  if (operation.request_body && operation.request_body.content_type) {
-    parts.push(`  -H "Content-Type: ${operation.request_body.content_type}"`);
-  }
-  
+  parts.push('curl -X POST');
+  parts.push('  -H "Content-Type: application/json"');
+
   // Add authorization header with selected API token or placeholder
   const apiKey = selectedApiToken || 'YOUR_API_KEY';
   parts.push(`  -H "Authorization: Bearer ${apiKey}"`);
-  
-  // Build the URL - correct format for the proxy endpoint with proper gateway URL
+
+  // Build the URL with the proper gateway URL
   const config = getConfig();
   const currentHost = window.location.hostname;
   const protocol = window.location.protocol; // Get the current protocol (http: or https:)
   // Use toolDisplayURL from config if available, otherwise fall back to proxyURL, then default gateway
   const baseUrl = config.toolDisplayURL || config.proxyURL || `${protocol}//${currentHost}:9090`;
-  // The correct URL format is just /tools/{toolSlug} - the operation ID goes in the request body
-  let url = `${baseUrl}/tools/${toolSlug}`;
-  
-  // Add path parameters if any
+  parts.push(`  ${baseUrl}/tools/${toolSlug}`);
+
+  // Generate an example request body with only the required operation_id
+  const exampleBody = {
+    // Always include the operation_id in the request body for tool proxy
+    operation_id: operationId
+  };
+
+  // Only add parameters section if we have URL or query parameters
   if (operation.parameters && operation.parameters.length > 0) {
-    const pathParams = operation.parameters.filter(p => p.in === 'path');
-    if (pathParams.length > 0) {
-      pathParams.forEach(param => {
-        const paramValue = `{${param.name}}`;
-        url += `/${paramValue}`;
-      });
-    }
-  }
-  
-  // Add query parameters if any
-  if (operation.parameters && operation.parameters.length > 0) {
-    const queryParams = operation.parameters.filter(p => p.in === 'query');
-    if (queryParams.length > 0) {
-      url += '?';
-      queryParams.forEach((param, index) => {
-        const paramValue = param.schema?.type === 'number' ? '1' : 
-                          param.schema?.type === 'boolean' ? 'true' : 
-                          param.schema?.enum?.length > 0 ? param.schema.enum[0] : 
-                          `{${param.name}}`;
-        url += `${param.name}=${paramValue}${index < queryParams.length - 1 ? '&' : ''}`;
-      });
-    }
-  }
-  
-  // Add URL to parts
-  parts.push(`  ${url}`);
-  
-  // Add request body if applicable
-  if ((method === 'POST' || method === 'PUT' || method === 'PATCH')) {
-    
-    // Generate an example request body with only the required operation_id
-    const exampleBody = {
-      // Always include the operation_id in the request body for tool proxy
-      operation_id: operationId
-    };
-    
-    // Only add parameters section if we have URL or query parameters
-    if (operation.parameters && operation.parameters.length > 0) {
-      const paramData = {};
-      operation.parameters.forEach(param => {
-        if (param.in === 'query' || param.in === 'path') {
-          if (param.example) {
-            paramData[param.name] = [param.example.toString()];
-          } else if (param.schema && param.schema.type === 'string') {
-            paramData[param.name] = [`example_${param.name}`];
-          } else if (param.schema && (param.schema.type === 'number' || param.schema.type === 'integer')) {
-            paramData[param.name] = ['42'];
-          } else if (param.schema && param.schema.type === 'boolean') {
-            paramData[param.name] = ['true'];
-          }
+    const paramData = {};
+    operation.parameters.forEach(param => {
+      if (param.in === 'query' || param.in === 'path') {
+        if (param.example) {
+          paramData[param.name] = [param.example.toString()];
+        } else if (param.schema && param.schema.type === 'string') {
+          paramData[param.name] = [`example_${param.name}`];
+        } else if (param.schema && (param.schema.type === 'number' || param.schema.type === 'integer')) {
+          paramData[param.name] = ['42'];
+        } else if (param.schema && param.schema.type === 'boolean') {
+          paramData[param.name] = ['true'];
         }
-      });
-      
-      // Only add parameters if we have any
-      if (Object.keys(paramData).length > 0) {
-        exampleBody.parameters = paramData;
       }
+    });
+
+    // Only add parameters if we have any
+    if (Object.keys(paramData).length > 0) {
+      exampleBody.parameters = paramData;
     }
-    
-    // If there's a schema defined, add example payload properties
-    if (operation.request_body && operation.request_body.schema && operation.request_body.schema.properties) {
-      const payloadData = {};
-      Object.entries(operation.request_body.schema.properties).forEach(([propName, propSchema]) => {
-        if (propSchema.example) {
-          payloadData[propName] = propSchema.example;
-        } else if (propSchema.type === 'string') {
-          payloadData[propName] = `example_${propName}`;
-        } else if (propSchema.type === 'number' || propSchema.type === 'integer') {
-          payloadData[propName] = 42;
-        } else if (propSchema.type === 'boolean') {
-          payloadData[propName] = true;
-        } else if (propSchema.type === 'array') {
-          payloadData[propName] = [];
-        } else if (propSchema.type === 'object') {
-          payloadData[propName] = {};
-        }
-      });
-      
-      // Only add payload if we have properties
-      if (Object.keys(payloadData).length > 0) {
-        exampleBody.payload = payloadData;
-      }
-    }
-    
-    // Add example headers if needed (currently not populated)
-    // Only add if we actually have custom headers
-    if (operation.headers && operation.headers.length > 0) {
-      const headerData = {};
-      operation.headers.forEach(header => {
-        headerData[header.name] = [header.example || `example_${header.name}`];
-      });
-      
-      if (Object.keys(headerData).length > 0) {
-        exampleBody.headers = headerData;
-      }
-    }
-    
-    const bodyJson = JSON.stringify(exampleBody, null, 2).replace(/'/g, "\\'");
-    parts.push(`  -d '${bodyJson}'`);
   }
+
+  // If there's a schema defined, add example payload properties
+  if (operation.request_body && operation.request_body.schema && operation.request_body.schema.properties) {
+    const payloadData = {};
+    Object.entries(operation.request_body.schema.properties).forEach(([propName, propSchema]) => {
+      if (propSchema.example) {
+        payloadData[propName] = propSchema.example;
+      } else if (propSchema.type === 'string') {
+        payloadData[propName] = `example_${propName}`;
+      } else if (propSchema.type === 'number' || propSchema.type === 'integer') {
+        payloadData[propName] = 42;
+      } else if (propSchema.type === 'boolean') {
+        payloadData[propName] = true;
+      } else if (propSchema.type === 'array') {
+        payloadData[propName] = [];
+      } else if (propSchema.type === 'object') {
+        payloadData[propName] = {};
+      }
+    });
+    
+    // Only add payload if we have properties
+    if (Object.keys(payloadData).length > 0) {
+      exampleBody.payload = payloadData;
+    }
+  }
+  
+  // Add example headers if needed (currently not populated)
+  // Only add if we actually have custom headers
+  if (operation.headers && operation.headers.length > 0) {
+    const headerData = {};
+    operation.headers.forEach(header => {
+      headerData[header.name] = [header.example || `example_${header.name}`];
+    });
+    
+    if (Object.keys(headerData).length > 0) {
+      exampleBody.headers = headerData;
+    }
+  }
+  
+  const bodyJson = JSON.stringify(exampleBody, null, 2).replace(/'/g, "\\'");
+  parts.push(`  -d '${bodyJson}'`);
   
   // Join parts with newlines and backslashes for continuation
   return parts.join(' \\\n');

--- a/ui/admin-frontend/src/portal/pages/ToolDocumentationPage.test.js
+++ b/ui/admin-frontend/src/portal/pages/ToolDocumentationPage.test.js
@@ -1,0 +1,109 @@
+import { generateCurlExample } from "./ToolDocumentationPage";
+
+jest.mock("../../config", () => ({
+  getConfig: () => ({ toolDisplayURL: "http://localhost:9091" }),
+}));
+
+jest.mock("../../admin/utils/pubClient", () => ({ get: jest.fn(), post: jest.fn() }));
+
+const toolDetails = { attributes: { name: "Currency Exchange Rates" } };
+
+// The operation reported in #488: an OpenAPI path with two path parameters and
+// one query parameter.
+const getExchangeRate = {
+  operation_id: "getExchangeRate",
+  method: "get",
+  path: "/rate/{base}/{quote}",
+  parameters: [
+    { name: "base", in: "path", required: true, schema: { type: "string" } },
+    { name: "quote", in: "path", required: true, schema: { type: "string" } },
+    { name: "date", in: "query", required: false, schema: { type: "string" } },
+  ],
+};
+
+const commandLine = (curl, predicate) =>
+  curl
+    .split("\\\n")
+    .map((line) => line.trim())
+    .find(predicate);
+
+describe("generateCurlExample", () => {
+  it("targets the bare tool endpoint", () => {
+    const curl = generateCurlExample(getExchangeRate, toolDetails);
+    const url = commandLine(curl, (line) => line.startsWith("http"));
+
+    expect(url).toBe("http://localhost:9091/tools/currency-exchange-rates");
+  });
+
+  it("does not append the OpenAPI path template or query string", () => {
+    const curl = generateCurlExample(getExchangeRate, toolDetails);
+
+    // The old output was .../tools/currency-exchange-rates/{base}/{quote}?date={date},
+    // which matches no route and 404s when pasted.
+    expect(curl).not.toContain("{base}");
+    expect(curl).not.toContain("{quote}");
+    expect(curl).not.toContain("?date=");
+  });
+
+  it("uses POST regardless of the operation's HTTP method", () => {
+    // The operation is a GET, but the tool endpoint always takes a POST with a
+    // JSON body naming the operation.
+    expect(generateCurlExample(getExchangeRate, toolDetails)).toContain("curl -X POST");
+  });
+
+  it("selects the operation and parameters in the body", () => {
+    const curl = generateCurlExample(getExchangeRate, toolDetails);
+    const body = curl.slice(curl.indexOf("-d '") + 4, curl.lastIndexOf("'"));
+    const parsed = JSON.parse(body);
+
+    expect(parsed.operation_id).toBe("getExchangeRate");
+    // Parameters are arrays of strings, matching map[string][]string upstream.
+    expect(parsed.parameters).toEqual({
+      base: ["example_base"],
+      quote: ["example_quote"],
+      date: ["example_date"],
+    });
+  });
+
+  it("emits a body for a GET operation", () => {
+    // Previously the body was only generated for POST/PUT/PATCH operations, so
+    // a GET produced a request the endpoint rejects for having no operation_id.
+    expect(generateCurlExample(getExchangeRate, toolDetails)).toContain('"operation_id"');
+  });
+
+  it("sends JSON and the bearer token", () => {
+    const curl = generateCurlExample(getExchangeRate, toolDetails, "app-key-123");
+
+    expect(curl).toContain('-H "Content-Type: application/json"');
+    expect(curl).toContain('-H "Authorization: Bearer app-key-123"');
+  });
+
+  it("falls back to a placeholder when no token is selected", () => {
+    expect(generateCurlExample(getExchangeRate, toolDetails)).toContain("Bearer YOUR_API_KEY");
+  });
+
+  it("includes an example payload for an operation with a request body", () => {
+    const createAlert = {
+      operation_id: "createAlert",
+      method: "post",
+      path: "/alerts",
+      parameters: [],
+      request_body: {
+        content_type: "application/json",
+        schema: { properties: { threshold: { type: "number" }, note: { type: "string" } } },
+      },
+    };
+
+    const curl = generateCurlExample(createAlert, toolDetails);
+    const body = curl.slice(curl.indexOf("-d '") + 4, curl.lastIndexOf("'"));
+    const parsed = JSON.parse(body);
+
+    expect(parsed.operation_id).toBe("createAlert");
+    expect(parsed.payload).toEqual({ threshold: 42, note: "example_note" });
+  });
+
+  it("handles a missing operation or tool", () => {
+    expect(generateCurlExample(null, toolDetails)).toBe("curl example not available");
+    expect(generateCurlExample(getExchangeRate, null)).toBe("curl example not available");
+  });
+});


### PR DESCRIPTION
Fixes #488.

## Problem

The generated **Example Request** on `/portal/tools/{id}/docs` printed a URL that does not exist. For an operation whose OpenAPI path is `/rate/{base}/{quote}`:

```bash
curl -X POST \
  -H "Authorization: Bearer YOUR_API_KEY" \
  http://localhost:9091/tools/currency-exchange-rates/{base}/{quote}?date={date} \
  -d '{ "operation_id": "getExchangeRate", "parameters": { … } }'
```

The body was correct. The URL was not: the tool endpoint is the bare `/tools/{slug}`, and the operation and its parameters are selected in the body. Appending the OpenAPI path template and query string produced a path that matches no route, so copying it gave a 404.

This page is otherwise excellent and is the natural first stop for a developer — it is where the MCP endpoint, the auth contract and a ready-to-paste Claude Desktop config all live. The one thing a developer is most likely to copy verbatim was the thing that was wrong.

## Changes

**`ToolDocumentationPage.js`**

- The URL is always the bare `{baseUrl}/tools/{slug}`. The path-parameter and query-string appending is gone.
- The command is always `POST` with `Content-Type: application/json`, whatever method the underlying operation uses. Previously it printed the operation's own method **and** only generated a body for `POST`/`PUT`/`PATCH` — so a `GET` operation like `getExchangeRate` got no body at all, and would have been rejected for having no `operation_id` even if the URL had been right.

**`AppDetailView.js`** — the two smaller items reported on the same page:

- **Tool Access Details** showed "No description available" under every tool: it read `tool.attributes.short_description`, which only datasources carry. A Tool is serialised with `description` (confirmed in `getUserAccessibleTools`, the endpoint the page actually calls).
- **Key ID** rendered blank: the component read `credential.keyID`, the API serialises `key_id` (`CredentialDetail`).

## Tests

`ToolDocumentationPage.test.js` covers the generator against the reported operation:

- targets the bare tool endpoint;
- emits no `{base}`, `{quote}` or `?date=` anywhere in the command;
- uses `POST` even though the operation is a `GET`, and emits a body for it;
- selects the operation and parameters in the body, with parameters as arrays of strings (matching `map[string][]string` upstream);
- sends `Content-Type: application/json` and the bearer token, falling back to the placeholder;
- includes an example payload for an operation that has a request body;
- returns the placeholder string for a missing operation or tool.

The whole frontend suite passes: 119 suites, 1195 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
