### PR TITLE
fix: stop /tools/{id}/operations no-opping on a non-envelope body (#489)

### DIFF
--- a/api/models.go
+++ b/api/models.go
@@ -569,7 +569,8 @@ type OperationsResponse struct {
 	Operations []string `json:"operations"`
 }
 
-// OperationInput represents the input for adding or removing operations from a tool
+// OperationInput represents the input for adding or removing operations from a tool.
+// The bare form {"operation": "<operationId>"} is accepted as well.
 // @Description Operation input model
 type OperationInput struct {
 	Data struct {
@@ -578,6 +579,8 @@ type OperationInput struct {
 			Operation string `json:"operation"`
 		} `json:"attributes"`
 	} `json:"data"`
+	// Operation is the bare-form alternative to the data envelope above.
+	Operation string `json:"operation,omitempty"`
 }
 
 // ModelPriceInput represents the input for model price-related operations

--- a/api/tool_handlers.go
+++ b/api/tool_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -397,8 +398,49 @@ func (a *API) searchTools(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": serializeTools(tools, a.config.DB)})
 }
 
+// bindOperationName reads the operation name from the request body, accepting
+// either the JSON:API envelope or the bare form:
+//
+//	{"data": {"attributes": {"operation": "getExchangeRate"}}}
+//	{"operation": "getExchangeRate"}
+//
+// The bare form is the natural reading of the endpoint name and what most
+// people reach for when scripting the API. It used to bind to an empty
+// OperationInput, and the handler then returned 200 with the serialised tool
+// having changed nothing — leaving a Tool with no enabled operations, which is
+// inert but looks fine until AsTool errors or getMCPServerForTool reports
+// "tool has no whitelisted operations", neither of which points back here.
+func bindOperationName(c *gin.Context) (string, error) {
+	var body struct {
+		// Bare form.
+		Operation string `json:"operation"`
+		// JSON:API envelope.
+		Data *struct {
+			Type       string `json:"type"`
+			Attributes struct {
+				Operation string `json:"operation"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+
+	if err := c.ShouldBindJSON(&body); err != nil {
+		return "", err
+	}
+
+	operation := body.Operation
+	if body.Data != nil && body.Data.Attributes.Operation != "" {
+		operation = body.Data.Attributes.Operation
+	}
+
+	if operation == "" {
+		return "", errors.New(`operation is required: send {"operation":"<operationId>"} ` +
+			`or {"data":{"attributes":{"operation":"<operationId>"}}}`)
+	}
+	return operation, nil
+}
+
 // @Summary Add operation to tool
-// @Description Add an operation to a specific tool
+// @Description Add an operation to a specific tool. The body may use the JSON:API envelope ({"data":{"attributes":{"operation":"..."}}}) or the bare form ({"operation":"..."}).
 // @Tags tools
 // @Accept json
 // @Produce json
@@ -422,8 +464,8 @@ func (a *API) addOperationToTool(c *gin.Context) {
 		return
 	}
 
-	var input OperationInput
-	if err := c.ShouldBindJSON(&input); err != nil {
+	operation, err := bindOperationName(c)
+	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Errors: []struct {
 				Title  string `json:"title"`
@@ -433,7 +475,7 @@ func (a *API) addOperationToTool(c *gin.Context) {
 		return
 	}
 
-	err = a.service.AddOperationToTool(uint(id), input.Data.Attributes.Operation)
+	err = a.service.AddOperationToTool(uint(id), operation)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Errors: []struct {
@@ -459,7 +501,7 @@ func (a *API) addOperationToTool(c *gin.Context) {
 }
 
 // @Summary Remove operation from tool
-// @Description Remove an operation from a specific tool
+// @Description Remove an operation from a specific tool. The body may use the JSON:API envelope ({"data":{"attributes":{"operation":"..."}}}) or the bare form ({"operation":"..."}).
 // @Tags tools
 // @Accept json
 // @Produce json
@@ -483,8 +525,8 @@ func (a *API) removeOperationFromTool(c *gin.Context) {
 		return
 	}
 
-	var input OperationInput
-	if err := c.ShouldBindJSON(&input); err != nil {
+	operation, err := bindOperationName(c)
+	if err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{
 			Errors: []struct {
 				Title  string `json:"title"`
@@ -494,7 +536,7 @@ func (a *API) removeOperationFromTool(c *gin.Context) {
 		return
 	}
 
-	err = a.service.RemoveOperationFromTool(uint(id), input.Data.Attributes.Operation)
+	err = a.service.RemoveOperationFromTool(uint(id), operation)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{
 			Errors: []struct {

--- a/api/tool_operations_input_test.go
+++ b/api/tool_operations_input_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func operationRequest(body string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/tools/4/operations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	return c
+}
+
+func TestBindOperationName(t *testing.T) {
+	t.Run("JSON:API envelope", func(t *testing.T) {
+		got, err := bindOperationName(operationRequest(`{"data":{"attributes":{"operation":"getExchangeRate"}}}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "getExchangeRate" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	// The natural reading of the endpoint name, and what scripting the API
+	// tends to produce. It used to bind to an empty OperationInput, and the
+	// handler returned 200 with the tool unchanged.
+	t.Run("bare form", func(t *testing.T) {
+		got, err := bindOperationName(operationRequest(`{"operation":"getExchangeRate"}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "getExchangeRate" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("envelope wins when both are present", func(t *testing.T) {
+		got, err := bindOperationName(operationRequest(
+			`{"operation":"bare","data":{"attributes":{"operation":"enveloped"}}}`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "enveloped" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("a body naming no operation is rejected", func(t *testing.T) {
+		for _, body := range []string{
+			`{}`,
+			`{"operation":""}`,
+			`{"data":{"attributes":{}}}`,
+			`{"data":{"attributes":{"operation":""}}}`,
+			`{"operationId":"getExchangeRate"}`,
+		} {
+			_, err := bindOperationName(operationRequest(body))
+			if err == nil {
+				t.Errorf("expected %s to be rejected", body)
+				continue
+			}
+			// The message has to name both accepted shapes, since silently
+			// doing nothing is what made this hard to spot.
+			if !strings.Contains(err.Error(), `{"operation"`) ||
+				!strings.Contains(err.Error(), `"data"`) {
+				t.Errorf("error for %s should name both shapes, got %q", body, err.Error())
+			}
+		}
+	})
+
+	t.Run("malformed JSON is rejected", func(t *testing.T) {
+		if _, err := bindOperationName(operationRequest(`not json`)); err == nil {
+			t.Error("expected malformed JSON to be rejected")
+		}
+	})
+}

--- a/services/plugin_security/command_validation_test.go
+++ b/services/plugin_security/command_validation_test.go
@@ -10,7 +10,11 @@ import (
 // blockingService is a Service stub whose host validation always rejects,
 // simulating the enterprise internal-network block.
 type blockingService struct {
-	communityService
+	// Embed the interface, not the CE concrete type: communityService is
+	// built only under !enterprise, and these stubs must compile in both
+	// editions. ValidateCommand only ever calls ValidateGRPCHost, which
+	// both stubs override, so the nil embedded Service is never invoked.
+	Service
 }
 
 func (s *blockingService) ValidateGRPCHost(host string) error {
@@ -21,7 +25,7 @@ func (s *blockingService) IsInternalIP(host string) bool { return true }
 
 // allowingService is a Service stub whose host validation always passes.
 type allowingService struct {
-	communityService
+	Service
 }
 
 func (s *allowingService) ValidateGRPCHost(host string) error { return nil }


### PR DESCRIPTION
Fixes #489.

## Problem

`POST` and `DELETE /api/v1/tools/{id}/operations` bound the body into an `OperationInput` and passed `input.Data.Attributes.Operation` straight through without checking it was set. A body in the bare form bound to an empty struct, and the handler returned 200 with the serialised tool having changed nothing:

```bash
# Ignored. Returns 200 and the serialised tool.
curl -X POST .../api/v1/tools/4/operations -d '{"operation":"getExchangeRate"}'

# Works.
curl -X POST .../api/v1/tools/4/operations -d '{"data":{"attributes":{"operation":"getExchangeRate"}}}'
```

The result is a Tool with no enabled operations, which is inert but looks fine: `AsTool` errors and `getMCPServerForTool` reports `"tool has no whitelisted operations"` — neither of which points back at the call that was accepted. Easy to hit when scripting the API, because the bare form is the natural reading of the endpoint name and there is no example in the reference.

## Changes

`bindOperationName` reads the operation from either shape, and rejects a body naming none with a 400 that quotes both:

```
operation is required: send {"operation":"<operationId>"} or {"data":{"attributes":{"operation":"<operationId>"}}}
```

The issue offered either "reject with a 400 naming the expected envelope" or "accept the bare form" — this does both, so an existing correct caller is unaffected, the natural form now works, and anything else fails loudly instead of silently. The envelope wins if a body somehow carries both.

The swagger `@Description` on both routes and the `OperationInput` model document the bare form.

## Not changed

The issue adds that "the same treatment would be worth applying to the other envelope-taking endpoints". That is a broad sweep across a lot of handlers with its own regression surface, so it is not bundled here — happy to open a follow-up if you want it done across the API.

## Tests

`TestBindOperationName` covers the envelope, the bare form, both present, malformed JSON, and five bodies that name no operation (`{}`, an empty string in either position, an empty `attributes`, and a plausible-but-wrong `operationId` key) — asserting each is rejected with a message naming both accepted shapes.

`go test ./api/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
